### PR TITLE
feat: Equals and hashCode in MethodSelectQuery now consider all fields

### DIFF
--- a/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/MethodSelectQuery.java
+++ b/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/MethodSelectQuery.java
@@ -85,16 +85,19 @@ final class MethodSelectQuery  implements SelectQuery {
         }
         MethodSelectQuery that = (MethodSelectQuery) o;
         return Objects.equals(entity, that.entity) &&
-                Objects.equals(where, that.where);
+                Objects.equals(where, that.where) &&
+                Objects.equals(sorts, that.sorts)  &&
+                Objects.equals(limit, that.limit) &&
+                Objects.equals(count, that.count);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(entity, where);
+        return Objects.hash(entity, where, sorts, limit, count);
     }
 
     @Override
     public String toString() {
-        return entity + " where " + where + " orderBy " + sorts;
+        return entity + " where " + where + " orderBy " + sorts + " limit " + limit + " count " + count;
     }
 }


### PR DESCRIPTION
Not only entity and where as before.

This allows using `MethodSelectQuery` as a key, e.g. for caching