### PR TITLE
Include new structure to find all queries

### DIFF
--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
@@ -19,6 +19,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+import jakarta.nosql.Entity;
 import org.eclipse.jnosql.mapping.metadata.ClassConverter;
 import org.eclipse.jnosql.mapping.metadata.ClassInformationNotFoundException;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
@@ -137,9 +138,14 @@ class DefaultEntitiesMetadata implements EntitiesMetadata {
 
     void projectionFound(@Observes ProjectionFound projectionFound) {
         LOGGER.fine(() -> "Adding projection: " + projectionFound);
+        Class<?> type = projectionFound.type();
+        if(type.getAnnotation(Entity.class) != null) {
+            LOGGER.fine(() -> "Ignoring projection, because it is an entity: " + type);
+            return;
+        }
         Function<Class<?>, ProjectionMetadata> projectionConverter = new ProjectionConverter();
-        ProjectionMetadata apply = projectionConverter.apply(projectionFound.type());
-        this.projections.put(projectionFound.type(), apply);
+        ProjectionMetadata apply = projectionConverter.apply(type);
+        this.projections.put(type, apply);
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/ProjectionConverter.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/ProjectionConverter.java
@@ -24,11 +24,14 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 public class ProjectionConverter implements Function<Class<?>, ProjectionMetadata> {
 
     private static final Logger LOGGER = Logger.getLogger(ProjectionConverter.class.getName());
+    private static final Predicate<String> IS_BLANK = String::isBlank;
+    private static final Predicate<String> IS_NOT_BLANK = IS_BLANK.negate();
 
     @Override
     public ProjectionMetadata apply(Class<?> type) {
@@ -67,8 +70,11 @@ public class ProjectionConverter implements Function<Class<?>, ProjectionMetadat
     }
 
     private static String getName(Parameter parameter, RecordComponent recordComponent) {
-        Optional<String> nameFromColumn = Optional.ofNullable(parameter.getAnnotation(Column.class)).map(Column::value);
-        Optional<String> nameFromSelect = Optional.ofNullable(recordComponent.getAnnotation(Select.class)).map(Select::value);
+        Optional<String> nameFromColumn = Optional.ofNullable(parameter.getAnnotation(Column.class)).map(Column::value)
+                .filter(IS_NOT_BLANK);
+        Optional<String> nameFromSelect = Optional.ofNullable(recordComponent.getAnnotation(Select.class))
+                .map(Select::value)
+                .filter(IS_NOT_BLANK);
 
         return nameFromColumn
                 .or(() -> nameFromSelect)

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassGraphClassScannerTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ClassGraphClassScannerTest.java
@@ -131,7 +131,7 @@ class ClassGraphClassScannerTest {
     @Test
     void shouldReturnProjections() {
         Set<Class<?>> projections = classScanner.projections();
-        assertThat(projections).hasSize(2)
+        assertThat(projections).hasSize(3)
                 .contains(ComputerView.class, PCView.class)
                 .doesNotContain(BookDTO.class);
     }
@@ -139,14 +139,14 @@ class ClassGraphClassScannerTest {
     @Test
     void shouldIgnoreProjectionClassesThatAreNotRecords() {
         Set<Class<?>> projections = classScanner.projections();
-        assertThat(projections).hasSize(2)
+        assertThat(projections).hasSize(3)
                 .doesNotContain(BookDTO.class);
     }
 
     @Test
     void shouldIgnoreProjectionClassesThatAreNotAnnotated() {
         Set<Class<?>> projections = classScanner.projections();
-        assertThat(projections).hasSize(2)
+        assertThat(projections).hasSize(3)
                 .doesNotContain(BookDTO.class);
     }
 

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadataTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadataTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jnosql.mapping.reflection.entities.ComputerView;
 import org.eclipse.jnosql.mapping.reflection.entities.Movie;
 import org.eclipse.jnosql.mapping.reflection.entities.Person;
 import org.eclipse.jnosql.mapping.reflection.entities.Vendor;
+import org.eclipse.jnosql.mapping.reflection.entities.constructor.Counter;
 import org.eclipse.jnosql.mapping.reflection.entities.inheritance.EmailNotification;
 import org.eclipse.jnosql.mapping.reflection.entities.inheritance.LargeProject;
 import org.eclipse.jnosql.mapping.reflection.entities.inheritance.Notification;
@@ -175,6 +176,14 @@ class DefaultEntitiesMetadataTest {
             softly.assertThat(projectionMetadata.type()).isEqualTo(CarResult.class);
             softly.assertThat(projectionMetadata.className()).isEqualTo(CarResult.class.getName());
         });
+    }
+
+    @Test
+    void shouldIgnoreWhenIsEntity(){
+        ProjectionFound projectionFound = new ProjectionFound(Counter.class);
+        mappings.projectionFound(projectionFound);
+        Optional<ProjectionMetadata> projection = mappings.projection(Counter.class);
+        SoftAssertions.assertSoftly(softly -> softly.assertThat(projection).isNotPresent());
     }
 
     @Test

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ProjectionConverterTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ProjectionConverterTest.java
@@ -13,11 +13,13 @@ package org.eclipse.jnosql.mapping.reflection;
 
 import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.mapping.metadata.ProjectionConstructorMetadata;
+import org.eclipse.jnosql.mapping.reflection.entities.BookSummary;
 import org.eclipse.jnosql.mapping.reflection.entities.ComputerView;
 import org.eclipse.jnosql.mapping.reflection.entities.PCView;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.Year;
 
 class ProjectionConverterTest {
 
@@ -92,6 +94,21 @@ class ProjectionConverterTest {
             softly.assertThat(constructor.parameters().get(0).type()).isEqualTo(String.class);
             softly.assertThat(constructor.parameters().get(1).name()).isEqualTo("native");
             softly.assertThat(constructor.parameters().get(1).type()).isEqualTo(BigDecimal.class);
+        });
+    }
+
+    @Test
+    void shouldUseAttributeNameWhenAnnotationIsBlank() {
+        Class<?> type = BookSummary.class;
+        var metadata = converter.apply(type);
+        var constructor = metadata.constructor();
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(constructor).isNotNull();
+            softly.assertThat(constructor.parameters()).hasSize(2);
+            softly.assertThat(constructor.parameters().get(0).name()).isEqualTo("name");
+            softly.assertThat(constructor.parameters().get(0).type()).isEqualTo(String.class);
+            softly.assertThat(constructor.parameters().get(1).name()).isEqualTo("release");
+            softly.assertThat(constructor.parameters().get(1).type()).isEqualTo(Year.class);
         });
     }
 

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionClassScannerTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionClassScannerTest.java
@@ -129,7 +129,7 @@ class ReflectionClassScannerTest {
     @Test
     void shouldFindProjections() {
         Set<Class<?>> projections = classScanner.projections();
-        assertThat(projections).hasSize(2)
+        assertThat(projections).hasSize(3)
                 .contains(ComputerView.class, PCView.class);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/entities/BookSummary.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/entities/BookSummary.java
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.reflection.entities;
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Projection;
+
+import java.time.Year;
+
+@Projection
+public record BookSummary(@Column String name, @Column Year release) {
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
@@ -45,7 +45,9 @@ class SemistructuredFindAllOperation implements FindAllOperation {
     public <T> T execute(RepositoryInvocationContext context) {
         EntityMetadata entityMetadata = context.entityMetadata();
         var query = SelectQuery.select().from(entityMetadata.name()).build();
-        return (T) semistructuredReturnType.executeFindByQuery(context, query);
+
+        return (T) semistructuredReturnType.executeFindByQuery(context,
+                semistructuredQueryBuilder.updateQuery(query,context));
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
@@ -18,7 +18,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
-import org.eclipse.jnosql.mapping.metadata.repository.RepositoryMethod;
 import org.eclipse.jnosql.mapping.metadata.repository.spi.FindAllOperation;
 import org.eclipse.jnosql.mapping.metadata.repository.spi.RepositoryInvocationContext;
 
@@ -45,8 +44,6 @@ class SemistructuredFindAllOperation implements FindAllOperation {
     @Override
     public <T> T execute(RepositoryInvocationContext context) {
         EntityMetadata entityMetadata = context.entityMetadata();
-        Class<?> type = entityMetadata.type();
-        RepositoryMethod method = context.method();
         var query = SelectQuery.select().from(entityMetadata.name()).build();
         return (T) semistructuredReturnType.executeFindByQuery(context, query);
     }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
@@ -47,7 +47,7 @@ class SemistructuredFindAllOperation implements FindAllOperation {
         var query = SelectQuery.select().from(entityMetadata.name()).build();
 
         return (T) semistructuredReturnType.executeFindByQuery(context,
-                semistructuredQueryBuilder.updateQuery(query,context));
+                semistructuredQueryBuilder.updateQuery(query, context));
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
@@ -28,15 +28,21 @@ class SemistructuredFindAllOperation implements FindAllOperation {
 
     private final SemistructuredQueryBuilder semistructuredQueryBuilder;
 
+    private final SemistructuredReturnType semistructuredReturnType;
+
     @Inject
-    SemistructuredFindAllOperation(SemistructuredQueryBuilder semistructuredQueryBuilder) {
+    SemistructuredFindAllOperation(SemistructuredQueryBuilder semistructuredQueryBuilder,
+                                   SemistructuredReturnType semistructuredReturnType) {
         this.semistructuredQueryBuilder = semistructuredQueryBuilder;
+        this.semistructuredReturnType = semistructuredReturnType;
     }
 
     SemistructuredFindAllOperation() {
         this.semistructuredQueryBuilder = null;
+        this.semistructuredReturnType = null;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T execute(RepositoryInvocationContext context) {
         EntityMetadata entityMetadata = context.entityMetadata();
@@ -44,6 +50,8 @@ class SemistructuredFindAllOperation implements FindAllOperation {
         Class<?> type = entityMetadata.type();
         RepositoryMethod method = context.method();
         var query = SelectQuery.select().from(entityMetadata.name()).build();
+
+        return (T) semistructuredReturnType.executeFindByQuery(context, query);
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
@@ -48,7 +48,6 @@ class SemistructuredFindAllOperation implements FindAllOperation {
         Class<?> type = entityMetadata.type();
         RepositoryMethod method = context.method();
         var query = SelectQuery.select().from(entityMetadata.name()).build();
-
         return (T) semistructuredReturnType.executeFindByQuery(context, query);
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
@@ -15,14 +15,36 @@
 package org.eclipse.jnosql.mapping.semistructured.repository;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoryMethod;
 import org.eclipse.jnosql.mapping.metadata.repository.spi.FindAllOperation;
 import org.eclipse.jnosql.mapping.metadata.repository.spi.RepositoryInvocationContext;
+import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
 
 @ApplicationScoped
 class SemistructuredFindAllOperation implements FindAllOperation {
 
+    private final SemistructuredQueryBuilder semistructuredQueryBuilder;
+
+    @Inject
+    SemistructuredFindAllOperation(SemistructuredQueryBuilder semistructuredQueryBuilder) {
+        this.semistructuredQueryBuilder = semistructuredQueryBuilder;
+    }
+
+    SemistructuredFindAllOperation() {
+        this.semistructuredQueryBuilder = null;
+    }
+
     @Override
     public <T> T execute(RepositoryInvocationContext context) {
-        return null;
+        EntityMetadata entityMetadata = context.entityMetadata();
+        var template = (SemiStructuredTemplate) context.template();
+        Class<?> type = entityMetadata.type();
+        RepositoryMethod method = context.method();
+        var query = SelectQuery.select().from(entityMetadata.name()).build();
     }
+
+
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
@@ -47,7 +47,7 @@ class SemistructuredFindAllOperation implements FindAllOperation {
         var query = SelectQuery.select().from(entityMetadata.name()).build();
 
         return (T) semistructuredReturnType.executeFindByQuery(context,
-                semistructuredQueryBuilder.updateQuery(query, context));
+                semistructuredQueryBuilder.applyInheritance(query, context));
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperation.java
@@ -21,7 +21,6 @@ import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
 import org.eclipse.jnosql.mapping.metadata.repository.RepositoryMethod;
 import org.eclipse.jnosql.mapping.metadata.repository.spi.FindAllOperation;
 import org.eclipse.jnosql.mapping.metadata.repository.spi.RepositoryInvocationContext;
-import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
 
 @ApplicationScoped
 class SemistructuredFindAllOperation implements FindAllOperation {
@@ -46,7 +45,6 @@ class SemistructuredFindAllOperation implements FindAllOperation {
     @Override
     public <T> T execute(RepositoryInvocationContext context) {
         EntityMetadata entityMetadata = context.entityMetadata();
-        var template = (SemiStructuredTemplate) context.template();
         Class<?> type = entityMetadata.type();
         RepositoryMethod method = context.method();
         var query = SelectQuery.select().from(entityMetadata.name()).build();

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
@@ -55,7 +55,7 @@ class SemistructuredQueryBuilder {
         this.paramsBinderMap = new ConcurrentHashMap<>();
     }
 
-    public SemistructuredQueryBuilder() {
+    SemistructuredQueryBuilder() {
         this.converters = null;
         this.parsers = new ConcurrentHashMap<>();
         this.paramsBinderMap = new ConcurrentHashMap<>();
@@ -77,7 +77,7 @@ class SemistructuredQueryBuilder {
         return includeInheritance(query, entityMetadata);
     }
 
-    public DeleteQuery deleteQuery(RepositoryInvocationContext context) {
+    DeleteQuery deleteQuery(RepositoryInvocationContext context) {
         var entityMetadata = context.entityMetadata();
         var provider = DeleteMethodProvider.INSTANCE;
         var method = context.method();

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
@@ -91,6 +91,11 @@ class SemistructuredQueryBuilder {
         return includeInheritance(query, entityMetadata);
     }
 
+    public SelectQuery updateQuery(SelectQuery query, RepositoryInvocationContext context) {
+        var entityMetadata = context.entityMetadata();
+        return includeInheritance(query, entityMetadata);
+    }
+
 
     private CommunicationObserverParser observer(EntityMetadata entityMetadata) {
         Class<?> entityType = entityMetadata.type();
@@ -137,7 +142,6 @@ class SemistructuredQueryBuilder {
         }
         return null;
     }
-
 
 
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
@@ -91,7 +91,7 @@ class SemistructuredQueryBuilder {
         return includeInheritance(query, entityMetadata);
     }
 
-    SelectQuery updateQuery(SelectQuery query, RepositoryInvocationContext context) {
+    SelectQuery applyInheritance(SelectQuery query, RepositoryInvocationContext context) {
         var entityMetadata = context.entityMetadata();
         return includeInheritance(query, entityMetadata);
     }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
@@ -91,7 +91,7 @@ class SemistructuredQueryBuilder {
         return includeInheritance(query, entityMetadata);
     }
 
-    public SelectQuery updateQuery(SelectQuery query, RepositoryInvocationContext context) {
+    SelectQuery updateQuery(SelectQuery query, RepositoryInvocationContext context) {
         var entityMetadata = context.entityMetadata();
         return includeInheritance(query, entityMetadata);
     }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryBuilder.java
@@ -62,7 +62,7 @@ class SemistructuredQueryBuilder {
     }
 
 
-    public SelectQuery selectQuery(RepositoryInvocationContext context) {
+    SelectQuery selectQuery(RepositoryInvocationContext context) {
         var method = context.method();
         var entityMetadata = context.entityMetadata();
         var parameters = context.parameters();

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
@@ -14,8 +14,73 @@
  */
 package org.eclipse.jnosql.mapping.semistructured.repository;
 
+import jakarta.data.repository.Select;
 import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.mapping.core.repository.DynamicReturn;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.ProjectionMetadata;
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoryMethod;
+import org.eclipse.jnosql.mapping.metadata.repository.spi.RepositoryInvocationContext;
+import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 @ApplicationScoped
 class SemistructuredReturnType {
+
+    private EntitiesMetadata entitiesMetadata;
+
+    @SuppressWarnings("unchecked")
+    protected Object executeFindByQuery(RepositoryInvocationContext context, SelectQuery query) {
+
+        var method = context.method();
+        var template = (SemiStructuredTemplate) context.template();
+        var entityMetadata = context.entityMetadata();
+        var typeClass = entityMetadata.type();
+        DynamicReturn<?> dynamicReturn = DynamicReturn.builder()
+                .classSource(typeClass)
+                .methodName(method.name())
+                .returnType(method.returnType().orElseThrow())
+
+                .result(() -> {
+                    Stream<Object> select = template.select(query);
+                    return select.map(mapper(method));
+                })
+                .singleResult(() -> {
+                    Optional<Object> object = template.singleResult(query);
+                    return object.map(mapper(method));
+                })
+                .pagination(DynamicReturn.findPageRequest(args))
+                .streamPagination(streamPagination(query, method))
+                .singleResultPagination(getSingleResult(query, method))
+                .page(getPage(query, method))
+                .build();
+        return dynamicReturn.execute();
+    }
+
+    protected <E> Function<Object, E> mapper(RepositoryInvocationContext context) {
+        return value -> {
+            RepositoryMethod method = context.method();
+            var entityMetadata = context.entityMetadata();
+            var returnType = method.elementType().orElseThrow();
+            Optional<ProjectionMetadata> projection = this.entitiesMetadata.projection(returnType);
+            if (projection.isPresent()) {
+                ProjectionMetadata projectionMetadata = projection.orElseThrow();
+                return projectorConverter().map(value, projectionMetadata);
+            }
+            Select[] annotations = method.getAnnotationsByType(Select.class);
+            if (annotations.length == 1) {
+                String fieldReturn = annotations[0].value();
+                Optional<EntityMetadata> valueEntityMetadata = entitiesMetadata().findByClassName(value.getClass().getName());
+                return (E) valueEntityMetadata
+                        .map(entityMetadata -> value(entityMetadata, fieldReturn, value))
+                        .orElse(value);
+            }
+            return (E) value;
+        };
+    }
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
@@ -130,14 +130,14 @@ class SemistructuredReturnType {
     protected <E> Function<Object, E> mapper(RepositoryMethod method) {
         return value -> {
             var returnType = method.elementType().orElse(method.returnType().orElseThrow());
-            Optional<ProjectionMetadata> projection = this.entitiesMetadata.projection(returnType);
+            var projection = this.entitiesMetadata.projection(returnType);
             if (projection.isPresent()) {
                 ProjectionMetadata projectionMetadata = projection.orElseThrow();
                 return projectorConverter.map(value, projectionMetadata);
             }
-            var annotations = method.select();
-            if (annotations.size() == 1) {
-                String fieldReturn = annotations.getFirst();
+            var attributes = method.select();
+            if (attributes.size() == 1) {
+                String fieldReturn = attributes.getFirst();
                 Optional<EntityMetadata> valueEntityMetadata = entitiesMetadata.findByClassName(value.getClass().getName());
                 return (E) valueEntityMetadata
                         .map(entityMetadata -> value(entityMetadata, fieldReturn, value))

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
@@ -14,12 +14,16 @@
  */
 package org.eclipse.jnosql.mapping.semistructured.repository;
 
-import jakarta.data.repository.Select;
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.mapping.core.NoSQLPage;
 import org.eclipse.jnosql.mapping.core.repository.DynamicReturn;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.FieldMetadata;
 import org.eclipse.jnosql.mapping.metadata.ProjectionMetadata;
 import org.eclipse.jnosql.mapping.metadata.repository.RepositoryMethod;
 import org.eclipse.jnosql.mapping.metadata.repository.spi.RepositoryInvocationContext;
@@ -29,14 +33,26 @@ import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @ApplicationScoped
 class SemistructuredReturnType {
 
-    private EntitiesMetadata entitiesMetadata;
+    private final EntitiesMetadata entitiesMetadata;
 
-    private ProjectorConverter projectorConverter;
+    private final  ProjectorConverter projectorConverter;
+
+    @Inject
+    SemistructuredReturnType(EntitiesMetadata entitiesMetadata, ProjectorConverter projectorConverter) {
+        this.entitiesMetadata = entitiesMetadata;
+        this.projectorConverter = projectorConverter;
+    }
+
+    SemistructuredReturnType() {
+        this.entitiesMetadata = null;
+        this.projectorConverter = null;
+    }
 
     @SuppressWarnings("unchecked")
     protected Object executeFindByQuery(RepositoryInvocationContext context, SelectQuery query) {
@@ -58,14 +74,15 @@ class SemistructuredReturnType {
                     Optional<Object> object = template.singleResult(query);
                     return object.map(mapper(method));
                 })
-                .pagination(DynamicReturn.findPageRequest(args))
-                .streamPagination(streamPagination(query, method))
-                .singleResultPagination(getSingleResult(query, method))
-                .page(getPage(query, method))
+                .pagination(DynamicReturn.findPageRequest(context.parameters()))
+                .streamPagination(streamPagination(query, method, template))
+                .singleResultPagination(getSingleResult(query, method, template))
+                .page(getPage(query, method, template))
                 .build();
         return dynamicReturn.execute();
     }
 
+    @SuppressWarnings("unchecked")
     protected <E> Function<Object, E> mapper(RepositoryInvocationContext context) {
         return value -> {
             RepositoryMethod method = context.method();
@@ -85,5 +102,66 @@ class SemistructuredReturnType {
             }
             return (E) value;
         };
+    }
+
+    protected <T> Function<PageRequest, Stream<T>> streamPagination(SelectQuery query,
+                                                                    RepositoryMethod method,
+                                                                    SemiStructuredTemplate template) {
+        return p -> template.select(query).map(mapper(method));
+    }
+
+    protected <T> Function<PageRequest, Optional<T>> getSingleResult(SelectQuery query,
+                                                                     RepositoryMethod method,
+                                                                 SemiStructuredTemplate template) {
+        return p -> template.singleResult(query).map(mapper(method));
+    }
+
+    protected <T>  Function<PageRequest, Page<T>> getPage(SelectQuery query,
+                                                          RepositoryMethod method,
+                                                          SemiStructuredTemplate template) {
+        return p -> {
+            Stream<T> entities = template.select(query).map(mapper(method));
+            return NoSQLPage.of(entities.toList(), p);
+        };
+    }
+
+
+    @SuppressWarnings("unchecked")
+    protected <E> Function<Object, E> mapper(RepositoryMethod method) {
+        return value -> {
+            var returnType = method.elementType().orElse(method.returnType().orElseThrow());
+            Optional<ProjectionMetadata> projection = this.entitiesMetadata.projection(returnType);
+            if (projection.isPresent()) {
+                ProjectionMetadata projectionMetadata = projection.orElseThrow();
+                return projectorConverter.map(value, projectionMetadata);
+            }
+            var annotations = method.select();
+            if (annotations.size() == 1) {
+                String fieldReturn = annotations.getFirst();
+                Optional<EntityMetadata> valueEntityMetadata = entitiesMetadata.findByClassName(value.getClass().getName());
+                return (E) valueEntityMetadata
+                        .map(entityMetadata -> value(entityMetadata, fieldReturn, value))
+                        .orElse(value);
+            }
+            return (E) value;
+        };
+    }
+
+    private Object value(EntityMetadata entityMetadata, String returnName, Object value) {
+        var names = returnName.split("\\.");
+        Optional<FieldMetadata> fieldMetadata = entityMetadata.fieldMapping(names[0]);
+        if (fieldMetadata.isPresent()) {
+            var field = fieldMetadata.orElseThrow();
+            var convertedField = field.read(value);
+            if (convertedField != null && names.length > 1) {
+                var subField = Stream.of(names).skip(1).collect(Collectors.joining("."));
+                var subEntityMetadata = entitiesMetadata.findByClassName(convertedField.getClass().getName())
+                        .orElseThrow(() -> new IllegalArgumentException("Entity metadata not found for " + convertedField.getClass()));
+                return value(subEntityMetadata, subField, convertedField);
+
+            }
+            return convertedField == null ? value : convertedField;
+        }
+        return value;
     }
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.semistructured.repository;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+class SemistructuredReturnType {
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/RepositoryFindAllTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/RepositoryFindAllTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.semistructured.repository;
+
+
+import jakarta.inject.Inject;
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.eclipse.jnosql.mapping.semistructured.MockProducer;
+import org.eclipse.jnosql.mapping.semistructured.repository.entities.ComicBook;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.stream.Stream;
+
+@DisplayName("The scenarios to test the feature find all")
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, EntityConverter.class})
+@AddPackages(MockProducer.class)
+@AddPackages(Reflections.class)
+@AddExtensions({ReflectionEntityMetadataExtension.class})
+public class RepositoryFindAllTest extends AbstractRepositoryTest {
+
+    @Inject
+    private SemistructuredRepositoryProducer producer;
+
+
+    @Override
+    SemistructuredRepositoryProducer producer() {
+        return producer;
+    }
+
+
+    @Test
+    @DisplayName("Should find all using built-in Repository")
+    void shouldFindAll() {
+        Mockito.when(template.select(Mockito.any(SelectQuery.class))).thenReturn(Stream.empty());
+        bookStore.findAll();
+        Mockito.verify(template).select(selectQueryCaptor.capture());
+        SelectQuery selectQuery = selectQueryCaptor.getValue();
+
+        SoftAssertions.assertSoftly( softly -> {
+            softly.assertThat(selectQuery.name()).isEqualTo(ComicBook.class.getSimpleName());
+            softly.assertThat(selectQuery.condition()).isNotNull().isEmpty();
+        });
+    }
+
+
+
+
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/RepositoryFindAllTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/RepositoryFindAllTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 @DisplayName("The scenarios to test the feature find all")
@@ -54,12 +55,18 @@ public class RepositoryFindAllTest extends AbstractRepositoryTest {
     @Test
     @DisplayName("Should find all using built-in Repository")
     void shouldFindAll() {
-        Mockito.when(template.select(Mockito.any(SelectQuery.class))).thenReturn(Stream.empty());
-        bookStore.findAll();
+        var comicBook = new ComicBook("1", "Batman", 2020);
+        Mockito.when(template.select(Mockito.any(SelectQuery.class))).thenReturn(Stream.of(comicBook));
+        List<ComicBook> comicBooks = bookStore.findAll();
+
         Mockito.verify(template).select(selectQueryCaptor.capture());
         SelectQuery selectQuery = selectQueryCaptor.getValue();
 
         SoftAssertions.assertSoftly( softly -> {
+            softly.assertThat(comicBooks).isNotNull();
+            softly.assertThat(comicBooks).hasSize(1);
+            softly.assertThat(comicBooks.getFirst()).isEqualTo(comicBook);
+
             softly.assertThat(selectQuery.name()).isEqualTo(ComicBook.class.getSimpleName());
             softly.assertThat(selectQuery.condition()).isNotNull().isEmpty();
         });

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperationTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperationTest.java
@@ -14,8 +14,16 @@
  */
 package org.eclipse.jnosql.mapping.semistructured.repository;
 
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class SemistructuredFindAllOperationTest {
 
+
+    @Test
+    void shouldCreateInstance() {
+        SemistructuredFindAllOperation operation = new SemistructuredFindAllOperation();
+        assertNotNull(operation);
+    }
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperationTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredFindAllOperationTest.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.semistructured.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SemistructuredFindAllOperationTest {
+
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnTypeTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnTypeTest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.semistructured.repository;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SemistructuredReturnTypeTest {
+
+
+    @Test
+    void shouldCreateInstance() {
+        SemistructuredReturnType semistructuredReturnType = new SemistructuredReturnType();
+        assertNotNull(semistructuredReturnType);
+    }
+
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/entities/ComicBookBookStore.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/entities/ComicBookBookStore.java
@@ -25,6 +25,7 @@ public interface ComicBookBookStore {
     List<ComicBook> findAll();
 
     List<ComicBook> findByName(String name);
+
     long countAll();
 
     long countByName(String name);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/entities/ComicBookBookStore.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/entities/ComicBookBookStore.java
@@ -22,6 +22,7 @@ import java.util.List;
 @Repository
 public interface ComicBookBookStore {
 
+    List<ComicBook> findAll();
 
     List<ComicBook> findByName(String name);
     long countAll();

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/entities/PhotoSocialMediaRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/entities/PhotoSocialMediaRepository.java
@@ -23,6 +23,7 @@ import java.util.List;
 public interface PhotoSocialMediaRepository extends BasicRepository<PhotoSocialMedia, Long> {
 
     List<ComicBook> findByName(String name);
+
     long countAll();
 
     long countByName(String name);


### PR DESCRIPTION
This pull request introduces several improvements to the handling of projections and find-all operations in the JNoSQL mapping reflection and semistructured modules. The most significant changes are: projections that are also entities are now correctly ignored, blank annotation values are handled more robustly, a new `BookSummary` projection is introduced for testing, and the semistructured repository gains a working implementation for finding all entities, including a new `SemistructuredReturnType` class for result mapping and pagination.

**Projections and Entity Handling Improvements:**

- Projections that are also annotated as entities are now ignored when registering projections. This prevents accidental misuse and ensures only valid projections are processed. Tests have been added to verify this behavior. [[1]](diffhunk://#diff-5bca44ab129cdd342ec04d573158c3a5fccbe323a87bd39aba19cf77af7c6f4fR141-R148) [[2]](diffhunk://#diff-212cd750ed19f4f69fd1164045a8b4e3844eef5f458541b67ad028e4b834d38fR181-R188)
- The logic for extracting parameter names in projections now ignores blank values in `@Column` and `@Select` annotations, falling back to the attribute name when necessary. This is verified with a new test and the introduction of a `BookSummary` projection record. [[1]](diffhunk://#diff-9a0a00a62c1d119b4b9b75e1ffd10124b7eb0ec0ed4bc86e96245bf57e7c48e8L70-R77) [[2]](diffhunk://#diff-6a4c417886a2507a2e25c86e94d856e39f1451a2bfe4d7ba70c54c6092d6c1cbR100-R114) [[3]](diffhunk://#diff-db2f4a74bce6c4645cc97bb615e9946059ea9a6b3e2caf45a6ad4df9252bee9bR1-R24)

**Semistructured Repository Enhancements:**

- The `SemistructuredFindAllOperation` class now provides a real implementation for fetching all entities, constructing and executing a `SelectQuery` using injected `SemistructuredQueryBuilder` and `SemistructuredReturnType` components.
- A new `SemistructuredReturnType` class is introduced, encapsulating logic for mapping results, handling projections, and supporting pagination and single-result queries in a reusable way.
- The `SemistructuredQueryBuilder` methods are now package-private (not public), and a new `updateQuery` method is added to handle query customization, such as inheritance. [[1]](diffhunk://#diff-3b70821fc780723eb191c080a5316e37fd3002b16a54e8a6ebe4d186c75b8a43L58-R65) [[2]](diffhunk://#diff-3b70821fc780723eb191c080a5316e37fd3002b16a54e8a6ebe4d186c75b8a43L80-R80) [[3]](diffhunk://#diff-3b70821fc780723eb191c080a5316e37fd3002b16a54e8a6ebe4d186c75b8a43R94-R98)

**Test and Coverage Updates:**

- Tests for projection discovery are updated to expect three projections instead of two, reflecting the addition of the `BookSummary` projection. [[1]](diffhunk://#diff-f1abe6ba4a0a8c81929411c04d19351b7b365b70fdc94c72fde10a88e34e4947L134-R149) [[2]](diffhunk://#diff-207303ac97db20ec5b561603a600b89a674c8f7e8e63217ea7d048723c936773L132-R132)
- New imports and minor test adjustments are made to support the new projection and entity-handling logic. [[1]](diffhunk://#diff-212cd750ed19f4f69fd1164045a8b4e3844eef5f458541b67ad028e4b834d38fR29) [[2]](diffhunk://#diff-6a4c417886a2507a2e25c86e94d856e39f1451a2bfe4d7ba70c54c6092d6c1cbR16-R22)

These changes collectively improve the robustness of projection handling and expand the capabilities of the semistructured repository module.

**References:**
- [[1]](diffhunk://#diff-5bca44ab129cdd342ec04d573158c3a5fccbe323a87bd39aba19cf77af7c6f4fR141-R148) [[2]](diffhunk://#diff-212cd750ed19f4f69fd1164045a8b4e3844eef5f458541b67ad028e4b834d38fR181-R188) [[3]](diffhunk://#diff-9a0a00a62c1d119b4b9b75e1ffd10124b7eb0ec0ed4bc86e96245bf57e7c48e8L70-R77) [[4]](diffhunk://#diff-6a4c417886a2507a2e25c86e94d856e39f1451a2bfe4d7ba70c54c6092d6c1cbR100-R114) [[5]](diffhunk://#diff-db2f4a74bce6c4645cc97bb615e9946059ea9a6b3e2caf45a6ad4df9252bee9bR1-R24) [[6]](diffhunk://#diff-7df35ce68966b1b7bad3f48b47ed28e294d7cb30bf54ca1487ae5db362d85c6fR18-R53) [[7]](diffhunk://#diff-dcbd41b615ea79bee27ac8a303bc0a452c3827ab42d327abdfacb9f43eb80212R1-R167) [[8]](diffhunk://#diff-3b70821fc780723eb191c080a5316e37fd3002b16a54e8a6ebe4d186c75b8a43L58-R65) [[9]](diffhunk://#diff-3b70821fc780723eb191c080a5316e37fd3002b16a54e8a6ebe4d186c75b8a43L80-R80) [[10]](diffhunk://#diff-3b70821fc780723eb191c080a5316e37fd3002b16a54e8a6ebe4d186c75b8a43R94-R98) [[11]](diffhunk://#diff-f1abe6ba4a0a8c81929411c04d19351b7b365b70fdc94c72fde10a88e34e4947L134-R149) [[12]](diffhunk://#diff-207303ac97db20ec5b561603a600b89a674c8f7e8e63217ea7d048723c936773L132-R132) [[13]](diffhunk://#diff-212cd750ed19f4f69fd1164045a8b4e3844eef5f458541b67ad028e4b834d38fR29) [[14]](diffhunk://#diff-6a4c417886a2507a2e25c86e94d856e39f1451a2bfe4d7ba70c54c6092d6c1cbR16-R22)