### PR TITLE
chore: update jakarta.data.api.version to 1.1.0-M2 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <jakarta.enterprise.cdi.version>4.1.0</jakarta.enterprise.cdi.version>
         <jakarta.json.bind.version>3.0.1</jakarta.json.bind.version>
         <jakarta.json.version>2.1.3</jakarta.json.version>
-        <jakarta.data.api.version>1.1.0-M1</jakarta.data.api.version>
+        <jakarta.data.api.version>1.1.0-M2</jakarta.data.api.version>
         <jakarta.nosql.version>1.1.0-SNAPSHOT</jakarta.nosql.version>
         <jakarta.validation.version>3.1.1</jakarta.validation.version>
         <maven-javadoc-plugin.vesion>3.12.0</maven-javadoc-plugin.vesion>


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file, upgrading the `jakarta.data.api.version` dependency from `1.1.0-M1` to `1.1.0-M2`.