### PR TITLE
Support input parameter in IN and NOT IN expressions in JDQL pa…

### DIFF
--- a/jnosql-communication/jnosql-communication-query/antlr4/org/eclipse/jnosql/query/grammar/data/JDQL.g4
+++ b/jnosql-communication/jnosql-communication-query/antlr4/org/eclipse/jnosql/query/grammar/data/JDQL.g4
@@ -42,7 +42,7 @@ comparison_operator : EQ | GT | GTEQ | LT | LTEQ | NEQ;
 between_expression : scalar_expression NOT? BETWEEN scalar_expression AND scalar_expression;
 like_expression : scalar_expression NOT? LIKE (STRING | input_parameter);
 
-in_expression : state_field_path_expression NOT? IN '(' in_item (',' in_item)* ')';
+in_expression : state_field_path_expression NOT? IN  ( LPAREN in_item (COMMA in_item)* RPAREN | input_parameter);
 in_item : literal | enum_literal | input_parameter; // could simplify to just literal
 
 null_comparison_expression : state_field_path_expression IS NOT? NULL;

--- a/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/data/AbstractWhere.java
+++ b/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/data/AbstractWhere.java
@@ -169,6 +169,9 @@ abstract class AbstractWhere extends AbstractJDQLProvider {
         var name = ctx.state_field_path_expression().getText();
         var contextCondition = Condition.IN;
         List<QueryValue<?>> values = new ArrayList<>();
+        if (ctx.input_parameter() != null) {
+            values.add(DefaultQueryValue.of(ctx.input_parameter().getText()));
+        }
         for (JDQLParser.In_itemContext item : ctx.in_item()) {
             values.add(InItemFunction.INSTANCE.apply(item));
         }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQueryProviderInTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/data/SelectJakartaDataQueryProviderInTest.java
@@ -17,6 +17,7 @@ import org.eclipse.jnosql.communication.query.ArrayQueryValue;
 import org.eclipse.jnosql.communication.query.ConditionQueryValue;
 import org.eclipse.jnosql.communication.query.EnumQueryValue;
 import org.eclipse.jnosql.communication.query.NumberQueryValue;
+import org.eclipse.jnosql.communication.query.ParamQueryValue;
 import org.eclipse.jnosql.communication.query.QueryCondition;
 import org.eclipse.jnosql.communication.query.QueryValue;
 import org.eclipse.jnosql.communication.query.SelectQuery;
@@ -26,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.DayOfWeek;
+import java.util.List;
 
 class SelectJakartaDataQueryProviderInTest {
 
@@ -225,5 +227,47 @@ class SelectJakartaDataQueryProviderInTest {
         });
     }
 
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"WHERE age IN :ages", "FROM entity WHERE age IN :ages"})
+    void shouldQueryInParameter(String query){
+        SelectQuery selectQuery = selectParser.apply(query, "entity");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.orderBy()).isEmpty();
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.IN);
+            var value = condition.value();
+            soft.assertThat(value).isInstanceOf(DataArrayQueryValue.class);
+            DataArrayQueryValue arrayQueryValue = DataArrayQueryValue.class.cast(value);
+            soft.assertThat(arrayQueryValue.get()[0]).isInstanceOf(ParamQueryValue.class);
+            ParamQueryValue paramQueryValue = ParamQueryValue.class.cast(arrayQueryValue.get()[0]);
+            soft.assertThat(paramQueryValue.get()).isEqualTo("ages");
+        });
+    }
+
+    @ParameterizedTest(name = "Should parser the query {0}")
+    @ValueSource(strings = {"WHERE age NOT IN :ages"})
+    void shouldQueryNotInParameter(String query){
+        SelectQuery selectQuery = selectParser.apply(query, "entity");
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(selectQuery.fields()).isEmpty();
+            soft.assertThat(selectQuery.entity()).isEqualTo("entity");
+            soft.assertThat(selectQuery.orderBy()).isEmpty();
+            soft.assertThat(selectQuery.where()).isNotEmpty();
+            var where = selectQuery.where().orElseThrow();
+            var condition = where.condition();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.NOT);
+            var queryCondition = ((List<?>) condition.value().get()).get(0);
+            soft.assertThat(queryCondition).isInstanceOf(QueryCondition.class);
+            DataArrayQueryValue arrayQueryValue = (DataArrayQueryValue) ((QueryCondition)queryCondition).value();
+            soft.assertThat(arrayQueryValue.get()[0]).isInstanceOf(ParamQueryValue.class);
+            ParamQueryValue paramQueryValue = ParamQueryValue.class.cast(arrayQueryValue.get()[0]);
+            soft.assertThat(paramQueryValue.get()).isEqualTo("ages");
+        });
+    }
 
 }


### PR DESCRIPTION

This pull request updates the JDQL grammar and query parsing logic to support `IN` and `NOT IN` expressions with input parameters, improving flexibility for dynamic queries. It also adds tests to verify correct parsing and handling of these cases.

**JDQL grammar and parsing enhancements:**

* Updated the JDQL grammar in `JDQL.g4` to allow `IN` expressions to accept either a parenthesized list or an input parameter, enabling queries like `WHERE age IN :ages`.
* Modified `AbstractWhere.java` to handle input parameters in `IN` expressions, adding them as query values when present.

**Testing improvements:**

* Added imports for `ParamQueryValue` and `List` in `SelectJakartaDataQueryProviderInTest.java` to support new test cases. [[1]](diffhunk://#diff-3eed53be6ad8489980d61603f141de361032068c4123c91cd44bebde7bd36456R20) [[2]](diffhunk://#diff-3eed53be6ad8489980d61603f141de361032068c4123c91cd44bebde7bd36456R30)
* Introduced parameterized tests for `IN` and `NOT IN` expressions with input parameters, verifying correct parsing and value extraction in `SelectJakartaDataQueryProviderInTest.java`.