### PR TITLE
Include support on four new terms on method by query (1.1.x)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,11 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 === Changed
 
 - Include Cache on queries
+- Support named query parameters in JDQL
+- Include Contains restriction keyword
+- Include EndsWith restriction keyword
+- Include StartsWith restriction keyword
+- Include IgnoreCase restriction keyword
 
 == [1.1.9] - 2025-07-30
 

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
@@ -55,6 +55,14 @@ public enum Condition {
      */
     LIKE,
     /**
+     * Represents a text contains another text condition.
+     */
+    CONTAINS,
+    /**
+     * Represents a text contains another text at the end condition.
+     */
+    ENDS_WITH,
+    /**
      * Represents a logical conjunction condition.
      */
     AND,
@@ -66,6 +74,10 @@ public enum Condition {
      * Represents a negation condition.
      */
     NOT,
+    /**
+     * Represents a condition with ignore case flag.
+     */
+    IGNORE_CASE,
     /**
      * Represents a range check condition.
      */

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
@@ -81,7 +81,7 @@ public enum Condition {
     /**
      * Represents a condition that checks whether a value ends with a specific suffix.
      */
-    ENDS_WITH
+    ENDS_WITH,
     /**
      * Represents a condition with ignore case flag.
      */

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
@@ -1,6 +1,6 @@
 /*
  *
- *  Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
@@ -59,6 +59,10 @@ public enum Condition {
      */
     CONTAINS,
     /**
+     * Represents a text contains another text at the start condition.
+     */
+    STARTS_WITH,
+    /**
      * Represents a text contains another text at the end condition.
      */
     ENDS_WITH,

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/Condition.java
@@ -55,18 +55,6 @@ public enum Condition {
      */
     LIKE,
     /**
-     * Represents a text contains another text condition.
-     */
-    CONTAINS,
-    /**
-     * Represents a text contains another text at the start condition.
-     */
-    STARTS_WITH,
-    /**
-     * Represents a text contains another text at the end condition.
-     */
-    ENDS_WITH,
-    /**
      * Represents a logical conjunction condition.
      */
     AND,
@@ -79,13 +67,25 @@ public enum Condition {
      */
     NOT,
     /**
-     * Represents a condition with ignore case flag.
-     */
-    IGNORE_CASE,
-    /**
      * Represents a range check condition.
      */
-    BETWEEN;
+    BETWEEN,
+    /**
+     * Represents a condition that checks whether a value contains a specific substring.
+     */
+    CONTAINS,
+    /**
+     * Represents a condition that checks whether a value starts with a specific prefix.
+     */
+    STARTS_WITH,
+    /**
+     * Represents a condition that checks whether a value ends with a specific suffix.
+     */
+    ENDS_WITH
+    /**
+     * Represents a condition with ignore case flag.
+     */
+    IGNORE_CASE;
 
     /**
      * Return tne field as name to both document and column.

--- a/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/AbstractMethodQueryParser.java
+++ b/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/AbstractMethodQueryParser.java
@@ -46,6 +46,7 @@ import static org.eclipse.jnosql.communication.Condition.ENDS_WITH;
 import static org.eclipse.jnosql.communication.Condition.EQUALS;
 import static org.eclipse.jnosql.communication.Condition.GREATER_EQUALS_THAN;
 import static org.eclipse.jnosql.communication.Condition.GREATER_THAN;
+import static org.eclipse.jnosql.communication.Condition.IGNORE_CASE;
 import static org.eclipse.jnosql.communication.Condition.IN;
 import static org.eclipse.jnosql.communication.Condition.LESSER_EQUALS_THAN;
 import static org.eclipse.jnosql.communication.Condition.LESSER_THAN;
@@ -95,8 +96,9 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
     @Override
     public void exitEq(MethodParser.EqContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, EQUALS);
+        appendCondition(hasNot, ignoreCase, variable, EQUALS);
     }
 
     @Override
@@ -114,74 +116,84 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
     @Override
     public void exitGt(MethodParser.GtContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, GREATER_THAN);
+        appendCondition(hasNot, ignoreCase, variable, GREATER_THAN);
     }
 
     @Override
     public void exitGte(MethodParser.GteContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, GREATER_EQUALS_THAN);
+        appendCondition(hasNot, ignoreCase, variable, GREATER_EQUALS_THAN);
     }
 
     @Override
     public void exitLt(MethodParser.LtContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, LESSER_THAN);
+        appendCondition(hasNot, ignoreCase, variable, LESSER_THAN);
     }
 
     @Override
     public void exitLte(MethodParser.LteContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, LESSER_EQUALS_THAN);
+        appendCondition(hasNot, ignoreCase, variable, LESSER_EQUALS_THAN);
     }
 
     @Override
     public void exitLike(MethodParser.LikeContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, LIKE);
+        appendCondition(hasNot, ignoreCase, variable, LIKE);
     }
 
     @Override
     public void exitContains(MethodParser.ContainsContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, CONTAINS);
+        appendCondition(hasNot, ignoreCase, variable, CONTAINS);
     }
 
     @Override
     public void exitEndsWith(MethodParser.EndsWithContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, ENDS_WITH);
+        appendCondition(hasNot, ignoreCase, variable, ENDS_WITH);
     }
 
     @Override
     public void exitStartsWith(MethodParser.StartsWithContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, STARTS_WITH);
+        appendCondition(hasNot, ignoreCase, variable, STARTS_WITH);
     }
 
     @Override
     public void exitIn(MethodParser.InContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
         Condition operator = IN;
-        appendCondition(hasNot, variable, operator);
+        appendCondition(hasNot, ignoreCase, variable, operator);
     }
 
     @Override
     public void exitBetween(MethodParser.BetweenContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
+        boolean ignoreCase = Objects.nonNull(ctx.ignoreCase());
         String variable = getVariable(ctx.variable());
         Condition operator = BETWEEN;
         ArrayQueryValue value = MethodArrayValue.of(variable);
-        checkCondition(new MethodCondition(variable, operator, value), hasNot);
+        checkCondition(new MethodCondition(variable, operator, value), hasNot, ignoreCase);
     }
 
     @Override
@@ -201,20 +213,23 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
         this.and = false;
     }
 
-
-    @Override
-    public void exitIgnoreCase(MethodParser.IgnoreCaseContext ctx) {
-        throw new UnsupportedOperationException("IgnoreCase is not supported in Eclipse JNoSQL method query");
-    }
-
     private void appendCondition(boolean hasNot, String variable, Condition operator) {
         ParamQueryValue queryValue = new MethodParamQueryValue(variable);
         checkCondition(new MethodCondition(variable, operator, queryValue), hasNot);
     }
 
+    private void appendCondition(boolean hasNot, boolean ignoreCase, String variable, Condition operator) {
+        ParamQueryValue queryValue = new MethodParamQueryValue(variable);
+        checkCondition(new MethodCondition(variable, operator, queryValue), hasNot, ignoreCase);
+    }
 
     private void checkCondition(QueryCondition condition, boolean hasNot) {
-        QueryCondition newCondition = checkNotCondition(condition, hasNot);
+        checkCondition(condition, hasNot, false);
+    }
+
+    private void checkCondition(QueryCondition condition, boolean hasNot, boolean ignoreCase) {
+        QueryCondition newCondition = checkIgnoreCaseCondition(condition, ignoreCase);
+        newCondition = checkNotCondition(newCondition, hasNot);
         if (Objects.isNull(this.condition)) {
             this.condition = newCondition;
             return;
@@ -257,6 +272,15 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
         if (hasNot) {
             ConditionQueryValue conditions = ConditionQueryValue.of(Collections.singletonList(condition));
             return new MethodCondition("_NOT", NOT, conditions);
+        } else {
+            return condition;
+        }
+    }
+
+    private QueryCondition checkIgnoreCaseCondition(QueryCondition condition, boolean ignoreCase) {
+        if (ignoreCase) {
+            ConditionQueryValue conditions = ConditionQueryValue.of(Collections.singletonList(condition));
+            return new MethodCondition("_IGNORE_CASE", IGNORE_CASE, conditions);
         } else {
             return condition;
         }

--- a/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/AbstractMethodQueryParser.java
+++ b/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/AbstractMethodQueryParser.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  and Apache License v2.0 which accompanies this distribution.
@@ -41,6 +41,8 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.joining;
 import static org.eclipse.jnosql.communication.Condition.AND;
 import static org.eclipse.jnosql.communication.Condition.BETWEEN;
+import static org.eclipse.jnosql.communication.Condition.CONTAINS;
+import static org.eclipse.jnosql.communication.Condition.ENDS_WITH;
 import static org.eclipse.jnosql.communication.Condition.EQUALS;
 import static org.eclipse.jnosql.communication.Condition.GREATER_EQUALS_THAN;
 import static org.eclipse.jnosql.communication.Condition.GREATER_THAN;
@@ -50,6 +52,7 @@ import static org.eclipse.jnosql.communication.Condition.LESSER_THAN;
 import static org.eclipse.jnosql.communication.Condition.LIKE;
 import static org.eclipse.jnosql.communication.Condition.NOT;
 import static org.eclipse.jnosql.communication.Condition.OR;
+import static org.eclipse.jnosql.communication.Condition.STARTS_WITH;
 
 abstract class AbstractMethodQueryParser extends MethodBaseListener {
 
@@ -91,10 +94,9 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
 
     @Override
     public void exitEq(MethodParser.EqContext ctx) {
-        Condition operator = EQUALS;
         boolean hasNot = Objects.nonNull(ctx.not());
         String variable = getVariable(ctx.variable());
-        appendCondition(hasNot, variable, operator);
+        appendCondition(hasNot, variable, EQUALS);
     }
 
     @Override
@@ -113,40 +115,56 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
     public void exitGt(MethodParser.GtContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
         String variable = getVariable(ctx.variable());
-        Condition operator = GREATER_THAN;
-        appendCondition(hasNot, variable, operator);
+        appendCondition(hasNot, variable, GREATER_THAN);
     }
 
     @Override
     public void exitGte(MethodParser.GteContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
         String variable = getVariable(ctx.variable());
-        Condition operator = GREATER_EQUALS_THAN;
-        appendCondition(hasNot, variable, operator);
+        appendCondition(hasNot, variable, GREATER_EQUALS_THAN);
     }
 
     @Override
     public void exitLt(MethodParser.LtContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
         String variable = getVariable(ctx.variable());
-        Condition operator = LESSER_THAN;
-        appendCondition(hasNot, variable, operator);
+        appendCondition(hasNot, variable, LESSER_THAN);
     }
 
     @Override
     public void exitLte(MethodParser.LteContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
         String variable = getVariable(ctx.variable());
-        Condition operator = LESSER_EQUALS_THAN;
-        appendCondition(hasNot, variable, operator);
+        appendCondition(hasNot, variable, LESSER_EQUALS_THAN);
     }
 
     @Override
     public void exitLike(MethodParser.LikeContext ctx) {
         boolean hasNot = Objects.nonNull(ctx.not());
         String variable = getVariable(ctx.variable());
-        Condition operator = LIKE;
-        appendCondition(hasNot, variable, operator);
+        appendCondition(hasNot, variable, LIKE);
+    }
+
+    @Override
+    public void exitContains(MethodParser.ContainsContext ctx) {
+        boolean hasNot = Objects.nonNull(ctx.not());
+        String variable = getVariable(ctx.variable());
+        appendCondition(hasNot, variable, CONTAINS);
+    }
+
+    @Override
+    public void exitEndsWith(MethodParser.EndsWithContext ctx) {
+        boolean hasNot = Objects.nonNull(ctx.not());
+        String variable = getVariable(ctx.variable());
+        appendCondition(hasNot, variable, ENDS_WITH);
+    }
+
+    @Override
+    public void exitStartsWith(MethodParser.StartsWithContext ctx) {
+        boolean hasNot = Objects.nonNull(ctx.not());
+        String variable = getVariable(ctx.variable());
+        appendCondition(hasNot, variable, STARTS_WITH);
     }
 
     @Override
@@ -183,20 +201,6 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
         this.and = false;
     }
 
-    @Override
-    public void exitContains(MethodParser.ContainsContext ctx) {
-        throw new UnsupportedOperationException("Contains is not supported in Eclipse JNoSQL method query");
-    }
-
-    @Override
-    public void exitEndsWith(MethodParser.EndsWithContext ctx) {
-        throw new UnsupportedOperationException("EndsWith is not supported in Eclipse JNoSQL method query");
-    }
-
-    @Override
-    public void exitStartsWith(MethodParser.StartsWithContext ctx) {
-        throw new UnsupportedOperationException("StartsWith is not supported in Eclipse JNoSQL method query");
-    }
 
     @Override
     public void exitIgnoreCase(MethodParser.IgnoreCaseContext ctx) {

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/DeleteByMethodQueryProviderTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/DeleteByMethodQueryProviderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  and Apache License v2.0 which accompanies this distribution.
@@ -346,6 +346,54 @@ class DeleteByMethodQueryProviderTest {
         assertEquals("active", condition.name());
         assertEquals(Condition.EQUALS, condition.condition());
         assertEquals(BooleanQueryValue.FALSE, condition.value());
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"deleteByNameContains"})
+    void shouldRunQuery34(String query) {
+        Condition operator = Condition.CONTAINS;
+        String variable = "name";
+        checkCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"deleteByNameEndsWith"})
+    void shouldRunQuery35(String query) {
+        Condition operator = Condition.ENDS_WITH;
+        String variable = "name";
+        checkCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"deleteByNameStartsWith"})
+    void shouldRunQuery36(String query) {
+        Condition operator = Condition.STARTS_WITH;
+        String variable = "name";
+        checkCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"deleteByNameNotContains"})
+    void shouldRunQuery37(String query) {
+        Condition operator = Condition.CONTAINS;
+        String variable = "name";
+        checkNotCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"deleteByNameNotEndsWith"})
+    void shouldRunQuery38(String query) {
+        Condition operator = Condition.ENDS_WITH;
+        String variable = "name";
+        checkNotCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"deleteByNameNotStartsWith"})
+    void shouldRunQuery39(String query) {
+        Condition operator = Condition.STARTS_WITH;
+        String variable = "name";
+        checkNotCondition(query, operator, variable);
     }
 
 

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/SelectMethodQueryProviderTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/SelectMethodQueryProviderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  and Apache License v2.0 which accompanies this distribution.
@@ -555,21 +555,15 @@ class SelectMethodQueryProviderTest {
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"findFirstByHexadecimalStartsWithAndIsControlOrderByIdAsc"})
-    void shouldReturnParserQuery38(String query) {
-        String entity = "entity";
-        Assertions.assertThrows(UnsupportedOperationException.class, () -> queryProvider.apply(query, entity));
-    }
-
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"findByNameContains", "findByNameEndsWith", "findByNameStartsWith", "findByStreetNameIgnoreCaseLike", "findByHexadecimalIgnoreCase"})
+    @ValueSource(strings = {"findByStreetNameIgnoreCaseLike", "findByHexadecimalIgnoreCase"})
     void shouldReturnUnsupportedOperationExceptionQuery(String query) {
         String entity = "entity";
+        queryProvider.apply(query, entity);
         Assertions.assertThrows(UnsupportedOperationException.class, () -> queryProvider.apply(query, entity));
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"findByNameNotContains", "findByNameNotEndsWith", "findByNameNotStartsWith", "findByStreetNameIgnoreCaseNotLike", "findByHexadecimalIgnoreCaseNot"})
+    @ValueSource(strings = {"findByStreetNameIgnoreCaseNotLike", "findByHexadecimalIgnoreCaseNot"})
     void shouldReturnUnsupportedOperationExceptionQueryWithNegation(String query) {
         String entity = "entity";
         Assertions.assertThrows(UnsupportedOperationException.class, () -> queryProvider.apply(query, entity));
@@ -586,6 +580,54 @@ class SelectMethodQueryProviderTest {
             soft.assertThat(selectQuery).isNotNull();
             soft.assertThat(selectQuery.entity()).isEqualTo(entity);
         });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"findByNameContains"})
+    void shouldFindByContains(String query) {
+        Condition operator = Condition.CONTAINS;
+        String variable = "name";
+        checkCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"findByNameStartsWith"})
+    void shouldFindByStartWith(String query) {
+        Condition operator = Condition.STARTS_WITH;
+        String variable = "name";
+        checkCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"findByNameEndsWith"})
+    void shouldFindByEndsWith(String query) {
+        Condition operator = Condition.ENDS_WITH;
+        String variable = "name";
+        checkCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"findByNameNotContains"})
+    void shouldFindByNotContains(String query) {
+        Condition operator = Condition.CONTAINS;
+        String variable = "name";
+        checkNotCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"findByNameNotStartsWith"})
+    void shouldFindByNotStartWith(String query) {
+        Condition operator = Condition.STARTS_WITH;
+        String variable = "name";
+        checkNotCondition(query, operator, variable);
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"findByNameNotEndsWith"})
+    void shouldFindByNotEndsWith(String query) {
+        Condition operator = Condition.ENDS_WITH;
+        String variable = "name";
+        checkNotCondition(query, operator, variable);
     }
 
     private void checkOrderBy(String query, Direction direction, Direction direction2) {

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/Conditions.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/Conditions.java
@@ -58,6 +58,16 @@ public final class Conditions {
                     .get()
                     .stream().map(v -> getCondition(v, parameters, observer, entity))
                     .toArray(CriteriaCondition[]::new));
+            case CONTAINS -> CriteriaCondition.contains(Element.of(getName(condition, observer, entity),
+                    Values.get(condition.value(),
+                            parameters)));
+            case ENDS_WITH -> CriteriaCondition.endsWith(Element.of(getName(condition, observer, entity),
+                    Values.get(condition.value(),
+                            parameters)));
+            case IGNORE_CASE -> CriteriaCondition.ignoreCase(ConditionQueryValue.class.cast(condition.value())
+                    .get()
+                    .stream().map(v -> getCondition(v, parameters, observer, entity))
+                    .findAny().orElseThrow());
             default -> throw new QueryException("There is not support the type: " + condition.condition());
         };
     }

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/Conditions.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/Conditions.java
@@ -61,6 +61,9 @@ public final class Conditions {
             case CONTAINS -> CriteriaCondition.contains(Element.of(getName(condition, observer, entity),
                     Values.get(condition.value(),
                             parameters)));
+            case STARTS_WITH -> CriteriaCondition.startsWith(Element.of(getName(condition, observer, entity),
+                    Values.get(condition.value(),
+                            parameters)));
             case ENDS_WITH -> CriteriaCondition.endsWith(Element.of(getName(condition, observer, entity),
                     Values.get(condition.value(),
                             parameters)));

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CriteriaCondition.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CriteriaCondition.java
@@ -454,6 +454,44 @@ public final class CriteriaCondition {
         return of(element, Condition.OR);
     }
 
+    /**
+     * Creates a {@link CriteriaCondition} with a {@link Condition#CONTAINS}, indicating that a select will scan a
+     * semistructured NoSQL database with the same name and the value contains the one provided in this element.
+     *
+     * @param element an element instance
+     * @return a {@link CriteriaCondition} with {@link Condition#CONTAINS}
+     * @throws NullPointerException when the element is null
+     */
+    public static CriteriaCondition contains(Element element) {
+        return new CriteriaCondition(element, Condition.CONTAINS);
+    }
+
+    /**
+     * Creates a {@link CriteriaCondition} with a {@link Condition#ENDS_WITH}, indicating that a select will scan a
+     * semistructured NoSQL database with the same name and the value ends with the one provided in this element.
+     *
+     * @param element an element instance
+     * @return a {@link CriteriaCondition} with {@link Condition#CONTAINS}
+     * @throws NullPointerException when the element is null
+     */
+    public static CriteriaCondition endsWith(Element element) {
+        return new CriteriaCondition(element, Condition.ENDS_WITH);
+    }
+
+    /**
+     * Creates a {@link CriteriaCondition} with a {@link Condition#IGNORE_CASE}, indicating that a select will
+     * scan a semistructured NoSQL database with the same name and the value matches the underlying condition
+     * ignoring the case.
+     *
+     * @param element an element instance
+     * @return a {@link CriteriaCondition} with {@link Condition#IGNORE_CASE}
+     * @throws NullPointerException when the element is null
+     */
+    public static CriteriaCondition ignoreCase(CriteriaCondition condition) {
+        Element element = Element.of(Condition.IGNORE_CASE.getNameField(), condition);
+        return of(element, Condition.IGNORE_CASE);
+    }
+
     private static void checkInClause(Value value) {
         if (!value.isInstanceOf(Iterable.class)) {
             throw new IllegalArgumentException("On CriteriaCondition#in, you must use an iterable" +

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CriteriaCondition.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CriteriaCondition.java
@@ -495,7 +495,7 @@ public final class CriteriaCondition {
      * scan a semistructured NoSQL database with the same name and the value matches the underlying condition
      * ignoring the case.
      *
-     * @param element an element instance
+     * @param condition a condition to be wrapped into the ignoreCase condition
      * @return a {@link CriteriaCondition} with {@link Condition#IGNORE_CASE}
      * @throws NullPointerException when the element is null
      */

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CriteriaCondition.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CriteriaCondition.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  * and Apache License v2.0 which accompanies this distribution.

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CriteriaCondition.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CriteriaCondition.java
@@ -467,11 +467,23 @@ public final class CriteriaCondition {
     }
 
     /**
+     * Creates a {@link CriteriaCondition} with a {@link Condition#STARTS_WITH}, indicating that a select will scan a
+     * semistructured NoSQL database with the same name and the value starts with the one provided in this element.
+     *
+     * @param element an element instance
+     * @return a {@link CriteriaCondition} with {@link Condition#STARTS_WITH}
+     * @throws NullPointerException when the element is null
+     */
+    public static CriteriaCondition startsWith(Element element) {
+        return new CriteriaCondition(element, Condition.STARTS_WITH);
+    }
+
+    /**
      * Creates a {@link CriteriaCondition} with a {@link Condition#ENDS_WITH}, indicating that a select will scan a
      * semistructured NoSQL database with the same name and the value ends with the one provided in this element.
      *
      * @param element an element instance
-     * @return a {@link CriteriaCondition} with {@link Condition#CONTAINS}
+     * @return a {@link CriteriaCondition} with {@link Condition#ENDS_WITH}
      * @throws NullPointerException when the element is null
      */
     public static CriteriaCondition endsWith(Element element) {


### PR DESCRIPTION
Support for Contains, EndsWith, StartsWith, IgnoreCase.

Includes:
* backport of https://github.com/eclipse-jnosql/jnosql/pull/620 to 1.1.x (brings Contains, EndsWith, StartsWith) - with [this commit](https://github.com/eclipse-jnosql/jnosql/commit/bf4d5c7c684a8294fd6d24c4f6e4bb02d36d9eee)
* support for IgnoreCase
* merge of several checking methods in tests into a single checkConditions, which supports checking nested conditions