### PR TITLE
fix: improve handling of collection subclass columns

### DIFF
--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionFieldMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionFieldMetadata.java
@@ -25,6 +25,7 @@ import org.eclipse.jnosql.mapping.metadata.MappingType;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
+import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
@@ -89,8 +90,9 @@ final class DefaultCollectionFieldMetadata extends AbstractFieldMetadata impleme
     }
 
     private boolean hasFieldAnnotation(Class<?> annotation) {
-        return ((Class) ((ParameterizedType) this.field
-                .getGenericType())
+        ParameterizedType collectionType = Reflections.findParameterizedType(this.field.getGenericType(), Collection.class)
+                .orElseThrow(() -> new IllegalStateException(MessageFormat.format("Unable to find parameterized Collection implementation for {0}", this.field)));
+        return ((Class) collectionType
                 .getActualTypeArguments()[0])
                 .getAnnotation(annotation) != null;
     }

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultMapFieldMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultMapFieldMetadata.java
@@ -22,6 +22,8 @@ import org.eclipse.jnosql.mapping.metadata.MappingType;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
+import java.text.MessageFormat;
+import java.util.Map;
 import java.util.Objects;
 
 final class DefaultMapFieldMetadata extends AbstractFieldMetadata implements MapFieldMetadata {
@@ -29,7 +31,7 @@ final class DefaultMapFieldMetadata extends AbstractFieldMetadata implements Map
     private final TypeSupplier<?> typeSupplier;
 
     private final Class<?> keyType;
-
+    
     private final Class<?> valueType;
 
     DefaultMapFieldMetadata(MappingType type, Field field, String name, TypeSupplier<?> typeSupplier,
@@ -37,12 +39,10 @@ final class DefaultMapFieldMetadata extends AbstractFieldMetadata implements Map
                             FieldReader reader, FieldWriter writer, String udt) {
         super(type, field, name, converter, reader, writer, udt);
         this.typeSupplier = typeSupplier;
-        this.keyType = (Class<?>) ((ParameterizedType) this.field
-                .getGenericType())
-                .getActualTypeArguments()[0];
-        this.valueType = (Class<?>) ((ParameterizedType) this.field
-                .getGenericType())
-                .getActualTypeArguments()[1];
+        ParameterizedType mapType = Reflections.findParameterizedType(this.field.getGenericType(), Map.class)
+            .orElseThrow(() -> new IllegalStateException(MessageFormat.format("Unable to find parameterized Map implementation for {0}", this.field)));
+        this.keyType = (Class<?>) mapType.getActualTypeArguments()[0];
+        this.valueType = (Class<?>) mapType.getActualTypeArguments()[1];
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionClassConverterTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionClassConverterTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jnosql.mapping.metadata.InheritanceMetadata;
 import org.eclipse.jnosql.mapping.metadata.MappingType;
 import org.eclipse.jnosql.mapping.reflection.entities.Actor;
 import org.eclipse.jnosql.mapping.reflection.entities.Director;
+import org.eclipse.jnosql.mapping.reflection.entities.JsonContainer;
 import org.eclipse.jnosql.mapping.reflection.entities.Machine;
 import org.eclipse.jnosql.mapping.reflection.entities.NoConstructorEntity;
 import org.eclipse.jnosql.mapping.reflection.entities.Person;
@@ -204,4 +205,10 @@ class ReflectionClassConverterTest {
         assertEquals(5, constructor.parameters().size());
     }
 
+    
+    @Test
+    void shouldHandleCollectionInterfaceChildren() {
+        ClassConverter converter = new ReflectionClassConverter();
+        assertDoesNotThrow(() -> converter.apply(JsonContainer.class));
+    }
 }

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/entities/JsonContainer.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/entities/JsonContainer.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Jesse Gallagher
+ */
+package org.eclipse.jnosql.mapping.reflection.entities;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.nosql.Column;
+
+/**
+ * This class is intended to test the behavior of Map- and
+ * Collection-compatible members where the type does not
+ * directly contain the generic parameters.
+ */
+public class JsonContainer {
+	public interface JsonObjectChild extends JsonObject {}
+	public static abstract class JsonArrayChild implements JsonArray {}
+	
+	@Column
+	private JsonObject body;
+	@Column
+	private JsonArray tags;
+	@Column
+	private JsonObjectChild childBody;
+	@Column
+	private JsonArrayChild childTags;
+}


### PR DESCRIPTION
I found that a `@Column` property where the type is a non-generic subclass/subinterface of a Collection or Map type (like `JsonObject`) caused a ClassCastException. This change will try to find the actual declaration of the Map or Collection type to find its type arguments.

I expect that this still wouldn't handle the further-down case of a templated type that then uses that generic type in a property, but that would be a bigger problem to solve.