### PR TITLE
fix: handle empty primitive parameters in DefaultConstructorBuilder

### DIFF
--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultConstructorBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultConstructorBuilder.java
@@ -52,7 +52,17 @@ final class DefaultConstructorBuilder implements ConstructorBuilder {
 
     @Override
     public void addEmptyParameter() {
-        this.values.add(null);
+        Constructor<?> constructor = ((DefaultConstructorMetadata) this.metadata).constructor();
+        Class<?> type = constructor.getParameterTypes()[this.values.size()];
+        if(boolean.class.equals(type)) {
+           this.values.add(Boolean.FALSE);
+        } else if(char.class.equals(type)) {
+            this.values.add(Character.valueOf((char)0));
+        } else if(type.isPrimitive()) {
+            this.values.add(Byte.valueOf((byte)0));
+        } else {
+            this.values.add(null);
+        }
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassGraphClassScannerTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassGraphClassScannerTest.java
@@ -40,7 +40,7 @@ class ClassGraphClassScannerTest {
     void shouldReturnEntities() {
         Set<Class<?>> entities = classScanner.entities();
         Assertions.assertNotNull(entities);
-        assertThat(entities).hasSize(31)
+        assertThat(entities).hasSize(32)
                 .contains(Person.class);
     }
 

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultConstructorBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultConstructorBuilderTest.java
@@ -21,6 +21,7 @@ import org.eclipse.jnosql.mapping.metadata.ConstructorBuilder;
 import org.eclipse.jnosql.mapping.metadata.ConstructorMetadata;
 import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
 import org.eclipse.jnosql.mapping.reflection.entities.constructor.BookUser;
+import org.eclipse.jnosql.mapping.reflection.entities.constructor.Counter;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,12 +35,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DefaultConstructorBuilderTest {
 
     private ConstructorMetadata constructor;
+    private ConstructorMetadata counterConstructor;
 
     @BeforeEach
     void setUp(){
         ClassConverter converter = new ReflectionClassConverter();
         EntityMetadata entityMetadata = converter.apply(BookUser.class);
         this.constructor = entityMetadata.constructor();
+        
+        EntityMetadata counterMetadata = converter.apply(Counter.class);
+        this.counterConstructor = counterMetadata.constructor();
     }
 
     @Test
@@ -98,5 +103,19 @@ class DefaultConstructorBuilderTest {
         ConstructorBuilder other = DefaultConstructorBuilder.of(constructor);
         assertThat(builder).isEqualTo(other);
         assertThat(builder).hasSameHashCodeAs(other);
+    }
+    
+    @Test
+    void shouldHandleEmptyPrimitives() {
+        ConstructorBuilder builder = DefaultConstructorBuilder.of(counterConstructor);
+    	builder.addEmptyParameter();
+    	builder.addEmptyParameter();
+    	builder.addEmptyParameter();
+    	builder.addEmptyParameter();
+    	Counter counter = builder.build();
+    	assertThat(counter.count()).isEqualTo(0);
+    	assertThat(counter.active()).isFalse();
+    	assertThat(counter.ratio()).isEqualTo(0d);
+    	assertThat(counter.code()).isEqualTo((char)0);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/entities/constructor/Counter.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/entities/constructor/Counter.java
@@ -1,0 +1,23 @@
+/*
+ *   Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *    All rights reserved. This program and the accompanying materials
+ *    are made available under the terms of the Eclipse Public License v1.0
+ *    and Apache License v2.0 which accompanies this distribution.
+ *    The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *    and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *    You may elect to redistribute this code under either of these licenses.
+ *
+ *    Contributors:
+ *
+ *    Jesse Gallagher
+ */
+package org.eclipse.jnosql.mapping.reflection.entities.constructor;
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+
+@Entity
+public record Counter(@Column int count, @Column boolean active, @Column double ratio, @Column char code) {
+
+}


### PR DESCRIPTION
This change avoids an IllegalArgumentException when working with classes with primitive arguments when the underlying values are not in the data source. It modifies DefaultConstructorBuilder#addEmptyParameter method to check the type and use default values for primitives, falling back to `null` for objects.