### PR TITLE
Load class in EnumConverter using context classloader

### DIFF
--- a/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/data/EnumConverter.java
+++ b/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/data/EnumConverter.java
@@ -46,7 +46,7 @@ enum EnumConverter implements Function<String, Enum<?>> {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     private Enum<?> getEnumValue(String enumClassName, String enumValueName) throws ClassNotFoundException {
-        Class<?> enumClass = Class.forName(enumClassName);
+        Class<?> enumClass = Class.forName(enumClassName, true, Thread.currentThread().getContextClassLoader());
         if (enumClass.isEnum()) {
             Class<? extends Enum> enumType = enumClass.asSubclass(Enum.class);
             return Enum.valueOf(enumType, enumValueName);


### PR DESCRIPTION
This allows loading correctly in runtimes that scope application code to application classloaders. If JNoSQL classes are included in such a runtime, the class is loaded from the application instead of from the runtime's shared classloader. It still works correctly for flat classpath because the context classloader is set to the bootstrap classloader by default.

A port of https://github.com/eclipse-jnosql/jnosql/pull/670 from 1.1.x