### PR TITLE
Add support special chars

### DIFF
--- a/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/data/UpdateParser.java
+++ b/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/data/UpdateParser.java
@@ -12,6 +12,7 @@
 package org.eclipse.jnosql.communication.query.data;
 
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.eclipse.jnosql.communication.query.NullQueryValue;
 import org.eclipse.jnosql.communication.query.UpdateItem;
 import org.eclipse.jnosql.communication.query.UpdateQuery;
 import org.eclipse.jnosql.query.grammar.data.JDQLParser;
@@ -49,16 +50,19 @@ public final class UpdateParser extends AbstractWhere implements Function<String
         super.exitUpdate_item(ctx);
         String name = ctx.state_field_path_expression().getText();
         var scalarContext = ctx.scalar_expression();
-        if(isArithmeticOperation(scalarContext)) {
+        if (isArithmeticOperation(scalarContext)) {
             throw new UnsupportedOperationException("Eclipse JNoSQL does not support arithmetic operations in the UPDATE clause: " + scalarContext.getText());
         }
-        if(hasParenthesis(scalarContext)) {
+        if (hasParenthesis(scalarContext)) {
             throw new UnsupportedOperationException("Eclipse JNoSQL does not support parenthesis in the UPDATE clause: " + scalarContext.getText());
         }
-        var primaryExpression = scalarContext.primary_expression();
-        var value = PrimaryFunction.INSTANCE.apply(primaryExpression);
-        items.add(JDQLUpdateItem.of(name, value));
-
+        if (scalarContext != null) {
+            var primaryExpression = scalarContext.primary_expression();
+            var value = PrimaryFunction.INSTANCE.apply(primaryExpression);
+            items.add(JDQLUpdateItem.of(name, value));
+        } else {
+            items.add(JDQLUpdateItem.of(name, NullQueryValue.INSTANCE));
+        }
     }
 
 
@@ -75,14 +79,17 @@ public final class UpdateParser extends AbstractWhere implements Function<String
     }
 
     private static boolean isArithmeticOperation(JDQLParser.Scalar_expressionContext scalarContext) {
-        return Objects.nonNull(scalarContext.MUL())
+        return Objects.nonNull(scalarContext)
+                && (Objects.nonNull(scalarContext.MUL())
                 || Objects.nonNull(scalarContext.DIV())
                 || Objects.nonNull(scalarContext.PLUS())
                 || Objects.nonNull(scalarContext.MINUS())
-                || Objects.nonNull(scalarContext.CONCAT());
+                || Objects.nonNull(scalarContext.CONCAT()));
     }
     private boolean hasParenthesis(JDQLParser.Scalar_expressionContext scalarContext) {
-        return Objects.nonNull(scalarContext.LPAREN()) || Objects.nonNull(scalarContext.RPAREN());
+        return Objects.nonNull(scalarContext)
+                && (Objects.nonNull(scalarContext.LPAREN())
+                || Objects.nonNull(scalarContext.RPAREN()));
     }
 
 }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
@@ -46,8 +46,6 @@ class DeleteJakartaDataQuerySpecialTest {
             soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
             soft.assertThat(condition.name()).isEqualTo("active");
             soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.FALSE);
-
-
         });
     }
 

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
@@ -13,6 +13,7 @@ package org.eclipse.jnosql.communication.query.data;
 
 import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.Condition;
+import org.eclipse.jnosql.communication.query.BooleanQueryValue;
 import org.eclipse.jnosql.communication.query.ConditionQueryValue;
 import org.eclipse.jnosql.communication.query.NumberQueryValue;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +44,9 @@ class DeleteJakartaDataQuerySpecialTest {
             var where = deleteQuery.where().orElseThrow();
             var condition = where.condition();
             soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("active");
+            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.FALSE);
+
 
         });
     }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  You may elect to redistribute this code under either of these licenses.
+ *  Contributors:
+ *  Otavio Santana
+ */
+package org.eclipse.jnosql.communication.query.data;
+
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.Condition;
+import org.eclipse.jnosql.communication.query.ConditionQueryValue;
+import org.eclipse.jnosql.communication.query.NumberQueryValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DeleteJakartaDataQuerySpecialTest {
+
+
+    private DeleteParser deleteParser;
+
+    @BeforeEach
+    void setUp() {
+        deleteParser = new DeleteParser();
+    }
+
+
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"DELETE FROM entity WHERE age = 10 AND salary = 10.15"})
+    void shouldAndTwoConditions(String query){
+        var deleteQuery = deleteParser.apply(query);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(deleteQuery.fields()).isEmpty();
+            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
+            soft.assertThat(deleteQuery.where()).isNotEmpty();
+            var where = deleteQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.AND);
+
+            var values = (ConditionQueryValue) condition.value();
+            var conditions = values.get();
+            soft.assertThat(conditions).hasSize(2);
+            soft.assertThat(conditions.get(0).name()).isEqualTo("age");
+            soft.assertThat(conditions.get(0).value()).isEqualTo(NumberQueryValue.of(10));
+
+            soft.assertThat(conditions.get(1).name()).isEqualTo("salary");
+            soft.assertThat(conditions.get(1).value()).isEqualTo(NumberQueryValue.of(10.15));
+        });
+    }
+
+}

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
@@ -15,6 +15,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.Condition;
 import org.eclipse.jnosql.communication.query.BooleanQueryValue;
 import org.eclipse.jnosql.communication.query.ConditionQueryValue;
+import org.eclipse.jnosql.communication.query.NullQueryValue;
 import org.eclipse.jnosql.communication.query.NumberQueryValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -70,7 +71,18 @@ class DeleteJakartaDataQuerySpecialTest {
     @ParameterizedTest(name = "Should parser the query {0}")
     @ValueSource(strings = {"DELETE FROM entity WHERE license IS NULL"})
     void shouldCheckIsNull(String query){
+        var deleteQuery = deleteParser.apply(query);
 
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(deleteQuery.fields()).isEmpty();
+            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
+            soft.assertThat(deleteQuery.where()).isNotEmpty();
+            var where = deleteQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("license");
+            soft.assertThat(condition.value()).isEqualTo(NullQueryValue.INSTANCE);
+        });
     }
 
 

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
@@ -45,8 +45,26 @@ class DeleteJakartaDataQuerySpecialTest {
             var condition = where.condition();
             soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
             soft.assertThat(condition.name()).isEqualTo("active");
+            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.TRUE);
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"DELETE FROM entity WHERE active = false"})
+    void shouldValidateFalse(String query){
+        var deleteQuery = deleteParser.apply(query);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(deleteQuery.fields()).isEmpty();
+            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
+            soft.assertThat(deleteQuery.where()).isNotEmpty();
+            var where = deleteQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("active");
             soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.FALSE);
         });
     }
+
 
 }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
@@ -32,8 +32,8 @@ class DeleteJakartaDataQuerySpecialTest {
 
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"DELETE FROM entity WHERE age = 10 AND salary = 10.15"})
-    void shouldAndTwoConditions(String query){
+    @ValueSource(strings = {"DELETE FROM entity WHERE active = true"})
+    void shouldValidateTrue(String query){
         var deleteQuery = deleteParser.apply(query);
 
         SoftAssertions.assertSoftly(soft -> {
@@ -42,16 +42,8 @@ class DeleteJakartaDataQuerySpecialTest {
             soft.assertThat(deleteQuery.where()).isNotEmpty();
             var where = deleteQuery.where().orElseThrow();
             var condition = where.condition();
-            soft.assertThat(condition.condition()).isEqualTo(Condition.AND);
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
 
-            var values = (ConditionQueryValue) condition.value();
-            var conditions = values.get();
-            soft.assertThat(conditions).hasSize(2);
-            soft.assertThat(conditions.get(0).name()).isEqualTo("age");
-            soft.assertThat(conditions.get(0).value()).isEqualTo(NumberQueryValue.of(10));
-
-            soft.assertThat(conditions.get(1).name()).isEqualTo("salary");
-            soft.assertThat(conditions.get(1).value()).isEqualTo(NumberQueryValue.of(10.15));
         });
     }
 

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
@@ -67,4 +67,11 @@ class DeleteJakartaDataQuerySpecialTest {
     }
 
 
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"DELETE FROM entity WHERE license IS NULL"})
+    void shouldCheckIsNull(String query){
+
+    }
+
+
 }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
@@ -67,7 +67,6 @@ class DeleteJakartaDataQuerySpecialTest {
         });
     }
 
-
     @ParameterizedTest(name = "Should parser the query {0}")
     @ValueSource(strings = {"DELETE FROM entity WHERE license IS NULL"})
     void shouldCheckIsNull(String query){
@@ -85,5 +84,21 @@ class DeleteJakartaDataQuerySpecialTest {
         });
     }
 
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"DELETE FROM entity WHERE license IS NOT NULL"})
+    void shouldCheckIsNotNull(String query){
+        var deleteQuery = deleteParser.apply(query);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(deleteQuery.fields()).isEmpty();
+            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
+            soft.assertThat(deleteQuery.where()).isNotEmpty();
+            var where = deleteQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.NOT);
+            soft.assertThat(condition.name()).isEqualTo("license");
+            soft.assertThat(condition.value()).isEqualTo(NullQueryValue.INSTANCE);
+        });
+    }
 
 }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/DeleteJakartaDataQuerySpecialTest.java
@@ -17,9 +17,13 @@ import org.eclipse.jnosql.communication.query.BooleanQueryValue;
 import org.eclipse.jnosql.communication.query.ConditionQueryValue;
 import org.eclipse.jnosql.communication.query.NullQueryValue;
 import org.eclipse.jnosql.communication.query.NumberQueryValue;
+import org.eclipse.jnosql.communication.query.QueryCondition;
+import org.eclipse.jnosql.communication.query.QueryValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
 
 class DeleteJakartaDataQuerySpecialTest {
 
@@ -84,6 +88,7 @@ class DeleteJakartaDataQuerySpecialTest {
         });
     }
 
+    @SuppressWarnings("unchecked")
     @ParameterizedTest(name = "Should parser the query {0}")
     @ValueSource(strings = {"DELETE FROM entity WHERE license IS NOT NULL"})
     void shouldCheckIsNotNull(String query){
@@ -96,8 +101,12 @@ class DeleteJakartaDataQuerySpecialTest {
             var where = deleteQuery.where().orElseThrow();
             var condition = where.condition();
             soft.assertThat(condition.condition()).isEqualTo(Condition.NOT);
-            soft.assertThat(condition.name()).isEqualTo("license");
-            soft.assertThat(condition.value()).isEqualTo(NullQueryValue.INSTANCE);
+            QueryValue<?> negation = condition.value();
+            List<QueryCondition> value = (List<QueryCondition>) negation.get();
+            QueryCondition queryCondition = value.getFirst();
+            soft.assertThat(queryCondition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(queryCondition.name()).isEqualTo("license");
+            soft.assertThat(queryCondition.value()).isEqualTo(NullQueryValue.INSTANCE);
         });
     }
 

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQueryCountTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQueryCountTest.java
@@ -32,7 +32,7 @@ class SelectJakartaDataQueryCountTest {
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"select count(*) FROM entity WHERE active = true"})
+    @ValueSource(strings = {"select count(this) FROM entity WHERE active = true"})
     void shouldValidateTrue(String query){
         var selectQuery = selectParser.apply(query, null);
 
@@ -50,7 +50,7 @@ class SelectJakartaDataQueryCountTest {
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"select count(*) FROM entity WHERE active = false"})
+    @ValueSource(strings = {"select count(this) FROM entity WHERE active = false"})
     void shouldValidateFalse(String query){
         var selectQuery = selectParser.apply(query, null);
 
@@ -68,7 +68,7 @@ class SelectJakartaDataQueryCountTest {
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"select count(*) FROM entity WHERE license IS NULL"})
+    @ValueSource(strings = {"select count(this) FROM entity WHERE license IS NULL"})
     void shouldCheckIsNull(String query){
         var selectQuery = selectParser.apply(query, null);
 
@@ -87,7 +87,7 @@ class SelectJakartaDataQueryCountTest {
 
     @SuppressWarnings("unchecked")
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"select count(*) FROM entity WHERE license IS NOT NULL"})
+    @ValueSource(strings = {"select count(this) FROM entity WHERE license IS NOT NULL"})
     void shouldCheckIsNotNull(String query){
         var selectQuery = selectParser.apply(query, null);
 

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQueryCountTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQueryCountTest.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  You may elect to redistribute this code under either of these licenses.
+ *  Contributors:
+ *  Otavio Santana
+ */
+package org.eclipse.jnosql.communication.query.data;
+
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.Condition;
+import org.eclipse.jnosql.communication.query.BooleanQueryValue;
+import org.eclipse.jnosql.communication.query.NullQueryValue;
+import org.eclipse.jnosql.communication.query.QueryCondition;
+import org.eclipse.jnosql.communication.query.QueryValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+class SelectJakartaDataQueryCountTest {
+    private SelectParser selectParser;
+
+    @BeforeEach
+    void setUp() {
+        selectParser = new SelectParser();
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"select count(*) FROM entity WHERE active = true"})
+    void shouldValidateTrue(String query){
+        var selectQuery = selectParser.apply(query, null);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("active");
+            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.TRUE);
+            soft.assertThat(selectQuery.isCount()).isTrue();
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"select count(*) FROM entity WHERE active = false"})
+    void shouldValidateFalse(String query){
+        var selectQuery = selectParser.apply(query, null);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("active");
+            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.FALSE);
+            soft.assertThat(selectQuery.isCount()).isTrue();
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"select count(*) FROM entity WHERE license IS NULL"})
+    void shouldCheckIsNull(String query){
+        var selectQuery = selectParser.apply(query, null);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("license");
+            soft.assertThat(condition.value()).isEqualTo(NullQueryValue.INSTANCE);
+            soft.assertThat(selectQuery.isCount()).isTrue();
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"select count(*) FROM entity WHERE license IS NOT NULL"})
+    void shouldCheckIsNotNull(String query){
+        var selectQuery = selectParser.apply(query, null);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.NOT);
+            QueryValue<?> negation = condition.value();
+            List<QueryCondition> value = (List<QueryCondition>) negation.get();
+            QueryCondition queryCondition = value.getFirst();
+            soft.assertThat(queryCondition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(queryCondition.name()).isEqualTo("license");
+            soft.assertThat(queryCondition.value()).isEqualTo(NullQueryValue.INSTANCE);
+            soft.assertThat(selectQuery.isCount()).isTrue();
+        });
+    }
+
+}

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQuerySpecialTest.java
@@ -24,27 +24,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.List;
 
 class SelectJakartaDataQuerySpecialTest {
-
-
-    private DeleteParser deleteParser;
+    private SelectParser selectParser;
 
     @BeforeEach
     void setUp() {
-        deleteParser = new DeleteParser();
+        selectParser = new SelectParser();
     }
 
-
-
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"DELETE FROM entity WHERE active = true"})
+    @ValueSource(strings = {"FROM entity WHERE active = true"})
     void shouldValidateTrue(String query){
-        var deleteQuery = deleteParser.apply(query);
+        var selectQuery = selectParser.apply(query, null);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(deleteQuery.fields()).isEmpty();
-            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
-            soft.assertThat(deleteQuery.where()).isNotEmpty();
-            var where = deleteQuery.where().orElseThrow();
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
             var condition = where.condition();
             soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
             soft.assertThat(condition.name()).isEqualTo("active");
@@ -53,15 +49,15 @@ class SelectJakartaDataQuerySpecialTest {
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"DELETE FROM entity WHERE active = false"})
+    @ValueSource(strings = {"FROM entity WHERE active = false"})
     void shouldValidateFalse(String query){
-        var deleteQuery = deleteParser.apply(query);
+        var selectQuery = selectParser.apply(query, null);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(deleteQuery.fields()).isEmpty();
-            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
-            soft.assertThat(deleteQuery.where()).isNotEmpty();
-            var where = deleteQuery.where().orElseThrow();
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
             var condition = where.condition();
             soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
             soft.assertThat(condition.name()).isEqualTo("active");
@@ -70,15 +66,15 @@ class SelectJakartaDataQuerySpecialTest {
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"DELETE FROM entity WHERE license IS NULL"})
+    @ValueSource(strings = {"FROM entity WHERE license IS NULL"})
     void shouldCheckIsNull(String query){
-        var deleteQuery = deleteParser.apply(query);
+        var selectQuery = selectParser.apply(query, null);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(deleteQuery.fields()).isEmpty();
-            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
-            soft.assertThat(deleteQuery.where()).isNotEmpty();
-            var where = deleteQuery.where().orElseThrow();
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
             var condition = where.condition();
             soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
             soft.assertThat(condition.name()).isEqualTo("license");
@@ -88,15 +84,15 @@ class SelectJakartaDataQuerySpecialTest {
 
     @SuppressWarnings("unchecked")
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"DELETE FROM entity WHERE license IS NOT NULL"})
+    @ValueSource(strings = {"FROM entity WHERE license IS NOT NULL"})
     void shouldCheckIsNotNull(String query){
-        var deleteQuery = deleteParser.apply(query);
+        var selectQuery = selectParser.apply(query, null);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(deleteQuery.fields()).isEmpty();
-            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
-            soft.assertThat(deleteQuery.where()).isNotEmpty();
-            var where = deleteQuery.where().orElseThrow();
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
             var condition = where.condition();
             soft.assertThat(condition.condition()).isEqualTo(Condition.NOT);
             QueryValue<?> negation = condition.value();

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQuerySpecialTest.java
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  You may elect to redistribute this code under either of these licenses.
+ *  Contributors:
+ *  Otavio Santana
+ */
+package org.eclipse.jnosql.communication.query.data;
+
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.Condition;
+import org.eclipse.jnosql.communication.query.BooleanQueryValue;
+import org.eclipse.jnosql.communication.query.NullQueryValue;
+import org.eclipse.jnosql.communication.query.QueryCondition;
+import org.eclipse.jnosql.communication.query.QueryValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+class SelectJakartaDataQuerySpecialTest {
+
+
+    private DeleteParser deleteParser;
+
+    @BeforeEach
+    void setUp() {
+        deleteParser = new DeleteParser();
+    }
+
+
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"DELETE FROM entity WHERE active = true"})
+    void shouldValidateTrue(String query){
+        var deleteQuery = deleteParser.apply(query);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(deleteQuery.fields()).isEmpty();
+            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
+            soft.assertThat(deleteQuery.where()).isNotEmpty();
+            var where = deleteQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("active");
+            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.TRUE);
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"DELETE FROM entity WHERE active = false"})
+    void shouldValidateFalse(String query){
+        var deleteQuery = deleteParser.apply(query);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(deleteQuery.fields()).isEmpty();
+            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
+            soft.assertThat(deleteQuery.where()).isNotEmpty();
+            var where = deleteQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("active");
+            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.FALSE);
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"DELETE FROM entity WHERE license IS NULL"})
+    void shouldCheckIsNull(String query){
+        var deleteQuery = deleteParser.apply(query);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(deleteQuery.fields()).isEmpty();
+            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
+            soft.assertThat(deleteQuery.where()).isNotEmpty();
+            var where = deleteQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("license");
+            soft.assertThat(condition.value()).isEqualTo(NullQueryValue.INSTANCE);
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"DELETE FROM entity WHERE license IS NOT NULL"})
+    void shouldCheckIsNotNull(String query){
+        var deleteQuery = deleteParser.apply(query);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(deleteQuery.fields()).isEmpty();
+            soft.assertThat(deleteQuery.entity()).isEqualTo("entity");
+            soft.assertThat(deleteQuery.where()).isNotEmpty();
+            var where = deleteQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.NOT);
+            QueryValue<?> negation = condition.value();
+            List<QueryCondition> value = (List<QueryCondition>) negation.get();
+            QueryCondition queryCondition = value.getFirst();
+            soft.assertThat(queryCondition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(queryCondition.name()).isEqualTo("license");
+            soft.assertThat(queryCondition.value()).isEqualTo(NullQueryValue.INSTANCE);
+        });
+    }
+
+}

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/UpdateJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/UpdateJakartaDataQuerySpecialTest.java
@@ -74,7 +74,7 @@ class UpdateJakartaDataQuerySpecialTest {
             soft.assertThat(items).hasSize(1);
 
             soft.assertThat(items).isNotNull().hasSize(1)
-                    .contains(JDQLUpdateItem.of("active", BooleanQueryValue.FALSE));
+                    .contains(JDQLUpdateItem.of("active", NullQueryValue.INSTANCE));
         });
     }
 

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/UpdateJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/UpdateJakartaDataQuerySpecialTest.java
@@ -17,6 +17,8 @@ import org.eclipse.jnosql.communication.query.BooleanQueryValue;
 import org.eclipse.jnosql.communication.query.NullQueryValue;
 import org.eclipse.jnosql.communication.query.QueryCondition;
 import org.eclipse.jnosql.communication.query.QueryValue;
+import org.eclipse.jnosql.communication.query.StringQueryValue;
+import org.eclipse.jnosql.communication.query.UpdateItem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,83 +26,40 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.List;
 
 class UpdateJakartaDataQuerySpecialTest {
-    private SelectParser selectParser;
+    private UpdateParser updateParser;
 
     @BeforeEach
     void setUp() {
-        selectParser = new SelectParser();
+        updateParser = new UpdateParser();
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"FROM entity WHERE active = true"})
+    @ValueSource(strings = {"UPDATE entity SET active = true"})
     void shouldValidateTrue(String query){
-        var selectQuery = selectParser.apply(query, null);
+        var selectQuery = updateParser.apply(query);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(selectQuery.fields()).isEmpty();
             soft.assertThat(selectQuery.entity()).isEqualTo("entity");
-            soft.assertThat(selectQuery.where()).isNotEmpty();
-            var where = selectQuery.where().orElseThrow();
-            var condition = where.condition();
-            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
-            soft.assertThat(condition.name()).isEqualTo("active");
-            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.TRUE);
+            List<UpdateItem> items = selectQuery.set();
+            soft.assertThat(items).hasSize(1);
+
+            soft.assertThat(items).isNotNull().hasSize(1)
+                    .contains(JDQLUpdateItem.of("active", BooleanQueryValue.TRUE));
         });
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"FROM entity WHERE active = false"})
+    @ValueSource(strings = {"UPDATE entity SET active = false"})
     void shouldValidateFalse(String query){
-        var selectQuery = selectParser.apply(query, null);
+        var selectQuery = updateParser.apply(query);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(selectQuery.fields()).isEmpty();
             soft.assertThat(selectQuery.entity()).isEqualTo("entity");
-            soft.assertThat(selectQuery.where()).isNotEmpty();
-            var where = selectQuery.where().orElseThrow();
-            var condition = where.condition();
-            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
-            soft.assertThat(condition.name()).isEqualTo("active");
-            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.FALSE);
-        });
-    }
+            List<UpdateItem> items = selectQuery.set();
+            soft.assertThat(items).hasSize(1);
 
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"FROM entity WHERE license IS NULL"})
-    void shouldCheckIsNull(String query){
-        var selectQuery = selectParser.apply(query, null);
-
-        SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(selectQuery.fields()).isEmpty();
-            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
-            soft.assertThat(selectQuery.where()).isNotEmpty();
-            var where = selectQuery.where().orElseThrow();
-            var condition = where.condition();
-            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
-            soft.assertThat(condition.name()).isEqualTo("license");
-            soft.assertThat(condition.value()).isEqualTo(NullQueryValue.INSTANCE);
-        });
-    }
-
-    @SuppressWarnings("unchecked")
-    @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"FROM entity WHERE license IS NOT NULL"})
-    void shouldCheckIsNotNull(String query){
-        var selectQuery = selectParser.apply(query, null);
-
-        SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(selectQuery.fields()).isEmpty();
-            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
-            soft.assertThat(selectQuery.where()).isNotEmpty();
-            var where = selectQuery.where().orElseThrow();
-            var condition = where.condition();
-            soft.assertThat(condition.condition()).isEqualTo(Condition.NOT);
-            QueryValue<?> negation = condition.value();
-            List<QueryCondition> value = (List<QueryCondition>) negation.get();
-            QueryCondition queryCondition = value.getFirst();
-            soft.assertThat(queryCondition.condition()).isEqualTo(Condition.EQUALS);
-            soft.assertThat(queryCondition.name()).isEqualTo("license");
-            soft.assertThat(queryCondition.value()).isEqualTo(NullQueryValue.INSTANCE);
+            soft.assertThat(items).isNotNull().hasSize(1)
+                    .contains(JDQLUpdateItem.of("active", BooleanQueryValue.FALSE));
         });
     }
 

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/UpdateJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/UpdateJakartaDataQuerySpecialTest.java
@@ -63,4 +63,20 @@ class UpdateJakartaDataQuerySpecialTest {
         });
     }
 
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"UPDATE entity SET active = NULL"})
+    void shouldValidateNull(String query){
+        var selectQuery = updateParser.apply(query);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            List<UpdateItem> items = selectQuery.set();
+            soft.assertThat(items).hasSize(1);
+
+            soft.assertThat(items).isNotNull().hasSize(1)
+                    .contains(JDQLUpdateItem.of("active", BooleanQueryValue.FALSE));
+        });
+    }
+
+
 }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/UpdateJakartaDataQuerySpecialTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/UpdateJakartaDataQuerySpecialTest.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *  and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *  You may elect to redistribute this code under either of these licenses.
+ *  Contributors:
+ *  Otavio Santana
+ */
+package org.eclipse.jnosql.communication.query.data;
+
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.Condition;
+import org.eclipse.jnosql.communication.query.BooleanQueryValue;
+import org.eclipse.jnosql.communication.query.NullQueryValue;
+import org.eclipse.jnosql.communication.query.QueryCondition;
+import org.eclipse.jnosql.communication.query.QueryValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+class UpdateJakartaDataQuerySpecialTest {
+    private SelectParser selectParser;
+
+    @BeforeEach
+    void setUp() {
+        selectParser = new SelectParser();
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"FROM entity WHERE active = true"})
+    void shouldValidateTrue(String query){
+        var selectQuery = selectParser.apply(query, null);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("active");
+            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.TRUE);
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"FROM entity WHERE active = false"})
+    void shouldValidateFalse(String query){
+        var selectQuery = selectParser.apply(query, null);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("active");
+            soft.assertThat(condition.value()).isEqualTo(BooleanQueryValue.FALSE);
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"FROM entity WHERE license IS NULL"})
+    void shouldCheckIsNull(String query){
+        var selectQuery = selectParser.apply(query, null);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(condition.name()).isEqualTo("license");
+            soft.assertThat(condition.value()).isEqualTo(NullQueryValue.INSTANCE);
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"FROM entity WHERE license IS NOT NULL"})
+    void shouldCheckIsNotNull(String query){
+        var selectQuery = selectParser.apply(query, null);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.NOT);
+            QueryValue<?> negation = condition.value();
+            List<QueryCondition> value = (List<QueryCondition>) negation.get();
+            QueryCondition queryCondition = value.getFirst();
+            soft.assertThat(queryCondition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(queryCondition.name()).isEqualTo("license");
+            soft.assertThat(queryCondition.value()).isEqualTo(NullQueryValue.INSTANCE);
+        });
+    }
+
+}

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DatabaseManager.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DatabaseManager.java
@@ -250,8 +250,7 @@ public interface DatabaseManager extends AutoCloseable {
      */
     default Stream<CommunicationEntity> query(String query, String entity) {
         Objects.requireNonNull(query, "query is required");
-        QueryParser parser = new QueryParser();
-        return parser.query(query, entity, this, CommunicationObserverParser.EMPTY);
+        return QueryParser.INSTANCE.query(query, entity, this, CommunicationObserverParser.EMPTY);
     }
 
     /**

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/QueryParser.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/QueryParser.java
@@ -20,6 +20,8 @@ import java.util.stream.Stream;
  */
 public final class QueryParser {
 
+   static final QueryParser INSTANCE = new QueryParser();
+
     private final SelectQueryParser select = new SelectQueryParser();
     private final DeleteQueryParser delete = new DeleteQueryParser();
     private final UpdateQueryParser update = new UpdateQueryParser();

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DeleteQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DeleteQueryParserTest.java
@@ -312,7 +312,7 @@ class DeleteQueryParserTest {
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"FROM entity WHERE active = true"})
+    @ValueSource(strings = {"DELETE FROM entity WHERE active = true"})
     void shouldReturnQuerySpecialTrue(String query) {
         var captor = ArgumentCaptor.forClass(DeleteQuery.class);
          parser.query(query, manager, observer);
@@ -330,7 +330,7 @@ class DeleteQueryParserTest {
 
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"FROM entity WHERE active = false"})
+    @ValueSource(strings = {"DELETE FROM entity WHERE active = false"})
     void shouldReturnQuerySpecialFalse(String query) {
         var captor = ArgumentCaptor.forClass(DeleteQuery.class);
         parser.query(query, manager, observer);
@@ -347,7 +347,7 @@ class DeleteQueryParserTest {
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"FROM entity WHERE active IS NULL"})
+    @ValueSource(strings = {"DELETE FROM entity WHERE active IS NULL"})
     void shouldReturnQuerySpecialNull(String query) {
         var captor = ArgumentCaptor.forClass(DeleteQuery.class);
         parser.query(query, manager, observer);
@@ -364,7 +364,7 @@ class DeleteQueryParserTest {
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
-    @ValueSource(strings = {"FROM entity WHERE active IS NOT NULL"})
+    @ValueSource(strings = {"DELETE FROM entity WHERE active IS NOT NULL"})
     void shouldReturnQuerySpecialNotNull(String query) {
         var captor = ArgumentCaptor.forClass(DeleteQuery.class);
         parser.query(query, manager, observer);

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DeleteQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DeleteQueryParserTest.java
@@ -317,11 +317,11 @@ class DeleteQueryParserTest {
         var captor = ArgumentCaptor.forClass(DeleteQuery.class);
          parser.query(query, manager, observer);
         Mockito.verify(manager).delete(captor.capture());
-        var selectQuery = captor.getValue();
+        var deleteQuery = captor.getValue();
 
-        checkBaseQuery(selectQuery);
-        assertTrue(selectQuery.condition().isPresent());
-        CriteriaCondition condition = selectQuery.condition().get();
+        checkBaseQuery(deleteQuery);
+        assertTrue(deleteQuery.condition().isPresent());
+        CriteriaCondition condition = deleteQuery.condition().get();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
             softly.assertThat(condition.element()).isEqualTo(Element.of("active", true));
@@ -335,11 +335,11 @@ class DeleteQueryParserTest {
         var captor = ArgumentCaptor.forClass(DeleteQuery.class);
         parser.query(query, manager, observer);
         Mockito.verify(manager).delete(captor.capture());
-        var selectQuery = captor.getValue();
+        var deleteQuery = captor.getValue();
 
-        checkBaseQuery(selectQuery);
-        assertTrue(selectQuery.condition().isPresent());
-        CriteriaCondition condition = selectQuery.condition().get();
+        checkBaseQuery(deleteQuery);
+        assertTrue(deleteQuery.condition().isPresent());
+        CriteriaCondition condition = deleteQuery.condition().get();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
             softly.assertThat(condition.element()).isEqualTo(Element.of("active", false));
@@ -352,11 +352,11 @@ class DeleteQueryParserTest {
         var captor = ArgumentCaptor.forClass(DeleteQuery.class);
         parser.query(query, manager, observer);
         Mockito.verify(manager).delete(captor.capture());
-        var selectQuery = captor.getValue();
+        var deleteQuery = captor.getValue();
 
-        checkBaseQuery(selectQuery);
-        assertTrue(selectQuery.condition().isPresent());
-        CriteriaCondition condition = selectQuery.condition().get();
+        checkBaseQuery(deleteQuery);
+        assertTrue(deleteQuery.condition().isPresent());
+        CriteriaCondition condition = deleteQuery.condition().get();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
             softly.assertThat(condition.element()).isEqualTo(Element.of("active", Value.ofNull()));
@@ -369,11 +369,11 @@ class DeleteQueryParserTest {
         var captor = ArgumentCaptor.forClass(DeleteQuery.class);
         parser.query(query, manager, observer);
         Mockito.verify(manager).delete(captor.capture());
-        var selectQuery = captor.getValue();
+        var deleteQuery = captor.getValue();
 
-        checkBaseQuery(selectQuery);
-        assertTrue(selectQuery.condition().isPresent());
-        CriteriaCondition condition = selectQuery.condition().get();
+        checkBaseQuery(deleteQuery);
+        assertTrue(deleteQuery.condition().isPresent());
+        CriteriaCondition condition = deleteQuery.condition().get();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(condition.condition()).isEqualTo(Condition.NOT);
             CriteriaCondition subCondition = condition.element().get(CriteriaCondition.class);

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
@@ -597,6 +597,23 @@ class SelectQueryParserTest {
         });
     }
 
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"FROM entity WHERE active IS NOT NULL"})
+    void shouldReturnQuerySpecialNotNull(String query) {
+        var captor = ArgumentCaptor.forClass(SelectQuery.class);
+        parser.query(query, null, manager, observer);
+        Mockito.verify(manager).select(captor.capture());
+        var selectQuery = captor.getValue();
+
+        checkBaseQuery(selectQuery);
+        assertTrue(selectQuery.condition().isPresent());
+        CriteriaCondition condition = selectQuery.condition().get();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(condition.condition()).isEqualTo(Condition.NOT);
+            softly.assertThat(condition.element()).isEqualTo(Element.of("active", Value.ofNull()));
+        });
+    }
+
     @Test
     void shouldApply() {
         SelectQueryParser queryParser = new SelectQueryParser();

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
@@ -17,6 +17,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.Condition;
 import org.eclipse.jnosql.communication.QueryException;
 import org.eclipse.jnosql.communication.TypeReference;
+import org.eclipse.jnosql.communication.Value;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -576,6 +577,23 @@ class SelectQueryParserTest {
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
             softly.assertThat(condition.element()).isEqualTo(Element.of("active", false));
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"FROM entity WHERE active IS NULL"})
+    void shouldReturnQuerySpecialNull(String query) {
+        var captor = ArgumentCaptor.forClass(SelectQuery.class);
+        parser.query(query, null, manager, observer);
+        Mockito.verify(manager).select(captor.capture());
+        var selectQuery = captor.getValue();
+
+        checkBaseQuery(selectQuery);
+        assertTrue(selectQuery.condition().isPresent());
+        CriteriaCondition condition = selectQuery.condition().get();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            softly.assertThat(condition.element()).isEqualTo(Element.of("active", Value.ofNull()));
         });
     }
 

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
@@ -555,9 +555,10 @@ class SelectQueryParserTest {
         checkBaseQuery(selectQuery);
         assertTrue(selectQuery.condition().isPresent());
         CriteriaCondition condition = selectQuery.condition().get();
-
-        assertEquals(Condition.EQUALS, condition.condition());
-        assertEquals(Element.of("age", 10), condition.element());
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            softly.assertThat(Element.of("active", true)).isEqualTo( condition.element());
+        });
     }
 
     @Test

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
@@ -544,6 +544,22 @@ class SelectQueryParserTest {
         });
     }
 
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"FROM entity WHERE active = true"})
+    void shouldReturnQuerySpecialTrue(String query) {
+        var captor = ArgumentCaptor.forClass(SelectQuery.class);
+        parser.query(query, null, manager, observer);
+        Mockito.verify(manager).select(captor.capture());
+        var selectQuery = captor.getValue();
+
+        checkBaseQuery(selectQuery);
+        assertTrue(selectQuery.condition().isPresent());
+        CriteriaCondition condition = selectQuery.condition().get();
+
+        assertEquals(Condition.EQUALS, condition.condition());
+        assertEquals(Element.of("age", 10), condition.element());
+    }
+
     @Test
     void shouldApply() {
         SelectQueryParser queryParser = new SelectQueryParser();

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
@@ -557,7 +557,25 @@ class SelectQueryParserTest {
         CriteriaCondition condition = selectQuery.condition().get();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
-            softly.assertThat(Element.of("active", true)).isEqualTo( condition.element());
+            softly.assertThat(condition.element()).isEqualTo(Element.of("active", true));
+        });
+    }
+
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"FROM entity WHERE active = false"})
+    void shouldReturnQuerySpecialFalse(String query) {
+        var captor = ArgumentCaptor.forClass(SelectQuery.class);
+        parser.query(query, null, manager, observer);
+        Mockito.verify(manager).select(captor.capture());
+        var selectQuery = captor.getValue();
+
+        checkBaseQuery(selectQuery);
+        assertTrue(selectQuery.condition().isPresent());
+        CriteriaCondition condition = selectQuery.condition().get();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            softly.assertThat(condition.element()).isEqualTo(Element.of("active", false));
         });
     }
 

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/SelectQueryParserTest.java
@@ -610,7 +610,9 @@ class SelectQueryParserTest {
         CriteriaCondition condition = selectQuery.condition().get();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(condition.condition()).isEqualTo(Condition.NOT);
-            softly.assertThat(condition.element()).isEqualTo(Element.of("active", Value.ofNull()));
+            CriteriaCondition subCondition = condition.element().get(CriteriaCondition.class);
+            softly.assertThat(subCondition.condition()).isEqualTo(Condition.EQUALS);
+            softly.assertThat(subCondition.element()).isEqualTo(Element.of("active", Value.ofNull()));
         });
     }
 

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/UpdateQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/UpdateQueryParserTest.java
@@ -14,7 +14,6 @@ import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.Condition;
 import org.eclipse.jnosql.communication.QueryException;
 import org.eclipse.jnosql.communication.TypeReference;
-import org.eclipse.jnosql.communication.Value;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -346,7 +345,7 @@ class UpdateQueryParserTest {
         prepare.result();
         Mockito.verify(manager).update(captor.capture());
         var updateQuery = captor.getValue();
-        CriteriaCondition criteriaCondition = updateQuery.condition().get();
+        CriteriaCondition criteriaCondition = updateQuery.condition().orElseThrow();
         SoftAssertions.assertSoftly(soft -> {
             Element element = criteriaCondition.element();
             soft.assertThat(criteriaCondition.condition()).isEqualTo(Condition.EQUALS);
@@ -365,7 +364,7 @@ class UpdateQueryParserTest {
         prepare.result();
         Mockito.verify(manager).update(captor.capture());
         var updateQuery = captor.getValue();
-        CriteriaCondition criteriaCondition = updateQuery.condition().get();
+        CriteriaCondition criteriaCondition = updateQuery.condition().orElseThrow();
         SoftAssertions.assertSoftly(soft -> {
             Element element = criteriaCondition.element();
             soft.assertThat(criteriaCondition.condition()).isEqualTo(Condition.EQUALS);
@@ -385,7 +384,7 @@ class UpdateQueryParserTest {
         prepare.result();
         Mockito.verify(manager).update(captor.capture());
         var updateQuery = captor.getValue();
-        CriteriaCondition criteriaCondition = updateQuery.condition().get();
+        CriteriaCondition criteriaCondition = updateQuery.condition().orElseThrow();
         SoftAssertions.assertSoftly(soft -> {
             Element element = criteriaCondition.element();
             soft.assertThat(criteriaCondition.condition()).isEqualTo(Condition.EQUALS);

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/UpdateQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/UpdateQueryParserTest.java
@@ -14,6 +14,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.communication.Condition;
 import org.eclipse.jnosql.communication.QueryException;
 import org.eclipse.jnosql.communication.TypeReference;
+import org.eclipse.jnosql.communication.Value;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -396,6 +397,55 @@ class UpdateQueryParserTest {
             soft.assertThat(setItem.value().get()).isEqualTo("Ada");
         });
     }
+
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"UPDATE entity SET active = true"})
+    void shouldReturnQuerySpecialTrue(String query) {
+        var captor = ArgumentCaptor.forClass(UpdateQuery.class);
+        parser.query(query, manager, observer);
+        Mockito.verify(manager).update(captor.capture());
+        var updateQuery = captor.getValue();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(updateQuery.condition()).isEmpty();
+            var items = updateQuery.set();
+            soft.assertThat(items).isNotNull().hasSize(1);
+            soft.assertThat(items).contains(Element.of("active", true));
+        });
+    }
+
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"UPDATE entity SET active = false"})
+    void shouldReturnQuerySpecialFalse(String query) {
+        var captor = ArgumentCaptor.forClass(UpdateQuery.class);
+        parser.query(query, manager, observer);
+        Mockito.verify(manager).update(captor.capture());
+        var updateQuery = captor.getValue();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(updateQuery.condition()).isEmpty();
+            var items = updateQuery.set();
+            soft.assertThat(items).isNotNull().hasSize(1);
+            soft.assertThat(items).contains(Element.of("active", true));
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"UPDATE entity SET active = NULL"})
+    void shouldReturnQuerySpecialNull(String query) {
+        var captor = ArgumentCaptor.forClass(UpdateQuery.class);
+        parser.query(query, manager, observer);
+        Mockito.verify(manager).update(captor.capture());
+        var updateQuery = captor.getValue();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(updateQuery.condition()).isEmpty();
+            var items = updateQuery.set();
+            soft.assertThat(items).isNotNull().hasSize(1);
+            soft.assertThat(items).contains(Element.of("active", true));
+        });
+
+    }
+
 
     private void checkBaseQuery(UpdateQuery updateQuery) {
         assertEquals("entity", updateQuery.name());

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/UpdateQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/UpdateQueryParserTest.java
@@ -426,7 +426,7 @@ class UpdateQueryParserTest {
             soft.assertThat(updateQuery.condition()).isEmpty();
             var items = updateQuery.set();
             soft.assertThat(items).isNotNull().hasSize(1);
-            soft.assertThat(items).contains(Element.of("active", true));
+            soft.assertThat(items).contains(Element.of("active", false));
         });
     }
 
@@ -441,7 +441,7 @@ class UpdateQueryParserTest {
             soft.assertThat(updateQuery.condition()).isEmpty();
             var items = updateQuery.set();
             soft.assertThat(items).isNotNull().hasSize(1);
-            soft.assertThat(items).contains(Element.of("active", true));
+            soft.assertThat(items).contains(Element.of("active", null));
         });
 
     }


### PR DESCRIPTION
This pull request introduces improvements to the query parsing logic for the Jakarta Data specification, primarily focusing on better handling of `NULL` and boolean values in `SELECT`, `DELETE`, and `UPDATE` queries. It also adds comprehensive tests to verify these enhancements and refactors the instantiation of the `QueryParser` class for consistency and efficiency.

### Query Value Handling Improvements

* Updated `UpdateParser` logic to correctly handle cases where the value in the `SET` clause is `NULL`, ensuring that such assignments use `NullQueryValue.INSTANCE` instead of failing or producing incorrect results. [[1]](diffhunk://#diff-3a335407b11a827a73734908dcabeb0b3df6d324e9224bbb758282a2654ce8c8R15) [[2]](diffhunk://#diff-3a335407b11a827a73734908dcabeb0b3df6d324e9224bbb758282a2654ce8c8R59-R65)
* Improved safety in helper methods (`isArithmeticOperation`, `hasParenthesis`) by adding null checks for `scalarContext`, preventing potential null pointer exceptions during query parsing.

### QueryParser Refactoring

* Changed `DatabaseManager.query` to use a singleton instance of `QueryParser` (`QueryParser.INSTANCE`) instead of creating a new instance each time, improving performance and consistency. [[1]](diffhunk://#diff-ba6852233d611b9190d8b518fe42e1c9b19c85bd969f19fcc2c51adf552ca288L253-R253) [[2]](diffhunk://#diff-40bed55b702bb7ac4ab93ff9938ba58a07fca057f0cc6d6587ab79dde41a8783R23-R24)

### Test Coverage for Query Value Handling

* Added `DeleteJakartaDataQuerySpecialTest` to verify parsing and handling of boolean and `NULL` values in `DELETE` queries.
* Added `SelectJakartaDataQuerySpecialTest` to test boolean and `NULL` value handling in standard `SELECT` queries.
* Added `SelectJakartaDataQueryCountTest` to test correct handling of boolean and `NULL` values in `SELECT COUNT` queries.
* Added `UpdateJakartaDataQuerySpecialTest` to verify correct parsing and assignment of boolean and `NULL` values in `UPDATE` queries.

### Test Utility Enhancement

* Imported `SoftAssertions` in `DeleteQueryParserTest` to enable more robust and readable assertion checks in tests.