### PR TITLE
Fix: use EntityConverterFactory in template producers

### DIFF
--- a/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/ColumnTemplateProducer.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/ColumnTemplateProducer.java
@@ -22,6 +22,7 @@ import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 import org.eclipse.jnosql.mapping.semistructured.AbstractSemiStructuredTemplate;
 import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactory;
 import org.eclipse.jnosql.mapping.semistructured.EventPersistManager;
 
 import java.util.Objects;
@@ -52,7 +53,7 @@ public class ColumnTemplateProducer implements Function<DatabaseManager, ColumnT
 
 
     @Inject
-    private EntityConverter converter;
+    private EntityConverterFactory converter;
 
     @Inject
     private EventPersistManager eventManager;
@@ -88,12 +89,12 @@ public class ColumnTemplateProducer implements Function<DatabaseManager, ColumnT
 
         private final  Converters converters;
 
-        ProducerColumnTemplate(EntityConverter converter,
+        ProducerColumnTemplate(EntityConverterFactory converter,
                                DatabaseManager manager,
                                EventPersistManager eventManager,
                                EntitiesMetadata entities,
                                Converters converters) {
-            this.converter = converter;
+            this.converter = converter.create(manager);
             this.manager = manager;
             this.eventManager = eventManager;
             this.entities = entities;

--- a/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/DocumentTemplateProducer.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/DocumentTemplateProducer.java
@@ -22,6 +22,7 @@ import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 import org.eclipse.jnosql.mapping.semistructured.AbstractSemiStructuredTemplate;
 import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactory;
 import org.eclipse.jnosql.mapping.semistructured.EventPersistManager;
 
 import java.util.Objects;
@@ -35,7 +36,7 @@ import java.util.function.Function;
 public class DocumentTemplateProducer implements Function<DatabaseManager, DocumentTemplate> {
 
     @Inject
-    private EntityConverter converter;
+    private EntityConverterFactory converter;
 
     @Inject
     private EventPersistManager eventManager;
@@ -67,12 +68,12 @@ public class DocumentTemplateProducer implements Function<DatabaseManager, Docum
 
         private final  Converters converters;
 
-        ProducerDocumentTemplate(EntityConverter converter,
+        ProducerDocumentTemplate(EntityConverterFactory converter,
                                DatabaseManager manager,
                                EventPersistManager eventManager,
                                EntitiesMetadata entities,
                                Converters converters) {
-            this.converter = converter;
+            this.converter = converter.create(manager);
             this.manager = manager;
             this.eventManager = eventManager;
             this.entities = entities;

--- a/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/GraphTemplateProducer.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/GraphTemplateProducer.java
@@ -21,6 +21,7 @@ import org.eclipse.jnosql.communication.graph.GraphDatabaseManager;
 import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactory;
 import org.eclipse.jnosql.mapping.semistructured.EventPersistManager;
 
 import java.util.Objects;
@@ -34,7 +35,7 @@ import java.util.function.Function;
 public class GraphTemplateProducer implements Function<GraphDatabaseManager, GraphTemplate> {
 
     @Inject
-    private EntityConverter converter;
+    private EntityConverterFactory converter;
 
     @Inject
     private EventPersistManager eventManager;
@@ -66,12 +67,12 @@ public class GraphTemplateProducer implements Function<GraphDatabaseManager, Gra
 
         private final  Converters converters;
 
-        ProducerGraphTemplate(EntityConverter converter,
+        ProducerGraphTemplate(EntityConverterFactory converter,
                               GraphDatabaseManager manager,
                               EventPersistManager eventManager,
                               EntitiesMetadata entities,
                               Converters converters) {
-            this.converter = converter;
+            this.converter = converter.create(manager);
             this.manager = manager;
             this.eventManager = eventManager;
             this.entities = entities;


### PR DESCRIPTION
Fix: use `EntityConverterFactory` instead of `EntityConverter` in:
- `ColumnTemplateProducer`
- `DocumentTemplateProducer`
- `GraphTemplateProducer`