### PR TITLE
Removing the unnecessary method calling in the query method execution

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,11 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
+=== Fixed
+
+- Removed the unnecessary method calling (`firePostEntity`) in the `AbstractSemiStructuredTemplate.executeQuery(SelectQuery)` method execution.
+- Fixed the `EventPersistManager.firePostEntity(T)` Javadoc
+
 === Added
 
 - Include support to ArrayReader

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
@@ -288,7 +288,7 @@ public abstract class AbstractSemiStructuredTemplate implements SemiStructuredTe
         requireNonNull(query, "query is required");
         Stream<CommunicationEntity> entities = manager().select(query);
         Function<CommunicationEntity, T> function = e -> converter().toEntity(e);
-        return entities.map(function).peek(eventManager()::firePostEntity);
+        return entities.map(function);
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManager.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManager.java
@@ -50,9 +50,9 @@ public class EventPersistManager {
     }
 
     /**
-     * Fires an event before an entity is persisted.
+     * Fires an event after an entity is persisted.
      *
-     * @param entity the entity to be persisted
+     * @param entity the persisted entity
      * @param <T>    the type of the entity
      */
     public <T> void firePostEntity(T entity) {

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/DefaultSemiStructuredTemplateTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/DefaultSemiStructuredTemplateTest.java
@@ -58,8 +58,7 @@ import static org.eclipse.jnosql.communication.semistructured.DeleteQuery.delete
 import static org.eclipse.jnosql.communication.semistructured.SelectQuery.select;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @EnableAutoWeld
 @AddPackages(value = {Converters.class, EntityConverter.class})
@@ -259,6 +258,8 @@ class DefaultSemiStructuredTemplateTest {
         SelectQuery query = select().from("person").build();
         template.select(query);
         verify(managerMock).select(query);
+        verify(eventPersistManager, never()).firePostEntity(any(Person.class));
+        verify(eventPersistManager, never()).firePreEntity(any(Person.class));
     }
 
     @Test
@@ -266,6 +267,8 @@ class DefaultSemiStructuredTemplateTest {
         SelectQuery query = select().from("person").build();
         template.count(query);
         verify(managerMock).count(query);
+        verify(eventPersistManager, never()).firePostEntity(any(Person.class));
+        verify(eventPersistManager, never()).firePreEntity(any(Person.class));
     }
 
     @Test
@@ -273,6 +276,8 @@ class DefaultSemiStructuredTemplateTest {
         SelectQuery query = select().from("person").build();
         template.exists(query);
         verify(managerMock).exists(query);
+        verify(eventPersistManager, never()).firePostEntity(any(Person.class));
+        verify(eventPersistManager, never()).firePreEntity(any(Person.class));
     }
 
     @Test
@@ -288,6 +293,8 @@ class DefaultSemiStructuredTemplateTest {
 
         Optional<Person> result = template.singleResult(query);
         assertTrue(result.isPresent());
+        verify(eventPersistManager, never()).firePostEntity(any(Person.class));
+        verify(eventPersistManager, never()).firePreEntity(any(Person.class));
     }
 
     @Test
@@ -300,6 +307,8 @@ class DefaultSemiStructuredTemplateTest {
 
         Optional<Person> result = template.singleResult(query);
         assertFalse(result.isPresent());
+        verify(eventPersistManager, never()).firePostEntity(any(Person.class));
+        verify(eventPersistManager, never()).firePreEntity(any(Person.class));
     }
 
     @Test
@@ -313,6 +322,8 @@ class DefaultSemiStructuredTemplateTest {
 
         Optional<Person> result = template.singleResult("from Person");
         assertTrue(result.isPresent());
+        verify(eventPersistManager, never()).firePostEntity(any(Person.class));
+        verify(eventPersistManager, never()).firePreEntity(any(Person.class));
     }
 
     @Test


### PR DESCRIPTION
### Changes

Ref. https://github.com/eclipse-jnosql/jnosql/issues/591

- Removed the unnecessary method calling (`firePostEntity`) in the `AbstractSemiStructuredTemplate.executeQuery(SelectQuery)` method execution.
- Fixed the `EventPersistManager.firePostEntity(T)` Javadoc 