### PR TITLE
1.1.x - Load class in EnumConverter using context classloader

### DIFF
--- a/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/data/EnumConverter.java
+++ b/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/data/EnumConverter.java
@@ -46,7 +46,7 @@ enum EnumConverter implements Function<String, Enum<?>> {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     private Enum<?> getEnumValue(String enumClassName, String enumValueName) throws ClassNotFoundException {
-        Class<?> enumClass = Class.forName(enumClassName);
+        Class<?> enumClass = Class.forName(enumClassName, true, Thread.currentThread().getContextClassLoader());
         if (enumClass.isEnum()) {
             Class<? extends Enum> enumType = enumClass.asSubclass(Enum.class);
             return Enum.valueOf(enumType, enumValueName);


### PR DESCRIPTION
This allows loading correctly in runtimes that scope application code to application classloaders. If JNoSQL classes are included in such a runtime, the class is loaded from the application instead of from the runtime's shared classloader. It still works correctly for flat classpath because the context classloader is set to the bootstrap classloader by default.

An example is GlassFish 8.0, which will bundle JNoSQL insde and its classes will be loaded by an internal GlassFish classloader, which is shared for all applicaitons. If an application contains an enum used in entities, the internal GlassFish classloader will attempt to load it but will not find it - it's a parent of the application classloader and it doesn't the classes in applications. On the other hand, the application classloader is set as the context classloader, so the context classloader will see the classes and will load them.