### PR TITLE
fix: RepositoryFilter correctly rejecting invalid provider strings

### DIFF
--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/RepositoryFilter.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/RepositoryFilter.java
@@ -51,7 +51,7 @@ enum RepositoryFilter implements Predicate<Class<?>> {
     public boolean isSupported(Class<?> type) {
         Optional<String> provider = getProvider(type);
         return provider.map(p -> Repository.ANY_PROVIDER.equals(p) || PROVIDER.equalsIgnoreCase(p))
-                .isPresent();
+                       .orElse(false);
     }
 
     /**

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/RepositoryFilterTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/RepositoryFilterTest.java
@@ -77,6 +77,11 @@ class RepositoryFilterTest {
         assertThat(supported.test(StringSupplier.class)).isFalse();
         assertThat(supported.test(Repository.class)).isFalse();
     }
+
+    @Test
+    void shouldReturnUnsupportedWhenAnnotatedWithRepositoryInvalidProvider() {
+        assertThat(supported.test(OtherServer.class)).isFalse();
+    }
     
     @Test
     void shouldReturnValidAndSupported() {
@@ -101,6 +106,10 @@ class RepositoryFilterTest {
 	
     @jakarta.data.repository.Repository(provider = "Eclipse_JNoSQL")
     private interface Server extends BasicRepository<Computer, String> {
+    }
+
+    @jakarta.data.repository.Repository(provider = "Other")
+    private interface OtherServer extends BasicRepository<Computer, String> {
     }
 
     private interface StringSupplier extends Supplier<String> {


### PR DESCRIPTION
Minor fix for the logic in RepositoryFilter, which was checking if an Optional<Boolean> was present instead of the value of the Boolean. This resulted in all values for `provider` in the Repository annotation being accepted.