### PR TITLE
feat: Open some classes for inheritance, support named method parameters

### DIFF
--- a/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/spi/DocumentExtension.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/spi/DocumentExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -59,9 +59,9 @@ public class DocumentExtension implements Extension {
 
         Set<Class<?>> customRepositories = scanner.customRepositories();
 
-        LOGGER.info(String.format("Processing Document extension: %d databases crud %d found, custom repositories: %d",
+        LOGGER.info(() -> String.format("Processing Document extension: %d databases crud %d found, custom repositories: %d",
                 databases.size(), crudTypes.size(), customRepositories.size()));
-        LOGGER.info("Processing repositories as a Document implementation: " + crudTypes);
+        LOGGER.info(() -> "Processing repositories as a Document implementation: " + crudTypes);
 
         databases.forEach(type -> {
             if (!type.getProvider().isBlank()) {

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredRepositoryProxy.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -65,7 +65,7 @@ public class SemiStructuredRepositoryProxy<T, K> extends AbstractSemiStructuredR
         this.repositoryType =  repositoryType;
     }
 
-    SemiStructuredRepositoryProxy(SemiStructuredTemplate template,
+    protected SemiStructuredRepositoryProxy(SemiStructuredTemplate template,
                                   EntityMetadata metadata, Class<?> typeClass,
                                   Converters converters) {
         this.template = template;

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -484,22 +484,24 @@ class CustomRepositoryHandlerTest {
     }
 
     @Test
-    void shouldReturnNotSupportedWhenQueryIsNotSelectAsDelete() {
+    void shouldReturnNumberOfDeletedEntitiesFromDeleteQuery() {
         var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
         Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
-        Mockito.when(template.query(Mockito.anyString()))
+        Mockito.when(preparedStatement.isCount())
+                .thenReturn(false);
+        Mockito.when(preparedStatement.result())
                 .thenReturn(Stream.of(Person.builder().age(26).name("Ada").build()));
-        Assertions.assertThatThrownBy(() ->people.deleteByNameReturnInt())
-                .isInstanceOf(UnsupportedOperationException.class);
+        Assertions.assertThat(people.deleteByNameReturnInt("Ada")).isEqualTo(1L);
     }
 
     @Test
-    void shouldReturnNotSupportedWhenQueryIsNotSelectAsUpdate() {
+    void shouldReturnNumberOfUpdatedEntitiesFromUpdateQuery() {
         var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
         Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
-        Mockito.when(template.query(Mockito.anyString()))
+        Mockito.when(preparedStatement.isCount())
+                .thenReturn(false);
+        Mockito.when(preparedStatement.result())
                 .thenReturn(Stream.of(Person.builder().age(26).name("Ada").build()));
-        Assertions.assertThatThrownBy(() ->people.updateReturnInt())
-                .isInstanceOf(UnsupportedOperationException.class);
+        Assertions.assertThat(people.updateReturnInt("Ada")).isEqualTo(1L);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/People.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/People.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -99,10 +99,10 @@ public interface People {
     }
 
     @Query("delete from Person where name = :name")
-    long deleteByNameReturnInt();
+    long deleteByNameReturnInt(@Param("name") String name);
 
     @Query("update Person where name = :name")
-    long updateReturnInt();
+    long updateReturnInt(@Param("name") String name);
     @Delete
     void deleteAll();
 }


### PR DESCRIPTION
This allows extending some classes in the driver for Jakarta Persistence.

Adds support for JDQL queries that refer to parameters by names, e.g. :name, not only by index, e.g. ?1.

Support boolean return type, which is required to pass the Data 1.0 TCK for Jakarta Persistence entities, not for NoSQL entities. The test is challenged: https://github.com/jakartaee/data/issues/923