### PR TITLE
feat: Open some classes for inheritance, support named method parameters

### DIFF
--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/QueryType.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/QueryType.java
@@ -93,19 +93,21 @@ public enum QueryType {
      * Validates the return type of method based on the type of query being executed.
      * <p>
      * This method checks whether the specified query is a {@code DELETE} or {@code UPDATE} operation
-     * and ensures that the return type is {@code Void}. If the query is not a {@code SELECT} operation
-     * and the return type is not {@code Void}, an {@code UnsupportedOperationException} is thrown.
+     * and ensures that the return type is {@code Void} or {@code int} or {@code long}.
+     * If the query is not a {@code SELECT} operation
+     * and the return type is not supporte, an {@code UnsupportedOperationException} is thrown.
      * <p>
      * This validation is necessary because {@code DELETE} and {@code UPDATE} operations typically
-     * do not return a result set, and as such, they should have a {@code Void} return type.
+     * do not return a result set, and as such, they should have a {@code Void} return type or
+     * return the number of deleted or updated entities, if it's supported by the data layer.
      *
      * @param returnType the return type of the method executing the query
      * @param query      the query being executed
      * @throws UnsupportedOperationException if the query is a {@code DELETE} or {@code UPDATE} operation
-     *                                       and the return type is not {@code Void}
+     *                                       and the return type is not supported
      */
     public void checkValidReturn(Class<?> returnType, String query) {
-        if (isNotSelect() && !isVoid(returnType)) {
+        if (isNotSelect() && !isVoid(returnType) && !isInt(returnType) && !isLong(returnType)) {
             throw new UnsupportedOperationException("The return type must be Void when the query is not a SELECT operation, due to the nature" +
                     " of DELETE and UPDATE operations. The query: " + query);
         }
@@ -113,6 +115,14 @@ public enum QueryType {
 
     private boolean isVoid(Class<?> returnType) {
         return returnType == Void.class || returnType == Void.TYPE;
+    }
+
+    private boolean isInt(Class<?> returnType) {
+        return returnType == Integer.class || returnType == int.class;
+    }
+
+    private boolean isLong(Class<?> returnType) {
+        return returnType == Long.class || returnType == long.class;
     }
 
     private static String extractQueryCommand(String query){

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -15,6 +15,7 @@
 package org.eclipse.jnosql.mapping.core.repository;
 
 import jakarta.data.page.PageRequest;
+
 import org.eclipse.jnosql.mapping.PreparedStatement;
 import org.eclipse.jnosql.mapping.core.NoSQLPage;
 
@@ -24,12 +25,14 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
  * The converter within the return method at Repository class.
  */
-enum DynamicReturnConverter {
+public enum DynamicReturnConverter {
 
     INSTANCE;
 
@@ -77,11 +80,16 @@ enum DynamicReturnConverter {
         Function<String, PreparedStatement> prepareConverter = dynamicQueryMethod.prepareConverter();
         Class<?> typeClass = dynamicQueryMethod.typeClass();
 
-        String value = RepositoryReflectionUtils.INSTANCE.getQuery(method);
+        String queryString = RepositoryReflectionUtils.INSTANCE.getQuery(method);
 
         Map<String, Object> params = RepositoryReflectionUtils.INSTANCE.getParams(method, args);
-        PreparedStatement prepare = prepareConverter.apply(value);
-        params.forEach(prepare::bind);
+        boolean namedParameters = queryContainsNamedParameters(queryString);
+        PreparedStatement prepare = prepareConverter.apply(queryString);
+                    params.entrySet().stream()
+                        .filter(namedParameters ?
+                                        (parameter -> !isOrdinalParameter(parameter))
+                                        : parameter -> isOrdinalParameter(parameter))
+                        .forEach(param -> prepare.bind(param.getKey(), param.getValue()));
 
         if (prepare.isCount()) {
             return prepare.count();
@@ -104,4 +112,20 @@ enum DynamicReturnConverter {
 
         return convert(dynamicReturn);
     }
+
+    private static boolean queryContainsNamedParameters(String queryString) {
+        final String ordinalParameterPattern = "\\?\\d+";
+        final String identifierFirstCharacterPattern = "(\\p{Alpha}|_|$)";
+        final String identifierAfterFirstCharacterpattern = "\\p{Alnum}|_|$";
+        String namedParameterPattern = ":" + identifierFirstCharacterPattern
+                + "(" + identifierAfterFirstCharacterpattern + ")*";
+        Pattern p = Pattern.compile("(" + ordinalParameterPattern + ")|(" + namedParameterPattern + ")");
+        Matcher m = p.matcher(queryString);
+        return m.find() && m.group().startsWith(":");
+    }
+
+    private static boolean isOrdinalParameter(Map.Entry<String, Object> parameter) {
+        return parameter.getKey().startsWith("?");
+    }
+
 }

--- a/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/spi/DocumentExtension.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/spi/DocumentExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -59,9 +59,9 @@ public class DocumentExtension implements Extension {
 
         Set<Class<?>> customRepositories = scanner.customRepositories();
 
-        LOGGER.info(String.format("Processing Document extension: %d databases crud %d found, custom repositories: %d",
+        LOGGER.info(() -> String.format("Processing Document extension: %d databases crud %d found, custom repositories: %d",
                 databases.size(), crudTypes.size(), customRepositories.size()));
-        LOGGER.info("Processing repositories as a Document implementation: " + crudTypes);
+        LOGGER.info(() -> "Processing repositories as a Document implementation: " + crudTypes);
 
         databases.forEach(type -> {
             if (!type.getProvider().isBlank()) {

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
@@ -346,10 +346,4 @@ public class CustomRepositoryHandler implements InvocationHandler {
     private static boolean returnsInt(Method method) {
         return method.getReturnType().equals(int.class) || method.getReturnType().equals(Integer.class);
     }
-
-    private static boolean returnsBoolean(Method method) {
-        return method.getReturnType().equals(boolean.class) || method.getReturnType().equals(Boolean.class);
-    }
-
-
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredRepositoryProxy.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -68,7 +68,7 @@ public class SemiStructuredRepositoryProxy<T, K> extends AbstractSemiStructuredR
         this.entitiesMetadata = entities;
     }
 
-    SemiStructuredRepositoryProxy(SemiStructuredTemplate template,
+    protected SemiStructuredRepositoryProxy(SemiStructuredTemplate template,
                                   EntityMetadata metadata, Class<?> typeClass,
                                   Converters converters,
                                   EntitiesMetadata entities) {

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -18,10 +18,10 @@ import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.inject.Inject;
+
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.Condition;
-import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.mapping.PreparedStatement;
 import org.eclipse.jnosql.mapping.core.Converters;
@@ -482,22 +482,24 @@ class CustomRepositoryHandlerTest {
     }
 
     @Test
-    void shouldReturnNotSupportedWhenQueryIsNotSelectAsDelete() {
+    void shouldReturnNumberOfDeletedEntitiesFromDeleteQuery() {
         var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
-        Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
-        Mockito.when(template.query(Mockito.anyString()))
-                .thenReturn(Stream.of(Person.builder().age(26).name("Ada").build()));
-        Assertions.assertThatThrownBy(() -> people.deleteByNameReturnInt())
-                .isInstanceOf(UnsupportedOperationException.class);
+        Mockito.when(template.prepare(Mockito.anyString(), Mockito.any())).thenReturn(preparedStatement);
+        Mockito.when(preparedStatement.isCount())
+                .thenReturn(false);
+        Mockito.when(preparedStatement.singleResult())
+                .thenReturn(Optional.of(1L));
+        Assertions.assertThat(people.deleteByNameReturnLong("Ada")).isEqualTo(1L);
     }
 
     @Test
-    void shouldReturnNotSupportedWhenQueryIsNotSelectAsUpdate() {
+    void shouldReturnNumberOfUpdatedEntitiesFromUpdateQuery() {
         var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
-        Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
-        Mockito.when(template.query(Mockito.anyString()))
-                .thenReturn(Stream.of(Person.builder().age(26).name("Ada").build()));
-        Assertions.assertThatThrownBy(() -> people.updateReturnInt())
-                .isInstanceOf(UnsupportedOperationException.class);
+        Mockito.when(template.prepare(Mockito.anyString(), Mockito.any())).thenReturn(preparedStatement);
+        Mockito.when(preparedStatement.isCount())
+                .thenReturn(false);
+        Mockito.when(preparedStatement.singleResult())
+                .thenReturn(Optional.of(1L));
+        Assertions.assertThat(people.updateReturnLong("Ada")).isEqualTo(1L);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/People.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/People.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -102,8 +102,8 @@ public interface People {
     }
 
     @Query("delete from Person where name = :name")
-    long deleteByNameReturnInt();
+    long deleteByNameReturnLong(@Param("name") String name);
 
     @Query("update Person where name = :name")
-    long updateReturnInt();
+    long updateReturnLong(@Param("name") String name);
 }


### PR DESCRIPTION
Port of changes from https://github.com/eclipse-jnosql/jnosql/pull/616 for 1.1.x.

This allows extending some classes in the driver for Jakarta Persistence.

Adds support for JDQL queries that refer to parameters by names, e.g. :name, not only by index, e.g. ?1.

Adds support for returning the number of deleted/updated entities in delete/update queries, which is required by the Data TCK for Persistent Entities.