### PR TITLE
chore: update jakarta.nosql.version to 1.1.0-M2 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <jakarta.json.bind.version>3.0.1</jakarta.json.bind.version>
         <jakarta.json.version>2.1.3</jakarta.json.version>
         <jakarta.data.api.version>1.1.0-M2</jakarta.data.api.version>
-        <jakarta.nosql.version>1.1.0-SNAPSHOT</jakarta.nosql.version>
+        <jakarta.nosql.version>1.1.0-M2</jakarta.nosql.version>
         <jakarta.validation.version>3.1.1</jakarta.validation.version>
         <maven-javadoc-plugin.vesion>3.12.0</maven-javadoc-plugin.vesion>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>


### PR DESCRIPTION
This pull request updates the `jakarta.nosql.version` dependency in the `pom.xml` file from a snapshot version to a milestone release. This change improves build stability by relying on a fixed, published version rather than a potentially unstable snapshot.

- Dependency update:
  * Updated the `jakarta.nosql.version` property from `1.1.0-SNAPSHOT` to `1.1.0-M2` in `pom.xml` to use a stable milestone release.