### PR TITLE
Copy columns to mapped query to pass the information to the repositories (1.1.x)

### DIFF
--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ParamValue.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ParamValue.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 /**
  * A Value that allows to set value instead of be immutable. This Value will use at the Dynamic query.
  */
-final class ParamValue implements Value {
+public final class ParamValue implements Value {
 
     private final String name;
 

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ParamValue.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ParamValue.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/Conditions.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/Conditions.java
@@ -17,12 +17,12 @@ import org.eclipse.jnosql.communication.query.ConditionQueryValue;
 import org.eclipse.jnosql.communication.query.QueryCondition;
 import org.eclipse.jnosql.communication.query.Where;
 
-final class Conditions {
+public final class Conditions {
 
     private Conditions() {
     }
 
-    static CriteriaCondition getCondition(Where where, Params params, CommunicationObserverParser observer, String entity) {
+    public static CriteriaCondition getCondition(Where where, Params params, CommunicationObserverParser observer, String entity) {
         QueryCondition condition = where.condition();
         return getCondition(condition, params, observer, entity);
     }

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/Conditions.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/Conditions.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  * and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DefaultSelectQuery.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DefaultSelectQuery.java
@@ -25,7 +25,7 @@ import static java.util.Optional.ofNullable;
 /**
  * The default implementation of column query.
  */
-record DefaultSelectQuery(long limit, long skip, String name,
+public record DefaultSelectQuery(long limit, long skip, String name,
                           List<String> columns, List<Sort<?>> sorts, CriteriaCondition criteriaCondition, boolean count)
         implements SelectQuery {
 

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DefaultSelectQuery.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DefaultSelectQuery.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  * and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
@@ -351,7 +351,7 @@ public abstract class AbstractSemiStructuredTemplate implements SemiStructuredTe
         requireNonNull(query, "query is required");
         requireNonNull(pageRequest, "pageRequest is required");
         var queryPage = new MappingQuery(query.sorts(), pageRequest.size(), NoSQLPage.skip(pageRequest),
-                query.condition().orElse(null), query.name());
+                query.condition().orElse(null), query.name(), query.columns());
         Stream<T> result = select(queryPage);
         return NoSQLPage.of(result.toList(), pageRequest);
     }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MapperSelect.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MapperSelect.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MapperSelect.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MapperSelect.java
@@ -155,7 +155,7 @@ final class MapperSelect extends AbstractMapperQuery implements MapperFrom, Mapp
         return this;
     }
     private SelectQuery build() {
-        return new MappingQuery(sorts, limit, start, condition, entity);
+        return new MappingQuery(sorts, limit, start, condition, entity, List.of());
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MappingQuery.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MappingQuery.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MappingQuery.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MappingQuery.java
@@ -16,6 +16,7 @@ package org.eclipse.jnosql.mapping.semistructured;
 
 
 import jakarta.data.Sort;
+
 import org.eclipse.jnosql.communication.semistructured.CriteriaCondition;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 
@@ -23,13 +24,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static java.util.Collections.emptyList;
 
 /**
  * This record represents a mapping implementation of the {@link SelectQuery} interface.
  * It encapsulates information about sorting, limit, skip, criteria condition, and the entity name.
  */
-public record MappingQuery(List<Sort<?>> sorts, long limit, long skip, CriteriaCondition criteriaCondition, String entity)
+public record MappingQuery(List<Sort<?>> sorts, long limit, long skip, CriteriaCondition criteriaCondition, String entity, List<String> columns)
         implements SelectQuery {
 
 
@@ -41,11 +41,6 @@ public record MappingQuery(List<Sort<?>> sorts, long limit, long skip, CriteriaC
     @Override
     public Optional<CriteriaCondition> condition() {
         return Optional.ofNullable(criteriaCondition);
-    }
-
-    @Override
-    public List<String> columns() {
-        return emptyList();
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepository.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepository.java
@@ -57,7 +57,7 @@ public abstract class AbstractSemiStructuredRepository<T, K> extends AbstractRep
         });
         SelectQuery query = new MappingQuery(sorts,
                 pageRequest.size(), NoSQLPage.skip(pageRequest)
-                , null ,metadata.name());
+                , null ,metadata.name(), List.of());
 
         List<T> entities = template().<T>select(query).toList();
         return NoSQLPage.of(entities, pageRequest);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
@@ -18,6 +18,7 @@ import jakarta.data.Sort;
 import jakarta.data.repository.Find;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
+
 import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
 import org.eclipse.jnosql.communication.semistructured.QueryType;
 import org.eclipse.jnosql.mapping.core.repository.DynamicQueryMethodReturn;
@@ -31,6 +32,8 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
+import org.eclipse.jnosql.mapping.core.query.AbstractRepository;
+
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -43,6 +46,10 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
 
     private static final Logger LOGGER = Logger.getLogger(AbstractSemiStructuredRepositoryProxy.class.getName());
 
+    // redeclare so that it can be accessed in this package
+    @Override
+    protected abstract AbstractRepository<T, K> repository();
+    
     @Override
     protected Object executeQuery(Object instance, Method method, Object[] params) {
         LOGGER.finest("Executing query on method: " + method);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -49,7 +49,7 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
     // redeclare so that it can be accessed in this package
     @Override
     protected abstract AbstractRepository<T, K> repository();
-    
+
     @Override
     protected Object executeQuery(Object instance, Method method, Object[] params) {
         LOGGER.finest("Executing query on method: " + method);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
@@ -164,7 +164,7 @@ public abstract class BaseSemiStructuredRepository<T, K> extends AbstractReposit
                     condition = condition.and(columnCondition);
                 }
                 return new MappingQuery(query.sorts(), query.limit(), query.skip(),
-                        condition, query.name());
+                        condition, query.name(), query.columns());
             }
         }
         return query;
@@ -213,7 +213,8 @@ public abstract class BaseSemiStructuredRepository<T, K> extends AbstractReposit
             return new MappingQuery(sorts, max,
                     skip,
                     documentQuery.condition().orElse(null),
-                    documentQuery.name());
+                    documentQuery.name(),
+                    documentQuery.columns());
         }
 
         if (limit.isPresent()) {
@@ -222,7 +223,7 @@ public abstract class BaseSemiStructuredRepository<T, K> extends AbstractReposit
             return new MappingQuery(documentQuery.sorts(), max,
                     skip,
                     documentQuery.condition().orElse(null),
-                    documentQuery.name());
+                    documentQuery.name(), documentQuery.columns());
         }
 
         return special.pageRequest().<org.eclipse.jnosql.communication.semistructured.SelectQuery>map(p -> {
@@ -234,7 +235,7 @@ public abstract class BaseSemiStructuredRepository<T, K> extends AbstractReposit
                 sorts.addAll(special.sorts());
             }
             return new MappingQuery(sorts, size, skip,
-                    documentQuery.condition().orElse(null), documentQuery.name());
+                    documentQuery.condition().orElse(null), documentQuery.name(), documentQuery.columns());
         }).orElse(documentQuery);
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
@@ -251,7 +251,8 @@ public class CustomRepositoryHandler implements InvocationHandler {
                 .orElseThrow(() -> new UnsupportedOperationException("The repository does not support the method " + method));
     }
 
-    protected AbstractSemiStructuredRepositoryProxy<Object, Object> createRepositoryProxy(SemiStructuredTemplate template, EntityMetadata entityMetadata,  Class<?> entityType, Converters converters) {
+    protected AbstractSemiStructuredRepositoryProxy<Object, Object> createRepositoryProxy(
+            SemiStructuredTemplate template, EntityMetadata entityMetadata,  Class<?> entityType, Converters converters) {
         return new SemiStructuredRepositoryProxy<>(template, entityMetadata, entityType, converters);
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
@@ -74,7 +74,7 @@ public class CustomRepositoryHandler implements InvocationHandler {
 
     private final Converters converters;
 
-    private final SemiStructuredRepositoryProxy<?, ?> defaultRepository;
+    private final AbstractSemiStructuredRepositoryProxy<?, ?> defaultRepository;
 
     protected CustomRepositoryHandler(EntitiesMetadata entitiesMetadata, SemiStructuredTemplate template,
                             Class<?> customRepositoryType,
@@ -214,7 +214,7 @@ public class CustomRepositoryHandler implements InvocationHandler {
         return new CustomRepositoryHandlerBuilder();
     }
 
-    private SemiStructuredRepositoryProxy<?, ?> findDefaultRepository() {
+    private AbstractSemiStructuredRepositoryProxy<?, ?> findDefaultRepository() {
         LOGGER.fine(() -> "Looking for the default repository from the custom repository methods: " + customRepositoryType);
         Method[] methods = customRepositoryType.getMethods();
         for (Method method : methods) {
@@ -237,22 +237,21 @@ public class CustomRepositoryHandler implements InvocationHandler {
         return null;
     }
 
-    private SemiStructuredRepositoryProxy<?, ?> defaultRepository() {
+    private AbstractSemiStructuredRepositoryProxy<?, ?> defaultRepository() {
         if (defaultRepository == null) {
             throw new UnsupportedOperationException("The custom repository does not contains methods to be used as default: " + customRepositoryType);
         }
         return defaultRepository;
     }
 
-    private SemiStructuredRepositoryProxy<?, ?> repository(Method method) {
+    private AbstractSemiStructuredRepositoryProxy<?, ?> repository(Method method) {
         RepositoryMetadata result = repositoryMetadata(method);
         Class<?> entityType = result.typeClass();
         return result.metadata().map(entityMetadata -> createRepositoryProxy(template, entityMetadata, entityType,  converters))
                 .orElseThrow(() -> new UnsupportedOperationException("The repository does not support the method " + method));
     }
 
-    protected SemiStructuredRepositoryProxy<Object, Object> createRepositoryProxy(
-            SemiStructuredTemplate template, EntityMetadata entityMetadata,  Class<?> entityType, Converters converters) {
+    protected AbstractSemiStructuredRepositoryProxy<Object, Object> createRepositoryProxy(SemiStructuredTemplate template, EntityMetadata entityMetadata,  Class<?> entityType, Converters converters) {
         return new SemiStructuredRepositoryProxy<>(template, entityMetadata, entityType, converters);
     }
 
@@ -303,7 +302,7 @@ public class CustomRepositoryHandler implements InvocationHandler {
                 .orElseThrow(() -> new UnsupportedOperationException("The repository does not support the method: " + method));
     }
 
-    private SemiStructuredRepositoryProxy<?, ?> repository(Method method, Parameter[] params) {
+    private AbstractSemiStructuredRepositoryProxy<?, ?> repository(Method method, Parameter[] params) {
         if (params.length == 0) {
             throw new IllegalArgumentException("Method must have at least one parameter");
         }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/DynamicQuery.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/DynamicQuery.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/DynamicQuery.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/DynamicQuery.java
@@ -57,7 +57,7 @@ public class DynamicQuery implements Supplier<SelectQuery> {
             return new MappingQuery(sorts, max,
                     skip,
                     query.condition().orElse(null),
-                    query.name());
+                    query.name(), query.columns());
         }
 
         if (limit.isPresent()) {
@@ -71,7 +71,8 @@ public class DynamicQuery implements Supplier<SelectQuery> {
             return new MappingQuery(sorts, max,
                     skip,
                     query.condition().orElse(null),
-                    query.name());
+                    query.name(),
+                    query.columns());
         }
 
         return special.pageRequest().<SelectQuery>map(p -> {
@@ -83,7 +84,7 @@ public class DynamicQuery implements Supplier<SelectQuery> {
                 sorts.addAll(special.sorts());
             }
             return new MappingQuery(sorts, size, skip,
-                    query.condition().orElse(null), query.name());
+                    query.condition().orElse(null), query.name(), query.columns());
         }).orElse(query);
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredParameterBasedQuery.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredParameterBasedQuery.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredParameterBasedQuery.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredParameterBasedQuery.java
@@ -62,7 +62,7 @@ public enum SemiStructuredParameterBasedQuery {
 
         var condition = condition(conditions);
         var entity = entityMetadata.name();
-        return new MappingQuery(updateSorter, 0L, 0L, condition, entity);
+        return new MappingQuery(updateSorter, 0L, 0L, condition, entity, List.of());
     }
 
     /**
@@ -91,7 +91,7 @@ public enum SemiStructuredParameterBasedQuery {
             limit = pageRequest.size();
             skip = NoSQLPage.skip(pageRequest);
         }
-        return new MappingQuery(updateSorter, limit, skip, condition, entity);
+        return new MappingQuery(updateSorter, limit, skip, condition, entity, List.of());
     }
 
     private CriteriaCondition condition(List<CriteriaCondition> conditions) {

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredRepositoryProxy.java
@@ -65,7 +65,7 @@ public class SemiStructuredRepositoryProxy<T, K> extends AbstractSemiStructuredR
         this.repositoryType =  repositoryType;
     }
 
-    protected SemiStructuredRepositoryProxy(SemiStructuredTemplate template,
+    SemiStructuredRepositoryProxy(SemiStructuredTemplate template,
                                   EntityMetadata metadata, Class<?> typeClass,
                                   Converters converters) {
         this.template = template;


### PR DESCRIPTION
This enhances the JDQL query parser to pass the information about non-entity fields to the SelectQuery parsed query.

Also opens several private classes or methods for extending them in drivers or extensions.