### PR TITLE
WIP: decouple CDI and add semistructured builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,6 @@ test-output/
 .settings/
 .checkstyle
 
-# Eclipse metadata
-.project
-.factorypath
-
 **/.DS_Store
 # Annotation processor metadata
 .apt_generated/
@@ -28,3 +24,77 @@ test-output/
 # Quarkus Plugin dir
 
 .quarkus/
+
+# Created by https://www.toptal.com/developers/gitignore/api/eclipse
+# Edit at https://www.toptal.com/developers/gitignore?templates=eclipse
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Eclipse metadata
+.project
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### Eclipse Patch ###
+# Spring Boot Tooling
+.sts4-cache/
+
+# End of https://www.toptal.com/developers/gitignore/api/eclipse

--- a/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/ColumnTemplateBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/ColumnTemplateBuilder.java
@@ -1,0 +1,427 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.column;
+
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.EntityPostPersist;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactoryBuilder;
+import org.eclipse.jnosql.mapping.semistructured.EventPersistManager;
+import org.eclipse.jnosql.mapping.semistructured.EventPersistManagerBuilder;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Step builder for creating {@link ColumnTemplate} instances outside a CDI container.
+ *
+ * <p>
+ * Usage example:
+ *
+ * <pre>{@code
+ * ColumnTemplate template = ColumnTemplateBuilder.builder()
+ *         .withConverters(converters)
+ *         .withEntities(entitiesMetadata)
+ *         .withManager(manager)
+ *         .build();
+ * }</pre>
+ *
+ * <p>
+ * All steps are immutable records. Each {@code withXxx()} call returns a new
+ * record with the updated value, leaving the original step unchanged.
+ * </p>
+ *
+ * <p>
+ * The {@code build()} method is available from {@link ManagerStep} onward.
+ * The two event consumers ({@link EntityPrePersist} and {@link EntityPostPersist})
+ * are optional — when not provided they default to no-op.
+ * </p>
+ *
+ * <p>
+ * <strong>Note:</strong> Instances created by this builder are not managed by
+ * any CDI container. The caller is responsible for lifecycle management.
+ * </p>
+ */
+public sealed interface ColumnTemplateBuilder permits ColumnTemplateBuilder.ConvertersStep,
+        ColumnTemplateBuilder.EntitiesStep,
+        ColumnTemplateBuilder.ManagerStep,
+        ColumnTemplateBuilder.PrePersistStep,
+        ColumnTemplateBuilder.PostPersistStep {
+
+    /**
+     * Returns a new builder starting from {@link ConvertersStep}.
+     *
+     * @return the first step of the builder
+     */
+    static ConvertersStep builder() {
+        return new ConvertersStep(null);
+    }
+
+    /**
+     * First step of the builder. Holds the {@link Converters}.
+     *
+     * @param converters the converters; may be {@code null} only in the initial step
+     *                   returned by {@link #builder()}
+     */
+    record ConvertersStep(Converters converters) implements ColumnTemplateBuilder {
+
+        /**
+         * Returns a new {@code ConvertersStep} with the given converters.
+         *
+         * @param converters the converters to use
+         * @return a new {@code ConvertersStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ConvertersStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ConvertersStep(converters);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link EntitiesMetadata}.
+         *
+         * @param entities the entities metadata
+         * @return an {@link EntitiesStep} holding both dependencies
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(converters, entities);
+        }
+    }
+
+    /**
+     * Second step of the builder. Holds {@link Converters} and {@link EntitiesMetadata}.
+     *
+     * @param converters the converters; must not be null
+     * @param entities   the entities metadata; must not be null
+     */
+    record EntitiesStep(Converters converters, EntitiesMetadata entities) implements ColumnTemplateBuilder {
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code EntitiesStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public EntitiesStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new EntitiesStep(converters, entities);
+        }
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated entities
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(converters, entities);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link DatabaseManager}.
+         *
+         * @param manager the column database manager
+         * @return a {@link ManagerStep} holding all three required dependencies
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public ManagerStep withManager(DatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+    }
+
+    /**
+     * Third step of the builder. Holds {@link Converters}, {@link EntitiesMetadata},
+     * and {@link DatabaseManager}. {@code build()} is available here using no-op
+     * consumers for both persist events.
+     *
+     * @param converters the converters; must not be null
+     * @param entities   the entities metadata; must not be null
+     * @param manager    the column database manager; must not be null
+     */
+    record ManagerStep(Converters converters, EntitiesMetadata entities,
+                       DatabaseManager manager) implements ColumnTemplateBuilder {
+
+        /**
+         * Returns a new {@code ManagerStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code ManagerStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ManagerStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+
+        /**
+         * Returns a new {@code ManagerStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code ManagerStep} with the updated entities
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public ManagerStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+
+        /**
+         * Returns a new {@code ManagerStep} with the given manager.
+         *
+         * @param manager the new column database manager
+         * @return a new {@code ManagerStep} with the updated manager
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public ManagerStep withManager(DatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+
+        /**
+         * Advances to the next step by providing a pre-persist consumer.
+         * If {@code prePersist} is {@code null}, a no-op consumer is used.
+         *
+         * @param prePersist the consumer to be invoked before entity persistence;
+         *                   {@code null} is treated as no-op
+         * @return a {@link PrePersistStep} with the given consumer
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            return new PrePersistStep(converters, entities, manager,
+                    prePersist != null ? prePersist : t -> {});
+        }
+
+        /**
+         * Builds a {@link ColumnTemplate} using no-op consumers for both persist events.
+         *
+         * @return a new {@link ColumnTemplate} instance
+         */
+        public ColumnTemplate build() {
+            Objects.requireNonNull(converters, "converters is required");
+            Objects.requireNonNull(entities, "entities is required");
+            Objects.requireNonNull(manager, "manager is required");
+            EventPersistManager eventManager = EventPersistManagerBuilder.builder().build();
+            var converterFactory = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters)
+                    .build();
+            return new ColumnTemplateProducer.ProducerColumnTemplate(converterFactory, manager,
+                    eventManager, entities, converters);
+        }
+    }
+
+    /**
+     * Fourth step of the builder. Holds all required dependencies plus the pre-persist consumer.
+     * {@code build()} is available here using a no-op post-persist consumer.
+     *
+     * @param converters the converters; must not be null
+     * @param entities   the entities metadata; must not be null
+     * @param manager    the column database manager; must not be null
+     * @param prePersist the consumer invoked before entity persistence; must not be null
+     */
+    record PrePersistStep(Converters converters, EntitiesMetadata entities,
+                          DatabaseManager manager,
+                          Consumer<EntityPrePersist> prePersist) implements ColumnTemplateBuilder {
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code PrePersistStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public PrePersistStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code PrePersistStep} with the updated entities
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public PrePersistStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given manager.
+         *
+         * @param manager the new column database manager
+         * @return a new {@code PrePersistStep} with the updated manager
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public PrePersistStep withManager(DatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given pre-persist consumer.
+         * If {@code prePersist} is {@code null}, a no-op consumer is used.
+         *
+         * @param prePersist the new pre-persist consumer; {@code null} is treated as no-op
+         * @return a new {@code PrePersistStep} with the updated consumer
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            return new PrePersistStep(converters, entities, manager,
+                    prePersist != null ? prePersist : t -> {});
+        }
+
+        /**
+         * Advances to the next step by providing a post-persist consumer.
+         * If {@code postPersist} is {@code null}, a no-op consumer is used.
+         *
+         * @param postPersist the consumer to be invoked after entity persistence;
+         *                    {@code null} is treated as no-op
+         * @return a {@link PostPersistStep} with both consumers
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            return new PostPersistStep(converters, entities, manager, prePersist,
+                    postPersist != null ? postPersist : t -> {});
+        }
+
+        /**
+         * Builds a {@link ColumnTemplate} using the current pre-persist consumer and a no-op
+         * post-persist consumer.
+         *
+         * @return a new {@link ColumnTemplate} instance
+         */
+        public ColumnTemplate build() {
+            Objects.requireNonNull(converters, "converters is required");
+            Objects.requireNonNull(entities, "entities is required");
+            Objects.requireNonNull(manager, "manager is required");
+            EventPersistManager eventManager = EventPersistManagerBuilder.builder()
+                    .withPrePersist(prePersist).build();
+            var converterFactory = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters)
+                    .build();
+            return new ColumnTemplateProducer.ProducerColumnTemplate(converterFactory, manager,
+                    eventManager, entities, converters);
+        }
+    }
+
+    /**
+     * Fifth and final step of the builder. Holds all dependencies including both
+     * persist consumers. Provides the complete {@code build()}.
+     *
+     * @param converters  the converters; must not be null
+     * @param entities    the entities metadata; must not be null
+     * @param manager     the column database manager; must not be null
+     * @param prePersist  the consumer invoked before entity persistence; must not be null
+     * @param postPersist the consumer invoked after entity persistence; must not be null
+     */
+    record PostPersistStep(Converters converters, EntitiesMetadata entities,
+                           DatabaseManager manager,
+                           Consumer<EntityPrePersist> prePersist,
+                           Consumer<EntityPostPersist> postPersist) implements ColumnTemplateBuilder {
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code PostPersistStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public PostPersistStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code PostPersistStep} with the updated entities
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public PostPersistStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given manager.
+         *
+         * @param manager the new column database manager
+         * @return a new {@code PostPersistStep} with the updated manager
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public PostPersistStep withManager(DatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given pre-persist consumer.
+         * If {@code prePersist} is {@code null}, a no-op consumer is used.
+         *
+         * @param prePersist the new pre-persist consumer; {@code null} is treated as no-op
+         * @return a new {@code PostPersistStep} with the updated consumer
+         */
+        public PostPersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            return new PostPersistStep(converters, entities, manager,
+                    prePersist != null ? prePersist : t -> {}, postPersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given post-persist consumer.
+         * If {@code postPersist} is {@code null}, a no-op consumer is used.
+         *
+         * @param postPersist the new post-persist consumer; {@code null} is treated as no-op
+         * @return a new {@code PostPersistStep} with the updated consumer
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            return new PostPersistStep(converters, entities, manager, prePersist,
+                    postPersist != null ? postPersist : t -> {});
+        }
+
+        /**
+         * Builds a {@link ColumnTemplate} using all accumulated dependencies.
+         * Internally creates an {@link EventPersistManager} from the two consumers,
+         * an {@link org.eclipse.jnosql.mapping.semistructured.EntityConverterFactory} via
+         * {@link EntityConverterFactoryBuilder}, and instantiates
+         * {@link ColumnTemplateProducer.ProducerColumnTemplate}.
+         *
+         * @return a new {@link ColumnTemplate} instance
+         */
+        public ColumnTemplate build() {
+            Objects.requireNonNull(converters, "converters is required");
+            Objects.requireNonNull(entities, "entities is required");
+            Objects.requireNonNull(manager, "manager is required");
+            EventPersistManager eventManager = EventPersistManagerBuilder.builder()
+                    .withPrePersist(prePersist)
+                    .withPostPersist(postPersist)
+                    .build();
+            var converterFactory = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters)
+                    .build();
+            return new ColumnTemplateProducer.ProducerColumnTemplate(converterFactory, manager,
+                    eventManager, entities, converters);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/ColumnTemplateBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/ColumnTemplateBuilderTest.java
@@ -1,0 +1,359 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.column;
+
+import jakarta.inject.Inject;
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+import org.eclipse.jnosql.mapping.column.entities.Person;
+import org.eclipse.jnosql.mapping.column.spi.ColumnExtension;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ColumnTemplateBuilderTest {
+
+    // -----------------------------------------------------------------------
+    // Structural / immutability tests — pure unit tests, no CDI
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    @DisplayName("Builder structure and immutability (no CDI)")
+    class StructureTests {
+
+        @Mock
+        Converters converters;
+
+        @Mock
+        Converters otherConverters;
+
+        @Mock
+        EntitiesMetadata entities;
+
+        @Mock
+        EntitiesMetadata otherEntities;
+
+        @Mock
+        DatabaseManager manager;
+
+        @Mock
+        DatabaseManager otherManager;
+
+        @Test
+        @DisplayName("builder() should return a ConvertersStep instance")
+        void shouldReturnConvertersStepFromBuilder() {
+            ColumnTemplateBuilder builder = ColumnTemplateBuilder.builder();
+            assertThat(builder).isInstanceOf(ColumnTemplateBuilder.ConvertersStep.class);
+        }
+
+        @Test
+        @DisplayName("withConverters() on ConvertersStep should return a new step without modifying the original")
+        void shouldBeImmutableOnConvertersStep() {
+            ColumnTemplateBuilder.ConvertersStep original = ColumnTemplateBuilder.builder()
+                    .withConverters(converters);
+            ColumnTemplateBuilder.ConvertersStep updated = original.withConverters(otherConverters);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.converters())
+                        .as("original step should still hold the first converters")
+                        .isSameAs(converters);
+                softly.assertThat(updated.converters())
+                        .as("updated step should hold the second converters")
+                        .isSameAs(otherConverters);
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withEntities() on ConvertersStep should advance to EntitiesStep")
+        void shouldAdvanceToEntitiesStep() {
+            ColumnTemplateBuilder next = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities);
+            assertThat(next).isInstanceOf(ColumnTemplateBuilder.EntitiesStep.class);
+        }
+
+        @Test
+        @DisplayName("withConverters() on EntitiesStep should return a new step without modifying the original")
+        void shouldBeImmutableOnEntitiesStepConverters() {
+            ColumnTemplateBuilder.EntitiesStep original = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities);
+            ColumnTemplateBuilder.EntitiesStep updated = original.withConverters(otherConverters);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.converters())
+                        .as("original step should still hold the first converters")
+                        .isSameAs(converters);
+                softly.assertThat(updated.converters())
+                        .as("updated step should hold the other converters")
+                        .isSameAs(otherConverters);
+                softly.assertThat(original.entities())
+                        .as("entities should be unchanged in both")
+                        .isSameAs(updated.entities());
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withEntities() on EntitiesStep should return a new step without modifying the original")
+        void shouldBeImmutableOnEntitiesStepEntities() {
+            ColumnTemplateBuilder.EntitiesStep original = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities);
+            ColumnTemplateBuilder.EntitiesStep updated = original.withEntities(otherEntities);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.entities())
+                        .as("original step should still hold the first entities")
+                        .isSameAs(entities);
+                softly.assertThat(updated.entities())
+                        .as("updated step should hold the other entities")
+                        .isSameAs(otherEntities);
+                softly.assertThat(original.converters())
+                        .as("converters should be unchanged in both")
+                        .isSameAs(updated.converters());
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withManager() on EntitiesStep should advance to ManagerStep")
+        void shouldAdvanceToManagerStep() {
+            ColumnTemplateBuilder next = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager);
+            assertThat(next).isInstanceOf(ColumnTemplateBuilder.ManagerStep.class);
+        }
+
+        @Test
+        @DisplayName("withManager() on ManagerStep should return a new step without modifying the original")
+        void shouldBeImmutableOnManagerStep() {
+            ColumnTemplateBuilder.ManagerStep original = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager);
+            ColumnTemplateBuilder.ManagerStep updated = original.withManager(otherManager);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.manager())
+                        .as("original step should still hold the first manager")
+                        .isSameAs(manager);
+                softly.assertThat(updated.manager())
+                        .as("updated step should hold the other manager")
+                        .isSameAs(otherManager);
+                softly.assertThat(original.converters())
+                        .as("converters should be unchanged in both")
+                        .isSameAs(updated.converters());
+                softly.assertThat(original.entities())
+                        .as("entities should be unchanged in both")
+                        .isSameAs(updated.entities());
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withPrePersist() on ManagerStep should advance to PrePersistStep")
+        void shouldAdvanceToPrePersistStep() {
+            ColumnTemplateBuilder next = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(e -> {});
+            assertThat(next).isInstanceOf(ColumnTemplateBuilder.PrePersistStep.class);
+        }
+
+        @Test
+        @DisplayName("withPostPersist() on PrePersistStep should advance to PostPersistStep")
+        void shouldAdvanceToPostPersistStep() {
+            ColumnTemplateBuilder next = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(e -> {})
+                    .withPostPersist(e -> {});
+            assertThat(next).isInstanceOf(ColumnTemplateBuilder.PostPersistStep.class);
+        }
+
+        @Test
+        @DisplayName("null pre-persist consumer on ManagerStep.withPrePersist() should silently use no-op")
+        void shouldAcceptNullPrePersistConsumerOnManagerStep() {
+            ColumnTemplateBuilder.PrePersistStep step = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(null);
+            assertThat(step).isNotNull();
+            assertThat(step.prePersist()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("null post-persist consumer on PrePersistStep.withPostPersist() should silently use no-op")
+        void shouldAcceptNullPostPersistConsumerOnPrePersistStep() {
+            ColumnTemplateBuilder.PostPersistStep step = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(e -> {})
+                    .withPostPersist(null);
+            assertThat(step).isNotNull();
+            assertThat(step.postPersist()).isNotNull();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Functional tests — uses CDI to get real EntitiesMetadata and Converters
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @EnableAutoWeld
+    @AddPackages(value = {Converters.class, EntityConverter.class})
+    @AddPackages(MockProducer.class)
+    @AddPackages(Reflections.class)
+    @AddExtensions({ReflectionEntityMetadataExtension.class, ColumnExtension.class})
+    @DisplayName("Functional tests (with real EntitiesMetadata and Converters via CDI)")
+    class FunctionalTests {
+
+        @Inject
+        EntitiesMetadata entitiesMetadata;
+
+        @Inject
+        Converters converters;
+
+        @Test
+        @DisplayName("build() after withManager() should return a non-null ColumnTemplate")
+        void shouldBuildColumnTemplate() {
+            DatabaseManager manager = mock(DatabaseManager.class);
+
+            ColumnTemplate template = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entitiesMetadata)
+                    .withManager(manager)
+                    .build();
+
+            assertThat(template).isNotNull();
+        }
+
+        @Test
+        @DisplayName("build() result should implement ColumnTemplate")
+        void shouldReturnInstanceOfColumnTemplate() {
+            DatabaseManager manager = mock(DatabaseManager.class);
+
+            Object result = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entitiesMetadata)
+                    .withManager(manager)
+                    .build();
+
+            assertThat(result).isInstanceOf(ColumnTemplate.class);
+        }
+
+        @Test
+        @DisplayName("build() without event consumers should not throw when insert is called")
+        void shouldBuildWithNoOpConsumers() {
+            DatabaseManager manager = mock(DatabaseManager.class);
+            org.eclipse.jnosql.communication.semistructured.CommunicationEntity entity =
+                    org.eclipse.jnosql.communication.semistructured.CommunicationEntity.of("Person");
+            org.mockito.Mockito.when(manager.insert(org.mockito.Mockito.any(
+                    org.eclipse.jnosql.communication.semistructured.CommunicationEntity.class))).thenReturn(entity);
+
+            ColumnTemplate template = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entitiesMetadata)
+                    .withManager(manager)
+                    .build();
+
+            Person person = Person.builder().withId(1L).withName("Ada").withAge(30).build();
+
+            org.assertj.core.api.Assertions.assertThatCode(() -> template.insert(person))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("pre-persist consumer should be invoked when an entity is inserted")
+        void shouldInvokePrePersistConsumerOnInsert() {
+            DatabaseManager manager = mock(DatabaseManager.class);
+            org.eclipse.jnosql.communication.semistructured.CommunicationEntity entity =
+                    org.eclipse.jnosql.communication.semistructured.CommunicationEntity.of("Person");
+            org.mockito.Mockito.when(manager.insert(org.mockito.Mockito.any(
+                    org.eclipse.jnosql.communication.semistructured.CommunicationEntity.class))).thenReturn(entity);
+
+            List<EntityPrePersist> captured = new ArrayList<>();
+
+            ColumnTemplate template = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entitiesMetadata)
+                    .withManager(manager)
+                    .withPrePersist(captured::add)
+                    .build();
+
+            Person person = Person.builder().withId(2L).withName("Grace").withAge(40).build();
+            template.insert(person);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(captured)
+                        .as("pre-persist consumer should have been invoked once")
+                        .hasSize(1);
+                softly.assertThat(captured.get(0).get())
+                        .as("captured entity should be the inserted person")
+                        .isSameAs(person);
+            });
+        }
+
+        @Test
+        @DisplayName("ManagerStep.build() and PostPersistStep.build() should each return a distinct ColumnTemplate")
+        void shouldReturnDistinctInstancesOnEachBuild() {
+            DatabaseManager manager = mock(DatabaseManager.class);
+
+            ColumnTemplateBuilder.ManagerStep step = ColumnTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entitiesMetadata)
+                    .withManager(manager);
+
+            ColumnTemplate first = step.build();
+            ColumnTemplate second = step.build();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(first).as("first build result should not be null").isNotNull();
+                softly.assertThat(second).as("second build result should not be null").isNotNull();
+                softly.assertThat(first).as("each build() call should return a new instance").isNotSameAs(second);
+            });
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/CDIConverterResolver.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/CDIConverterResolver.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.core;
+
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.nosql.AttributeConverter;
+import org.eclipse.jnosql.mapping.metadata.FieldParameterMetadata;
+
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+final class CDIConverterResolver implements ConverterResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(CDIConverterResolver.class.getName());
+
+    private final BeanManager beanManager;
+
+    CDIConverterResolver(BeanManager beanManager) {
+        this.beanManager = Objects.requireNonNull(beanManager, "The beanManager is required");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Optional<AttributeConverter<?, ?>> resolve(FieldParameterMetadata metadata) {
+        Objects.requireNonNull(metadata, "The metadata is required");
+        Class<?> type = metadata.converter().orElse(null);
+        if (type == null) {
+            return Optional.empty();
+        }
+
+        Iterator<Bean<?>> iterator = beanManager.getBeans(type).iterator();
+        if (!iterator.hasNext()) {
+            LOGGER.log(Level.FINE, "The converter type: {0} not found on CDI context", type);
+            return Optional.empty();
+        }
+
+        Bean<?> bean = iterator.next();
+        var context = beanManager.createCreationalContext(bean);
+        return Optional.of((AttributeConverter<?, ?>) beanManager.getReference(bean, type, context));
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/CompositeConverterResolver.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/CompositeConverterResolver.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.core;
+
+import jakarta.nosql.AttributeConverter;
+import org.eclipse.jnosql.mapping.metadata.FieldParameterMetadata;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class CompositeConverterResolver implements ConverterResolver {
+
+    private final List<ConverterResolver> resolvers;
+
+    public CompositeConverterResolver(ConverterResolver... resolvers) {
+        Objects.requireNonNull(resolvers, "The resolvers are required");
+        if (resolvers.length == 0) {
+            throw new IllegalArgumentException("The resolvers are required");
+        }
+        this.resolvers = Arrays.stream(resolvers)
+                .map(resolver -> Objects.requireNonNull(resolver, "The resolver is required"))
+                .toList();
+    }
+
+    @Override
+    public Optional<AttributeConverter<?, ?>> resolve(FieldParameterMetadata metadata) {
+        Objects.requireNonNull(metadata, "The metadata is required");
+        for (ConverterResolver resolver : resolvers) {
+            Optional<AttributeConverter<?, ?>> value = Objects.requireNonNull(resolver.resolve(metadata),
+                    "The converter resolver response is required");
+            if (value.isPresent()) {
+                return value;
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/ConverterResolver.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/ConverterResolver.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.core;
+
+import jakarta.nosql.AttributeConverter;
+import org.eclipse.jnosql.mapping.metadata.FieldParameterMetadata;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@FunctionalInterface
+public interface ConverterResolver {
+
+    Optional<AttributeConverter<?, ?>> resolve(FieldParameterMetadata metadata);
+
+    static ConverterResolver noOp() {
+        return metadata -> {
+            Objects.requireNonNull(metadata, "The metadata is required");
+            return Optional.empty();
+        };
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/Converters.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/Converters.java
@@ -16,18 +16,13 @@ package org.eclipse.jnosql.mapping.core;
 
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
 import jakarta.nosql.AttributeConverter;
 import org.eclipse.jnosql.mapping.metadata.FieldParameterMetadata;
 
-import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * The {@link jakarta.nosql.Convert} collection, this instance will generate/create an instance.
@@ -35,10 +30,31 @@ import java.util.logging.Logger;
 @ApplicationScoped
 public class Converters {
 
-    private static final Logger LOGGER = Logger.getLogger(Converters.class.getName());
+    private ConverterResolver resolver;
 
     @Inject
-    private BeanManager beanManager;
+    public Converters(BeanManager beanManager) {
+        this(new CDIConverterResolver(beanManager));
+    }
+
+    public Converters() {
+    }
+
+    private Converters(ConverterResolver resolver) {
+        this.resolver = Objects.requireNonNull(resolver, "The resolver is required");
+    }
+
+    public static Converters withResolver(ConverterResolver resolver) {
+        return new Converters(Objects.requireNonNull(resolver, "The resolver is required"));
+    }
+
+    public static Converters withResolvers(ConverterResolver... resolvers) {
+        return withResolver(new CompositeConverterResolver(resolvers));
+    }
+
+    public static Converters autoResolver() {
+        return withResolver(ConverterResolver.noOp());
+    }
 
     /**
      * Returns a converter instance where it might use scope from CDI.
@@ -55,31 +71,25 @@ public class Converters {
     }
 
 
-
     @SuppressWarnings("unchecked")
-    private <T> T getInstance(FieldParameterMetadata metadata) {
-        Class<T> type = (Class<T>) metadata.converter()
+    private <X, Y> AttributeConverter<X, Y> getInstance(FieldParameterMetadata metadata) {
+        var resolved = resolver().resolve(metadata);
+        if (resolved.isPresent()) {
+            return (AttributeConverter<X, Y>) resolved.get();
+        }
+        return (AttributeConverter<X, Y>) metadata.newConverter()
                 .orElseThrow(() -> new NoSuchElementException("There is not converter to the field: "
                         + metadata.name() + " in the Field: " + metadata.type()));
-
-        Iterator<Bean<?>> iterator = beanManager.getBeans(type).iterator();
-        if (iterator.hasNext()) {
-            Bean<T> bean = (Bean<T>) iterator.next();
-            CreationalContext<T> ctx = beanManager.createCreationalContext(bean);
-            return (T) beanManager.getReference(bean, type, ctx);
-        } else {
-            LOGGER.log(Level.FINE, "The converter type: " + type + " not found on CDI context, creating by constructor");
-            return (T) metadata.newConverter() .orElseThrow(() -> new NoSuchElementException("There is not converter to the field: "
-                    + metadata.name() + " in the Field: " + metadata.type()));
-        }
-
     }
 
+    private ConverterResolver resolver() {
+        return resolver == null ? ConverterResolver.noOp() : resolver;
+    }
 
     @Override
     public String toString() {
         return "DefaultConverters{" +
-                "beanManager=" + beanManager +
+                "resolver=" + resolver +
                 '}';
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/ConvertersTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/ConvertersTest.java
@@ -22,13 +22,16 @@ import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtensi
 import org.jboss.weld.junit5.auto.AddExtensions;
 import org.jboss.weld.junit5.auto.AddPackages;
 import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @EnableAutoWeld
 @AddPackages(value = Convert.class)
@@ -38,9 +41,11 @@ class ConvertersTest {
 
     @Inject
     private Converters converters;
+
     @Test
     void shouldReturnNPEWhenClassIsNull() {
-        Assertions.assertThrows(NullPointerException.class, () -> converters.get(null));
+        assertThatNullPointerException().isThrownBy(() -> converters.get(null))
+                .withMessage("The metadata is required");
     }
 
     @SuppressWarnings("unchecked")
@@ -56,7 +61,7 @@ class ConvertersTest {
                 .thenReturn((Optional<AttributeConverter<Object, Object>>) newInstance);
         AttributeConverter<String, String> attributeConverter = converters.get(fieldMetadata);
         Object text = attributeConverter.convertToDatabaseColumn("Text");
-        Assertions.assertNotNull(text);
+        assertThat(text).isNotNull();
     }
 
     @Test
@@ -74,13 +79,102 @@ class ConvertersTest {
 
         AttributeConverter<String, String> attributeConverter = converters.get(fieldMetadata);
         Object text = attributeConverter.convertToDatabaseColumn("Text");
-        Assertions.assertNotNull(text);
-        Assertions.assertEquals("Text", text);
+        assertThat(text).isNotNull();
+        assertThat(text).isEqualTo("Text");
     }
 
     @Test
-    void shouldGetToString(){
+    void shouldResolveUsingFactoryWithResolver() {
+        var metadata = metadata(MyConverter.class, new VetedConverter());
+        var custom = new VetedConverter();
+        var withResolver = Converters.withResolver(field -> Optional.of(custom));
+
+        var attributeConverter = withResolver.get(metadata);
+
+        assertThat(attributeConverter).isSameAs(custom);
+    }
+
+    @Test
+    void shouldResolveUsingFirstMatchWhenWithResolvers() {
+        var metadata = metadata(MyConverter.class, new VetedConverter());
+        var expected = new VetedConverter();
+        AtomicInteger secondResolverCalls = new AtomicInteger();
+        var converters = Converters.withResolvers(
+                field -> Optional.of(expected),
+                field -> {
+                    secondResolverCalls.incrementAndGet();
+                    return Optional.of(new VetedConverter());
+                });
+
+        var attributeConverter = converters.get(metadata);
+
+        assertThat(attributeConverter).isSameAs(expected);
+        assertThat(secondResolverCalls).hasValue(0);
+    }
+
+    @Test
+    void shouldFallbackToNewConverterWhenAutoResolverIsUsed() {
+        var metadata = metadata(VetedConverter.class, new VetedConverter());
+
+        var autoResolverConverters = Converters.autoResolver();
+        var attributeConverter = autoResolverConverters.get(metadata);
+
+        assertThat(attributeConverter).isInstanceOf(VetedConverter.class);
+    }
+
+    @Test
+    void shouldThrowWhenWithResolverReceivesNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> Converters.withResolver(null))
+                .withMessage("The resolver is required");
+    }
+
+    @Test
+    void shouldThrowWhenWithResolversReceivesNullArray() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> Converters.withResolvers((ConverterResolver[]) null))
+                .withMessage("The resolvers are required");
+    }
+
+    @Test
+    void shouldThrowWhenWithResolversReceivesEmptyArray() {
+        assertThatThrownBy(Converters::withResolvers)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The resolvers are required");
+    }
+
+    @Test
+    void shouldThrowWhenWithResolversContainsNullItem() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> Converters.withResolvers(ConverterResolver.noOp(), null))
+                .withMessage("The resolver is required");
+    }
+
+    @Test
+    void shouldThrowWhenResolverAndFallbackAreMissing() {
+        FieldMetadata metadata = Mockito.mock(FieldMetadata.class);
+        Mockito.when(metadata.converter()).thenReturn(Optional.empty());
+        Mockito.when(metadata.newConverter()).thenReturn(Optional.empty());
+        Mockito.when(metadata.name()).thenReturn("salary");
+        Mockito.when(metadata.type()).thenReturn((Class) String.class);
+
+        assertThatThrownBy(() -> Converters.autoResolver().get(metadata))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("There is not converter to the field: salary in the Field: class java.lang.String");
+    }
+
+    @Test
+    void shouldGetToString() {
         assertThat(this.converters.toString()).isNotNull().isNotBlank().isNotEmpty();
     }
 
+    @SuppressWarnings("unchecked")
+    private static FieldMetadata metadata(Class<?> converterType, AttributeConverter<?, ?> newConverter) {
+        FieldMetadata fieldMetadata = Mockito.mock(FieldMetadata.class);
+        Mockito.when(fieldMetadata.converter())
+                .thenReturn((Optional<Class<AttributeConverter<Object, Object>>>) Optional.of((Class<AttributeConverter<Object, Object>>) converterType));
+        Mockito.when(fieldMetadata.newConverter())
+                .thenReturn((Optional<AttributeConverter<Object, Object>>) Optional.of((AttributeConverter<Object, Object>) newConverter));
+        return fieldMetadata;
+    }
 }

--- a/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/DocumentTemplateBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/DocumentTemplateBuilder.java
@@ -1,0 +1,446 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.document;
+
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.EntityPostPersist;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactory;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactoryBuilder;
+import org.eclipse.jnosql.mapping.semistructured.EventPersistManager;
+import org.eclipse.jnosql.mapping.semistructured.EventPersistManagerBuilder;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Step builder for creating {@link DocumentTemplate} instances outside a
+ * CDI container.
+ *
+ * <p>
+ * Usage example:
+ *
+ * <pre>{@code
+ * DocumentTemplate template = DocumentTemplateBuilder.builder()
+ *         .withConverters(converters)
+ *         .withEntities(entitiesMetadata)
+ *         .withManager(databaseManager)
+ *         .withPrePersist(event -> {})
+ *         .withPostPersist(event -> {})
+ *         .build();
+ * }</pre>
+ *
+ * <p>
+ * All steps are immutable records. Each {@code withXxx()} call returns a new
+ * record with the updated value, leaving the original step unchanged.
+ * </p>
+ *
+ * <p>
+ * Required dependencies: {@link Converters}, {@link EntitiesMetadata},
+ * and {@link DatabaseManager}.
+ * Optional dependencies: event consumers for {@link EntityPrePersist}
+ * and {@link EntityPostPersist}. If not provided, no-op consumers are used.
+ * </p>
+ *
+ * <p>
+ * The {@code build()} method is available from {@link ManagerStep} onward.
+ * Once all required dependencies are provided, the builder creates
+ * an instance of {@link DocumentTemplate} internally using
+ * {@link EventPersistManager} and {@link EntityConverterFactory}.
+ * </p>
+ *
+ * <p>
+ * <strong>Note:</strong> Instances created by this builder are not managed by
+ * any CDI container. The caller is responsible for lifecycle management.
+ * </p>
+ */
+public sealed interface DocumentTemplateBuilder
+        permits DocumentTemplateBuilder.ConvertersStep,
+        DocumentTemplateBuilder.EntitiesStep,
+        DocumentTemplateBuilder.ManagerStep,
+        DocumentTemplateBuilder.PrePersistStep,
+        DocumentTemplateBuilder.PostPersistStep {
+
+    /**
+     * Returns a new builder starting from {@link ConvertersStep}.
+     * Call {@link ConvertersStep#withConverters(Converters)} to provide the
+     * required {@link Converters}.
+     *
+     * @return the first step of the builder
+     */
+    static ConvertersStep builder() {
+        return new ConvertersStep(null);
+    }
+
+    /**
+     * First step of the builder. Holds the {@link Converters}.
+     *
+     * @param converters the converters; may be {@code null} only in the
+     *                   initial step returned by {@link #builder()}
+     */
+    record ConvertersStep(Converters converters) implements DocumentTemplateBuilder {
+
+        /**
+         * Returns a new {@code ConvertersStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code ConvertersStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ConvertersStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ConvertersStep(converters);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link EntitiesMetadata}.
+         *
+         * @param entities the entities metadata to use
+         * @return an {@link EntitiesStep} holding both dependencies
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(converters, entities);
+        }
+    }
+
+    /**
+     * Second step of the builder. Holds {@link Converters} and {@link EntitiesMetadata}.
+     *
+     * @param converters the converters; must not be null
+     * @param entities   the entities metadata; must not be null
+     */
+    record EntitiesStep(Converters converters, EntitiesMetadata entities)
+            implements DocumentTemplateBuilder {
+
+        /**
+         * Returns a new {@code ConvertersStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code ConvertersStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ConvertersStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ConvertersStep(converters);
+        }
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(converters, entities);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link DatabaseManager}.
+         *
+         * @param manager the database manager to use
+         * @return a {@link ManagerStep} holding all three dependencies
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public ManagerStep withManager(DatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+    }
+
+    /**
+     * Third step of the builder. Holds {@link Converters}, {@link EntitiesMetadata},
+     * and {@link DatabaseManager}.
+     *
+     * @param converters the converters; must not be null
+     * @param entities   the entities metadata; must not be null
+     * @param manager    the database manager; must not be null
+     */
+    record ManagerStep(Converters converters, EntitiesMetadata entities, DatabaseManager manager)
+            implements DocumentTemplateBuilder {
+
+        /**
+         * Returns a new {@code ConvertersStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code ConvertersStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ConvertersStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ConvertersStep(converters);
+        }
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(converters, entities);
+        }
+
+        /**
+         * Returns a new {@code ManagerStep} with the given database manager.
+         *
+         * @param manager the new database manager
+         * @return a new {@code ManagerStep} with the updated manager
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public ManagerStep withManager(DatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+
+        /**
+         * Advances to the next step by providing an optional pre-persist consumer.
+         *
+         * @param prePersist the consumer invoked before entity persistence
+         * @return a {@link PrePersistStep} holding the pre-persist consumer
+         * @throws NullPointerException if {@code prePersist} is null
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            Objects.requireNonNull(prePersist, "prePersist is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Builds a {@link DocumentTemplate} using the accumulated dependencies
+         * with no-op event consumers.
+         *
+         * @return a new {@link DocumentTemplate} instance
+         */
+        public DocumentTemplate build() {
+            Objects.requireNonNull(converters, "converters is required");
+            Objects.requireNonNull(entities, "entities is required");
+            Objects.requireNonNull(manager, "manager is required");
+
+            EventPersistManager eventManager = EventPersistManagerBuilder.builder().build();
+            EntityConverterFactory factory = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters)
+                    .build();
+
+            return new DocumentTemplateProducer.ProducerDocumentTemplate(factory, manager, eventManager, entities,
+                    converters);
+        }
+    }
+
+    /**
+     * Fourth step of the builder. Holds all three required dependencies plus
+     * the pre-persist consumer.
+     *
+     * @param converters  the converters; must not be null
+     * @param entities    the entities metadata; must not be null
+     * @param manager     the database manager; must not be null
+     * @param prePersist  the pre-persist consumer; must not be null
+     */
+    record PrePersistStep(Converters converters, EntitiesMetadata entities, DatabaseManager manager,
+                          Consumer<EntityPrePersist> prePersist) implements DocumentTemplateBuilder {
+
+        /**
+         * Returns a new {@code ConvertersStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code ConvertersStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ConvertersStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ConvertersStep(converters);
+        }
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(converters, entities);
+        }
+
+        /**
+         * Returns a new {@code ManagerStep} with the given database manager.
+         *
+         * @param manager the new database manager
+         * @return a new {@code ManagerStep} with the updated manager
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public ManagerStep withManager(DatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given pre-persist consumer.
+         *
+         * @param prePersist the new pre-persist consumer
+         * @return a new {@code PrePersistStep} with the updated consumer
+         * @throws NullPointerException if {@code prePersist} is null
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            Objects.requireNonNull(prePersist, "prePersist is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Advances to the final step by providing the post-persist consumer.
+         *
+         * @param postPersist the consumer invoked after entity persistence
+         * @return a {@link PostPersistStep} ready to build
+         * @throws NullPointerException if {@code postPersist} is null
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            Objects.requireNonNull(postPersist, "postPersist is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Builds a {@link DocumentTemplate} with the pre-persist consumer
+         * and a no-op post-persist consumer.
+         *
+         * @return a new {@link DocumentTemplate} instance
+         */
+        public DocumentTemplate build() {
+            Objects.requireNonNull(converters, "converters is required");
+            Objects.requireNonNull(entities, "entities is required");
+            Objects.requireNonNull(manager, "manager is required");
+            Objects.requireNonNull(prePersist, "prePersist is required");
+
+            EventPersistManager eventManager = EventPersistManagerBuilder.builder()
+                    .withPrePersist(prePersist)
+                    .build();
+            EntityConverterFactory factory = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters)
+                    .build();
+
+            return new DocumentTemplateProducer.ProducerDocumentTemplate(factory, manager, eventManager, entities,
+                    converters);
+        }
+    }
+
+    /**
+     * Final step of the builder. Holds all dependencies including both
+     * pre-persist and post-persist consumers.
+     *
+     * @param converters   the converters; must not be null
+     * @param entities     the entities metadata; must not be null
+     * @param manager      the database manager; must not be null
+     * @param prePersist   the pre-persist consumer; must not be null
+     * @param postPersist  the post-persist consumer; must not be null
+     */
+    record PostPersistStep(Converters converters, EntitiesMetadata entities, DatabaseManager manager,
+                           Consumer<EntityPrePersist> prePersist, Consumer<EntityPostPersist> postPersist)
+            implements DocumentTemplateBuilder {
+
+        /**
+         * Returns a new {@code ConvertersStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code ConvertersStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ConvertersStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ConvertersStep(converters);
+        }
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(converters, entities);
+        }
+
+        /**
+         * Returns a new {@code ManagerStep} with the given database manager.
+         *
+         * @param manager the new database manager
+         * @return a new {@code ManagerStep} with the updated manager
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public ManagerStep withManager(DatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given pre-persist consumer.
+         *
+         * @param prePersist the new pre-persist consumer
+         * @return a new {@code PrePersistStep} with the updated consumer
+         * @throws NullPointerException if {@code prePersist} is null
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            Objects.requireNonNull(prePersist, "prePersist is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given post-persist consumer.
+         *
+         * @param postPersist the new post-persist consumer
+         * @return a new {@code PostPersistStep} with the updated consumer
+         * @throws NullPointerException if {@code postPersist} is null
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            Objects.requireNonNull(postPersist, "postPersist is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Builds a {@link DocumentTemplate} using all accumulated dependencies
+         * and both event consumers.
+         *
+         * @return a new {@link DocumentTemplate} instance
+         */
+        public DocumentTemplate build() {
+            Objects.requireNonNull(converters, "converters is required");
+            Objects.requireNonNull(entities, "entities is required");
+            Objects.requireNonNull(manager, "manager is required");
+            Objects.requireNonNull(prePersist, "prePersist is required");
+            Objects.requireNonNull(postPersist, "postPersist is required");
+
+            EventPersistManager eventManager = EventPersistManagerBuilder.builder()
+                    .withPrePersist(prePersist)
+                    .withPostPersist(postPersist)
+                    .build();
+            EntityConverterFactory factory = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters)
+                    .build();
+
+            return new DocumentTemplateProducer.ProducerDocumentTemplate(factory, manager, eventManager, entities,
+                    converters);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/DocumentTemplateBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/DocumentTemplateBuilderTest.java
@@ -1,0 +1,388 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.document;
+
+import jakarta.inject.Inject;
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.EntityPostPersist;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class DocumentTemplateBuilderTest {
+
+    // -----------------------------------------------------------------------
+    // Structural / immutability tests — pure unit tests, no CDI
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    @DisplayName("Builder structure and immutability (no CDI)")
+    class StructureTests {
+
+        @Mock
+        Converters converters;
+
+        @Mock
+        Converters otherConverters;
+
+        @Mock
+        EntitiesMetadata entities;
+
+        @Mock
+        EntitiesMetadata otherEntities;
+
+        @Mock
+        DatabaseManager manager;
+
+        @Mock
+        DatabaseManager otherManager;
+
+        @Test
+        @DisplayName("builder() should return a ConvertersStep instance")
+        void shouldReturnConvertersStepFromBuilder() {
+            DocumentTemplateBuilder builder = DocumentTemplateBuilder.builder();
+            assertThat(builder).isInstanceOf(DocumentTemplateBuilder.ConvertersStep.class);
+        }
+
+        @Test
+        @DisplayName("withConverters() on ConvertersStep should return a new step without modifying the original")
+        void shouldBeImmutableOnConvertersStep() {
+            DocumentTemplateBuilder.ConvertersStep original = DocumentTemplateBuilder.builder()
+                    .withConverters(converters);
+            DocumentTemplateBuilder.ConvertersStep updated = original.withConverters(otherConverters);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.converters())
+                        .as("original step should still hold the first converters")
+                        .isSameAs(converters);
+                softly.assertThat(updated.converters())
+                        .as("updated step should hold the second converters")
+                        .isSameAs(otherConverters);
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withEntities() on ConvertersStep should advance to EntitiesStep")
+        void shouldAdvanceToEntitiesStep() {
+            DocumentTemplateBuilder next = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities);
+            assertThat(next).isInstanceOf(DocumentTemplateBuilder.EntitiesStep.class);
+        }
+
+        @Test
+        @DisplayName("withConverters() on EntitiesStep should return a new ConvertersStep")
+        void shouldBeImmutableOnEntitiesStepConverters() {
+            DocumentTemplateBuilder.EntitiesStep original = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities);
+            DocumentTemplateBuilder.ConvertersStep updated = original.withConverters(otherConverters);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.converters())
+                        .as("original step should still hold the first converters")
+                        .isSameAs(converters);
+                softly.assertThat(updated.converters())
+                        .as("updated step should hold the other converters")
+                        .isSameAs(otherConverters);
+            });
+        }
+
+        @Test
+        @DisplayName("withEntities() on EntitiesStep should return a new step without modifying the original")
+        void shouldBeImmutableOnEntitiesStepEntities() {
+            DocumentTemplateBuilder.EntitiesStep original = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities);
+            DocumentTemplateBuilder.EntitiesStep updated = original.withEntities(otherEntities);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.entities())
+                        .as("original step should still hold the first entities")
+                        .isSameAs(entities);
+                softly.assertThat(updated.entities())
+                        .as("updated step should hold the other entities")
+                        .isSameAs(otherEntities);
+                softly.assertThat(original.converters())
+                        .as("converters should be unchanged in both")
+                        .isSameAs(updated.converters());
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withManager() on EntitiesStep should advance to ManagerStep")
+        void shouldAdvanceToManagerStep() {
+            DocumentTemplateBuilder next = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager);
+            assertThat(next).isInstanceOf(DocumentTemplateBuilder.ManagerStep.class);
+        }
+
+        @Test
+        @DisplayName("withManager() on ManagerStep should return a new step without modifying the original")
+        void shouldBeImmutableOnManagerStepManager() {
+            DocumentTemplateBuilder.ManagerStep original = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager);
+            DocumentTemplateBuilder.ManagerStep updated = original.withManager(otherManager);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.manager())
+                        .as("original step should still hold the first manager")
+                        .isSameAs(manager);
+                softly.assertThat(updated.manager())
+                        .as("updated step should hold the other manager")
+                        .isSameAs(otherManager);
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("build() on ManagerStep should return a non-null DocumentTemplate")
+        void shouldBuildDocumentTemplateFromManagerStep() {
+            DocumentTemplate template = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .build();
+            assertThat(template).isNotNull();
+        }
+
+        @Test
+        @DisplayName("returned DocumentTemplate should be an instance of DocumentTemplate")
+        void shouldReturnDocumentTemplateInstance() {
+            DocumentTemplate template = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .build();
+            assertThat(template).isInstanceOf(DocumentTemplate.class);
+        }
+
+        @Test
+        @DisplayName("withPrePersist() on ManagerStep should advance to PrePersistStep")
+        void shouldAdvanceToPrePersistStep() {
+            Consumer<EntityPrePersist> prePersist = e -> {};
+            DocumentTemplateBuilder next = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(prePersist);
+            assertThat(next).isInstanceOf(DocumentTemplateBuilder.PrePersistStep.class);
+        }
+
+        @Test
+        @DisplayName("withPostPersist() on PrePersistStep should advance to PostPersistStep")
+        void shouldAdvanceToPostPersistStep() {
+            Consumer<EntityPrePersist> prePersist = e -> {};
+            Consumer<EntityPostPersist> postPersist = e -> {};
+            DocumentTemplateBuilder next = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(prePersist)
+                    .withPostPersist(postPersist);
+            assertThat(next).isInstanceOf(DocumentTemplateBuilder.PostPersistStep.class);
+        }
+
+        @Test
+        @DisplayName("build() on PostPersistStep should return a non-null DocumentTemplate")
+        void shouldBuildDocumentTemplateFromPostPersistStep() {
+            Consumer<EntityPrePersist> prePersist = e -> {};
+            Consumer<EntityPostPersist> postPersist = e -> {};
+            DocumentTemplate template = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(prePersist)
+                    .withPostPersist(postPersist)
+                    .build();
+            assertThat(template).isNotNull();
+        }
+
+        @Test
+        @DisplayName("null converters should throw NullPointerException on withConverters()")
+        void shouldThrowOnNullConverters() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> DocumentTemplateBuilder.builder().withConverters(null))
+                    .withMessage("converters is required");
+        }
+
+        @Test
+        @DisplayName("null entities should throw NullPointerException on withEntities()")
+        void shouldThrowOnNullEntities() {
+            DocumentTemplateBuilder.ConvertersStep step = DocumentTemplateBuilder.builder()
+                    .withConverters(converters);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withEntities(null))
+                    .withMessage("entities is required");
+        }
+
+        @Test
+        @DisplayName("null manager should throw NullPointerException on withManager()")
+        void shouldThrowOnNullManager() {
+            DocumentTemplateBuilder.EntitiesStep step = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withManager(null))
+                    .withMessage("manager is required");
+        }
+
+        @Test
+        @DisplayName("null prePersist should throw NullPointerException on withPrePersist()")
+        void shouldThrowOnNullPrePersist() {
+            DocumentTemplateBuilder.ManagerStep step = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withPrePersist(null))
+                    .withMessage("prePersist is required");
+        }
+
+        @Test
+        @DisplayName("null postPersist should throw NullPointerException on withPostPersist()")
+        void shouldThrowOnNullPostPersist() {
+            Consumer<EntityPrePersist> prePersist = e -> {};
+            DocumentTemplateBuilder.PrePersistStep step = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(prePersist);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withPostPersist(null))
+                    .withMessage("postPersist is required");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Functional tests — uses CDI to get real dependencies
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @EnableAutoWeld
+    @AddPackages(value = {Converters.class, EntityConverter.class, DocumentTemplate.class})
+    @AddPackages(MockProducer.class)
+    @AddPackages(Reflections.class)
+    @AddExtensions({ReflectionEntityMetadataExtension.class})
+    @ExtendWith(MockitoExtension.class)
+    @DisplayName("Builder functional tests with real CDI dependencies")
+    class FunctionalTests {
+
+        @Inject
+        private Converters converters;
+
+        @Inject
+        private EntitiesMetadata entities;
+
+        @Mock
+        private DatabaseManager manager;
+
+        @Test
+        @DisplayName("should build a DocumentTemplate without pre/post persist consumers")
+        void shouldBuildWithoutEventConsumers() {
+            DocumentTemplate template = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .build();
+
+            assertThat(template).isNotNull()
+                    .isInstanceOf(DocumentTemplate.class);
+        }
+
+        @Test
+        @DisplayName("should invoke pre-persist consumer when provided")
+        void shouldInvokePrePersistConsumer() {
+            AtomicBoolean prePersistCalled = new AtomicBoolean(false);
+            Consumer<EntityPrePersist> prePersist = e -> prePersistCalled.set(true);
+
+            DocumentTemplate template = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(prePersist)
+                    .build();
+
+            assertThat(template).isNotNull();
+            // Note: We don't directly invoke the consumer here as that would require
+            // a full entity persistence scenario. This test verifies the builder
+            // accepts and holds the consumer.
+        }
+
+        @Test
+        @DisplayName("should invoke post-persist consumer when provided")
+        void shouldInvokePostPersistConsumer() {
+            AtomicBoolean postPersistCalled = new AtomicBoolean(false);
+            Consumer<EntityPostPersist> postPersist = e -> postPersistCalled.set(true);
+
+            DocumentTemplate template = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .withPrePersist(e -> {})
+                    .withPostPersist(postPersist)
+                    .build();
+
+            assertThat(template).isNotNull();
+            // Note: We don't directly invoke the consumer here as that would require
+            // a full entity persistence scenario. This test verifies the builder
+            // accepts and holds the consumer.
+        }
+
+        @Test
+        @DisplayName("should build DocumentTemplate without CDI container")
+        void shouldBuildWithoutCDI() {
+            // This test verifies that the builder can instantiate a DocumentTemplate
+            // outside of CDI, demonstrating the primary capability of this builder.
+            DocumentTemplate template = DocumentTemplateBuilder.builder()
+                    .withConverters(converters)
+                    .withEntities(entities)
+                    .withManager(manager)
+                    .build();
+
+            assertThat(template).isNotNull()
+                    .isInstanceOf(DocumentTemplate.class);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/GraphTemplateBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/GraphTemplateBuilder.java
@@ -1,0 +1,418 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.graph;
+
+import org.eclipse.jnosql.communication.graph.GraphDatabaseManager;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactory;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactoryBuilder;
+import org.eclipse.jnosql.mapping.semistructured.EventPersistManager;
+import org.eclipse.jnosql.mapping.semistructured.EventPersistManagerBuilder;
+import org.eclipse.jnosql.mapping.EntityPostPersist;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Step builder for creating {@link GraphTemplate} instances outside a CDI container.
+ *
+ * <p>
+ * Usage example:
+ * 
+ * <pre>{@code
+ * GraphTemplate template = GraphTemplateBuilder.builder()
+ *         .withConverters(converters)
+ *         .withEntities(entitiesMetadata)
+ *         .withManager(graphDatabaseManager)
+ *         .withPrePersist(prePersistConsumer)
+ *         .withPostPersist(postPersistConsumer)
+ *         .build();
+ * }</pre>
+ *
+ * <p>
+ * All steps are immutable records. Each {@code withXxx()} call returns a new
+ * record with the updated value, leaving the original step unchanged.
+ * </p>
+ *
+ * <p>
+ * The {@code build()} method is available once {@link Converters},
+ * {@link EntitiesMetadata}, and {@link GraphDatabaseManager} have been provided
+ * (from {@link ManagerStep} onward). Event consumers are optional and default to
+ * no-op implementations if not provided.
+ * </p>
+ *
+ * <p>
+ * <strong>Note:</strong> Instances created by this builder are not managed by
+ * any CDI container. The caller is responsible for lifecycle management.
+ * </p>
+ */
+public sealed interface GraphTemplateBuilder permits GraphTemplateBuilder.ConvertersStep,
+        GraphTemplateBuilder.EntitiesStep,
+        GraphTemplateBuilder.ManagerStep,
+        GraphTemplateBuilder.PrePersistStep,
+        GraphTemplateBuilder.PostPersistStep {
+
+    /**
+     * Returns a new builder starting from {@link ConvertersStep}.
+     * Call {@link ConvertersStep#withConverters(Converters)} to provide the
+     * required {@link Converters}.
+     *
+     * @return the first step of the builder
+     */
+    static ConvertersStep builder() {
+        return new ConvertersStep(null);
+    }
+
+    /**
+     * First step of the builder. Holds the {@link Converters}.
+     *
+     * @param converters the converters; may be {@code null} only in the
+     *                   initial step returned by {@link #builder()}
+     */
+    record ConvertersStep(Converters converters) implements GraphTemplateBuilder {
+
+        /**
+         * Returns a new {@code ConvertersStep} with the given converters.
+         *
+         * @param converters the converters
+         * @return a new {@code ConvertersStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ConvertersStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ConvertersStep(converters);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link EntitiesMetadata}.
+         *
+         * @param entities the entities metadata
+         * @return an {@link EntitiesStep} holding both dependencies
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(converters, entities);
+        }
+    }
+
+    /**
+     * Second step of the builder. Holds {@link Converters} and {@link EntitiesMetadata}.
+     *
+     * @param converters the converters; must not be null
+     * @param entities   the entities metadata; must not be null
+     */
+    record EntitiesStep(Converters converters, EntitiesMetadata entities) implements GraphTemplateBuilder {
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code EntitiesStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public EntitiesStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new EntitiesStep(converters, entities);
+        }
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(converters, entities);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link GraphDatabaseManager}.
+         *
+         * @param manager the graph database manager
+         * @return a {@link ManagerStep} holding all three dependencies
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public ManagerStep withManager(GraphDatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+    }
+
+    /**
+     * Third step of the builder. Holds {@link Converters}, {@link EntitiesMetadata},
+     * and {@link GraphDatabaseManager}. The {@code build()} method is available here
+     * with no-op consumers for events.
+     *
+     * @param converters the converters; must not be null
+     * @param entities   the entities metadata; must not be null
+     * @param manager    the graph database manager; must not be null
+     */
+    record ManagerStep(Converters converters, EntitiesMetadata entities, GraphDatabaseManager manager)
+            implements GraphTemplateBuilder {
+
+        /**
+         * Returns a new {@code ManagerStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code ManagerStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ManagerStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+
+        /**
+         * Returns a new {@code ManagerStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code ManagerStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public ManagerStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+
+        /**
+         * Returns a new {@code ManagerStep} with the given manager.
+         *
+         * @param manager the new graph database manager
+         * @return a new {@code ManagerStep} with the updated manager
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public ManagerStep withManager(GraphDatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converters, entities, manager);
+        }
+
+        /**
+         * Advances to the next step by providing a pre-persist event consumer.
+         *
+         * @param prePersist the consumer to invoke before entity persistence
+         * @return a {@link PrePersistStep} holding all four dependencies
+         * @throws NullPointerException if {@code prePersist} is null
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            Objects.requireNonNull(prePersist, "prePersist is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Builds a {@link GraphTemplate} using no-op consumers for both
+         * pre-persist and post-persist events.
+         *
+         * @return a new {@link GraphTemplate} instance
+         */
+        public GraphTemplate build() {
+            return new PostPersistStep(converters, entities, manager, e -> {}, e -> {}).build();
+        }
+    }
+
+    /**
+     * Fourth step of the builder. Holds all three required dependencies plus
+     * the pre-persist event consumer.
+     *
+     * @param converters  the converters; must not be null
+     * @param entities    the entities metadata; must not be null
+     * @param manager     the graph database manager; must not be null
+     * @param prePersist  the pre-persist consumer; must not be null
+     */
+    record PrePersistStep(Converters converters, EntitiesMetadata entities, GraphDatabaseManager manager,
+                          Consumer<EntityPrePersist> prePersist) implements GraphTemplateBuilder {
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code PrePersistStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public PrePersistStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code PrePersistStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public PrePersistStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given manager.
+         *
+         * @param manager the new graph database manager
+         * @return a new {@code PrePersistStep} with the updated manager
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public PrePersistStep withManager(GraphDatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given pre-persist consumer.
+         *
+         * @param prePersist the new pre-persist consumer
+         * @return a new {@code PrePersistStep} with the updated consumer
+         * @throws NullPointerException if {@code prePersist} is null
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            Objects.requireNonNull(prePersist, "prePersist is required");
+            return new PrePersistStep(converters, entities, manager, prePersist);
+        }
+
+        /**
+         * Advances to the final step by providing a post-persist event consumer.
+         * If {@code null} is provided, a no-op consumer is used.
+         *
+         * @param postPersist the consumer to invoke after entity persistence
+         * @return a {@link PostPersistStep} holding all dependencies
+         * @throws NullPointerException if {@code postPersist} is null
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            Objects.requireNonNull(postPersist, "postPersist is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Builds a {@link GraphTemplate} using a no-op consumer for the post-persist event.
+         *
+         * @return a new {@link GraphTemplate} instance
+         */
+        public GraphTemplate build() {
+            return new PostPersistStep(converters, entities, manager, prePersist, e -> {}).build();
+        }
+    }
+
+    /**
+     * Final step of the builder. Holds all dependencies including both
+     * pre-persist and post-persist event consumers.
+     *
+     * @param converters    the converters; must not be null
+     * @param entities      the entities metadata; must not be null
+     * @param manager       the graph database manager; must not be null
+     * @param prePersist    the pre-persist consumer; must not be null
+     * @param postPersist   the post-persist consumer; must not be null
+     */
+    record PostPersistStep(Converters converters, EntitiesMetadata entities, GraphDatabaseManager manager,
+                           Consumer<EntityPrePersist> prePersist, Consumer<EntityPostPersist> postPersist)
+            implements GraphTemplateBuilder {
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code PostPersistStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public PostPersistStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code PostPersistStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public PostPersistStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given manager.
+         *
+         * @param manager the new graph database manager
+         * @return a new {@code PostPersistStep} with the updated manager
+         * @throws NullPointerException if {@code manager} is null
+         */
+        public PostPersistStep withManager(GraphDatabaseManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given pre-persist consumer.
+         *
+         * @param prePersist the new pre-persist consumer
+         * @return a new {@code PostPersistStep} with the updated consumer
+         * @throws NullPointerException if {@code prePersist} is null
+         */
+        public PostPersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            Objects.requireNonNull(prePersist, "prePersist is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given post-persist consumer.
+         *
+         * @param postPersist the new post-persist consumer
+         * @return a new {@code PostPersistStep} with the updated consumer
+         * @throws NullPointerException if {@code postPersist} is null
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            Objects.requireNonNull(postPersist, "postPersist is required");
+            return new PostPersistStep(converters, entities, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Builds a complete {@link GraphTemplate} using all accumulated dependencies.
+         * Internally creates an {@link EventPersistManager} and an {@link EntityConverterFactory}
+         * without any CDI container involvement, then returns a {@link GraphTemplate}
+         * implementation.
+         *
+         * @return a new {@link GraphTemplate} instance
+         * @throws NullPointerException if any required dependency is null
+         */
+        public GraphTemplate build() {
+            Objects.requireNonNull(converters, "converters is required");
+            Objects.requireNonNull(entities, "entities is required");
+            Objects.requireNonNull(manager, "manager is required");
+            Objects.requireNonNull(prePersist, "prePersist is required");
+            Objects.requireNonNull(postPersist, "postPersist is required");
+
+            // Create EventPersistManager using the builder from semistructured
+            EventPersistManager eventManager = EventPersistManagerBuilder.builder()
+                    .withPrePersist(prePersist)
+                    .withPostPersist(postPersist)
+                    .build();
+
+            // Create EntityConverterFactory using the builder from semistructured
+            EntityConverterFactory converterFactory = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters)
+                    .build();
+
+            // Create and return the ProducerGraphTemplate (package-private class)
+            return new GraphTemplateProducer.ProducerGraphTemplate(converterFactory, manager, eventManager, entities, converters);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/GraphTemplateBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/GraphTemplateBuilderTest.java
@@ -1,0 +1,382 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.graph;
+
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.graph.GraphDatabaseManager;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.EntityPostPersist;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class GraphTemplateBuilderTest {
+
+    static class Person {
+        final String name;
+
+        Person(String name) {
+            this.name = name;
+        }
+    }
+
+    private Converters converters;
+    private EntitiesMetadata entities;
+    private GraphDatabaseManager manager;
+
+    @BeforeEach
+    void setUp() {
+        converters = Mockito.mock(Converters.class);
+        entities = Mockito.mock(EntitiesMetadata.class);
+        manager = Mockito.mock(GraphDatabaseManager.class);
+    }
+
+    // --- builder() ---
+
+    @Test
+    @DisplayName("builder() should return a ConvertersStep instance")
+    void shouldReturnConvertersStepFromBuilder() {
+        GraphTemplateBuilder builder = GraphTemplateBuilder.builder();
+        assertThat(builder).isInstanceOf(GraphTemplateBuilder.ConvertersStep.class);
+    }
+
+    // --- Step sequencing ---
+
+    @Test
+    @DisplayName("Steps should advance in order: ConvertersStep → EntitiesStep → ManagerStep")
+    void shouldAdvanceThroughStepsInOrder() {
+        var convertersStep = GraphTemplateBuilder.builder().withConverters(converters);
+        var entitiesStep = convertersStep.withEntities(entities);
+        var managerStep = entitiesStep.withManager(manager);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(convertersStep)
+                    .as("withConverters() should return ConvertersStep")
+                    .isInstanceOf(GraphTemplateBuilder.ConvertersStep.class);
+            softly.assertThat(entitiesStep)
+                    .as("withEntities() should return EntitiesStep")
+                    .isInstanceOf(GraphTemplateBuilder.EntitiesStep.class);
+            softly.assertThat(managerStep)
+                    .as("withManager() should return ManagerStep")
+                    .isInstanceOf(GraphTemplateBuilder.ManagerStep.class);
+        });
+    }
+
+    @Test
+    @DisplayName("ManagerStep.withPrePersist() should return a PrePersistStep")
+    void shouldAdvanceToPrePersistStepFromManagerStep() {
+        var managerStep = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withEntities(entities)
+                .withManager(manager);
+        var nextStep = managerStep.withPrePersist(e -> {});
+        assertThat(nextStep).isInstanceOf(GraphTemplateBuilder.PrePersistStep.class);
+    }
+
+    @Test
+    @DisplayName("PrePersistStep.withPostPersist() should return a PostPersistStep")
+    void shouldAdvanceToPostPersistStepFromPrePersistStep() {
+        var prePersistStep = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withEntities(entities)
+                .withManager(manager)
+                .withPrePersist(e -> {});
+        var nextStep = prePersistStep.withPostPersist(e -> {});
+        assertThat(nextStep).isInstanceOf(GraphTemplateBuilder.PostPersistStep.class);
+    }
+
+    // --- build() returns GraphTemplate ---
+
+    @Test
+    @DisplayName("build() from ManagerStep should return a GraphTemplate instance (no-op consumers)")
+    void shouldBuildFromManagerStep() {
+        GraphTemplate template = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withEntities(entities)
+                .withManager(manager)
+                .build();
+        assertThat(template).isNotNull().isInstanceOf(GraphTemplate.class);
+    }
+
+    @Test
+    @DisplayName("build() from PrePersistStep should return a GraphTemplate instance (no-op postPersist)")
+    void shouldBuildFromPrePersistStep() {
+        GraphTemplate template = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withEntities(entities)
+                .withManager(manager)
+                .withPrePersist(e -> {})
+                .build();
+        assertThat(template).isNotNull().isInstanceOf(GraphTemplate.class);
+    }
+
+    @Test
+    @DisplayName("build() from PostPersistStep should return a GraphTemplate instance (all consumers)")
+    void shouldBuildFromPostPersistStep() {
+        GraphTemplate template = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withEntities(entities)
+                .withManager(manager)
+                .withPrePersist(e -> {})
+                .withPostPersist(e -> {})
+                .build();
+        assertThat(template).isNotNull().isInstanceOf(GraphTemplate.class);
+    }
+
+    // --- null guards ---
+
+    @Test
+    @DisplayName("withConverters() should throw NullPointerException when null")
+    void shouldThrowWhenConvertersIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> GraphTemplateBuilder.builder().withConverters(null))
+                .withMessage("converters is required");
+    }
+
+    @Test
+    @DisplayName("withEntities() should throw NullPointerException when null")
+    void shouldThrowWhenEntitiesIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> GraphTemplateBuilder.builder()
+                        .withConverters(converters)
+                        .withEntities(null))
+                .withMessage("entities is required");
+    }
+
+    @Test
+    @DisplayName("withManager() should throw NullPointerException when null")
+    void shouldThrowWhenManagerIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> GraphTemplateBuilder.builder()
+                        .withConverters(converters)
+                        .withEntities(entities)
+                        .withManager(null))
+                .withMessage("manager is required");
+    }
+
+    @Test
+    @DisplayName("withPrePersist() should throw NullPointerException when null")
+    void shouldThrowWhenPrePersistIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> GraphTemplateBuilder.builder()
+                        .withConverters(converters)
+                        .withEntities(entities)
+                        .withManager(manager)
+                        .withPrePersist(null))
+                .withMessage("prePersist is required");
+    }
+
+    @Test
+    @DisplayName("withPostPersist() should throw NullPointerException when null")
+    void shouldThrowWhenPostPersistIsNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> GraphTemplateBuilder.builder()
+                        .withConverters(converters)
+                        .withEntities(entities)
+                        .withManager(manager)
+                        .withPrePersist(e -> {})
+                        .withPostPersist(null))
+                .withMessage("postPersist is required");
+    }
+
+    @Test
+    @DisplayName("build() should throw NullPointerException when converters is null in PostPersistStep")
+    void shouldThrowWhenConvertersIsNullInBuild() {
+        var step = new GraphTemplateBuilder.PostPersistStep(null, entities, manager, e -> {}, e -> {});
+        assertThatNullPointerException()
+                .isThrownBy(step::build)
+                .withMessage("converters is required");
+    }
+
+    @Test
+    @DisplayName("build() should throw NullPointerException when entities is null in PostPersistStep")
+    void shouldThrowWhenEntitiesIsNullInBuild() {
+        var step = new GraphTemplateBuilder.PostPersistStep(converters, null, manager, e -> {}, e -> {});
+        assertThatNullPointerException()
+                .isThrownBy(step::build)
+                .withMessage("entities is required");
+    }
+
+    @Test
+    @DisplayName("build() should throw NullPointerException when manager is null in PostPersistStep")
+    void shouldThrowWhenManagerIsNullInBuild() {
+        var step = new GraphTemplateBuilder.PostPersistStep(converters, entities, null, e -> {}, e -> {});
+        assertThatNullPointerException()
+                .isThrownBy(step::build)
+                .withMessage("manager is required");
+    }
+
+    // --- immutability ---
+
+    @Test
+    @DisplayName("ConvertersStep should be immutable: withConverters() returns new instance")
+    void shouldBeImmutableOnConvertersStep() {
+        Converters first = Mockito.mock(Converters.class);
+        Converters second = Mockito.mock(Converters.class);
+
+        GraphTemplateBuilder.ConvertersStep original = GraphTemplateBuilder.builder().withConverters(first);
+        GraphTemplateBuilder.ConvertersStep updated = original.withConverters(second);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(original.converters())
+                    .as("original should still hold first converters")
+                    .isSameAs(first);
+            softly.assertThat(updated.converters())
+                    .as("updated should hold second converters")
+                    .isSameAs(second);
+            softly.assertThat(original)
+                    .as("original and updated must be different instances")
+                    .isNotSameAs(updated);
+        });
+    }
+
+    @Test
+    @DisplayName("EntitiesStep should be immutable: withConverters() and withEntities() return new instances")
+    void shouldBeImmutableOnEntitiesStep() {
+        Converters first = Mockito.mock(Converters.class);
+        Converters second = Mockito.mock(Converters.class);
+        EntitiesMetadata firstMeta = Mockito.mock(EntitiesMetadata.class);
+        EntitiesMetadata secondMeta = Mockito.mock(EntitiesMetadata.class);
+
+        GraphTemplateBuilder.EntitiesStep original = GraphTemplateBuilder.builder()
+                .withConverters(first)
+                .withEntities(firstMeta);
+        GraphTemplateBuilder.EntitiesStep updatedConv = original.withConverters(second);
+        GraphTemplateBuilder.EntitiesStep updatedEnt = original.withEntities(secondMeta);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(original.converters())
+                    .as("original converters unchanged").isSameAs(first);
+            softly.assertThat(updatedConv.converters())
+                    .as("updated converters applied").isSameAs(second);
+            softly.assertThat(original.entities())
+                    .as("original entities unchanged").isSameAs(firstMeta);
+            softly.assertThat(updatedEnt.entities())
+                    .as("updated entities applied").isSameAs(secondMeta);
+            softly.assertThat(original).isNotSameAs(updatedConv);
+            softly.assertThat(original).isNotSameAs(updatedEnt);
+        });
+    }
+
+    @Test
+    @DisplayName("ManagerStep should be immutable: withManager() returns new instance")
+    void shouldBeImmutableOnManagerStep() {
+        GraphDatabaseManager first = Mockito.mock(GraphDatabaseManager.class);
+        GraphDatabaseManager second = Mockito.mock(GraphDatabaseManager.class);
+
+        GraphTemplateBuilder.ManagerStep original = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withEntities(entities)
+                .withManager(first);
+        GraphTemplateBuilder.ManagerStep updated = original.withManager(second);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(original.manager())
+                    .as("original should still hold first manager").isSameAs(first);
+            softly.assertThat(updated.manager())
+                    .as("updated should hold second manager").isSameAs(second);
+            softly.assertThat(original).isNotSameAs(updated);
+        });
+    }
+
+    @Test
+    @DisplayName("PrePersistStep should be immutable: withPrePersist() returns new instance")
+    void shouldBeImmutableOnPrePersistStep() {
+        Consumer<EntityPrePersist> first = e -> {};
+        Consumer<EntityPrePersist> second = e -> {};
+
+        GraphTemplateBuilder.PrePersistStep original = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withEntities(entities)
+                .withManager(manager)
+                .withPrePersist(first);
+        GraphTemplateBuilder.PrePersistStep updated = original.withPrePersist(second);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(original.prePersist())
+                    .as("original should still hold first consumer").isSameAs(first);
+            softly.assertThat(updated.prePersist())
+                    .as("updated should hold second consumer").isSameAs(second);
+            softly.assertThat(original).isNotSameAs(updated);
+        });
+    }
+
+    @Test
+    @DisplayName("PostPersistStep should be immutable: withPostPersist() returns new instance")
+    void shouldBeImmutableOnPostPersistStep() {
+        Consumer<EntityPostPersist> first = e -> {};
+        Consumer<EntityPostPersist> second = e -> {};
+
+        GraphTemplateBuilder.PostPersistStep original = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withEntities(entities)
+                .withManager(manager)
+                .withPrePersist(e -> {})
+                .withPostPersist(first);
+        GraphTemplateBuilder.PostPersistStep updated = original.withPostPersist(second);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(original.postPersist())
+                    .as("original should still hold first consumer").isSameAs(first);
+            softly.assertThat(updated.postPersist())
+                    .as("updated should hold second consumer").isSameAs(second);
+            softly.assertThat(original).isNotSameAs(updated);
+        });
+    }
+
+    // --- re-configuration within a step chain ---
+
+    @Test
+    @DisplayName("Steps should allow seamless re-configuration via withXxx() in a chain")
+    void shouldAllowSeamlessReconfiguration() {
+        Converters converters2 = Mockito.mock(Converters.class);
+        EntitiesMetadata entities2 = Mockito.mock(EntitiesMetadata.class);
+        GraphDatabaseManager manager2 = Mockito.mock(GraphDatabaseManager.class);
+
+        GraphTemplate template = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withConverters(converters2)
+                .withEntities(entities)
+                .withEntities(entities2)
+                .withManager(manager)
+                .withManager(manager2)
+                .build();
+
+        assertThat(template).isNotNull().isInstanceOf(GraphTemplate.class);
+    }
+
+    // --- no-op default consumers ---
+
+    @Test
+    @DisplayName("build() without event consumers should produce a GraphTemplate that does not throw")
+    void shouldNotThrowWhenNoEventConsumers() {
+        GraphTemplate template = GraphTemplateBuilder.builder()
+                .withConverters(converters)
+                .withEntities(entities)
+                .withManager(manager)
+                .build();
+        assertThat(template).isNotNull().isInstanceOf(GraphTemplate.class);
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/KeyValueEventPersistManager.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/KeyValueEventPersistManager.java
@@ -22,14 +22,42 @@ import org.eclipse.jnosql.communication.keyvalue.KeyValueEntity;
 import org.eclipse.jnosql.mapping.EntityPostPersist;
 import org.eclipse.jnosql.mapping.EntityPrePersist;
 
+import java.util.function.Consumer;
+
 @ApplicationScoped
 public class KeyValueEventPersistManager {
 
-    @Inject
-    private Event<EntityPrePersist> entityPrePersistEvent;
+    private final Consumer<EntityPrePersist> entityPrePersistEvent;
+
+    private final Consumer<EntityPostPersist> entityPostPersistEvent;
 
     @Inject
-    private Event<EntityPostPersist> entityPostPersistEvent;
+    KeyValueEventPersistManager(Event<EntityPrePersist> entityPrePersistEvent,
+                                Event<EntityPostPersist> entityPostPersistEvent) {
+        this.entityPrePersistEvent = entityPrePersistEvent::fire;
+        this.entityPostPersistEvent = entityPostPersistEvent::fire;
+    }
+
+    /**
+     * Package-private constructor for non-CDI usage.
+     * Accepts {@link Consumer} instances as replacements for CDI {@link Event} instances,
+     * enabling instantiation without a CDI container.
+     *
+     * @param prePersistConsumer  the consumer to invoke before persistence; must not be {@code null}
+     * @param postPersistConsumer the consumer to invoke after persistence; must not be {@code null}
+     */
+    KeyValueEventPersistManager(Consumer<EntityPrePersist> prePersistConsumer,
+                                Consumer<EntityPostPersist> postPersistConsumer) {
+        this.entityPrePersistEvent = prePersistConsumer;
+        this.entityPostPersistEvent = postPersistConsumer;
+    }
+
+    /**
+     * CDI no-arg constructor required for proxy creation.
+     */
+    KeyValueEventPersistManager() {
+        this(e -> {}, e -> {});
+    }
 
     /**
      * Fire an event once the method is called
@@ -38,7 +66,7 @@ public class KeyValueEventPersistManager {
      * @param <T>    the entity type
      */
     public <T> void firePreEntity(T entity) {
-        entityPrePersistEvent.fire(EntityPrePersist.of(entity));
+        entityPrePersistEvent.accept(EntityPrePersist.of(entity));
     }
 
     /**
@@ -49,6 +77,6 @@ public class KeyValueEventPersistManager {
      * @param <T>    the entity kind
      */
     public <T> void firePostEntity(T entity) {
-        entityPostPersistEvent.fire(EntityPostPersist.of(entity));
+        entityPostPersistEvent.accept(EntityPostPersist.of(entity));
     }
 }

--- a/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/KeyValueTemplateBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/KeyValueTemplateBuilder.java
@@ -1,0 +1,313 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.keyvalue;
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManager;
+import org.eclipse.jnosql.mapping.EntityPostPersist;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * A step builder for creating {@link KeyValueTemplate} instances without requiring a CDI container.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * KeyValueTemplate template = KeyValueTemplateBuilder.builder()
+ *     .withConverter(converter)
+ *     .withManager(bucketManager)
+ *     .build();
+ * }</pre>
+ *
+ * <p>Event consumers are optional. When not provided, no-op consumers are used.
+ * Steps are immutable — each {@code with*} method returns a new record instance.
+ *
+ * <p>The required dependencies are, in order:
+ * <ol>
+ *   <li>{@link KeyValueEntityConverter} — via {@link ConverterStep#withConverter(KeyValueEntityConverter)}</li>
+ *   <li>{@link BucketManager} — via {@link ConverterStep#withManager(BucketManager)}</li>
+ * </ol>
+ *
+ * <p>Optional event consumers:
+ * <ul>
+ *   <li>{@link Consumer}&lt;{@link EntityPrePersist}&gt; — via {@link ManagerStep#withPrePersist(Consumer)}</li>
+ *   <li>{@link Consumer}&lt;{@link EntityPostPersist}&gt; — via {@link PrePersistStep#withPostPersist(Consumer)}</li>
+ * </ul>
+ *
+ * <p>The {@link BucketManager} obtained outside a CDI container is the caller's responsibility
+ * to manage; e.g. from a Spring {@code ApplicationContext} or a direct driver instance.
+ */
+public sealed interface KeyValueTemplateBuilder
+        permits KeyValueTemplateBuilder.ConverterStep,
+                KeyValueTemplateBuilder.ManagerStep,
+                KeyValueTemplateBuilder.PrePersistStep,
+                KeyValueTemplateBuilder.PostPersistStep {
+
+    /**
+     * Returns the first step of the builder, requiring a {@link KeyValueEntityConverter}.
+     *
+     * @return the first {@link ConverterStep}
+     */
+    static ConverterStep builder() {
+        return new ConverterStep(null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 1 — ConverterStep
+    // -------------------------------------------------------------------------
+
+    /**
+     * First step of the builder. Holds the {@link KeyValueEntityConverter} and advances to
+     * {@link ManagerStep} once a {@link BucketManager} is provided.
+     *
+     * @param converter the converter; may be {@code null} at construction time but must be
+     *                  non-null before calling {@link #withManager(BucketManager)}
+     */
+    record ConverterStep(KeyValueEntityConverter converter) implements KeyValueTemplateBuilder {
+
+        /**
+         * Returns a new {@link ConverterStep} with the given converter.
+         *
+         * @param converter the converter; must not be {@code null}
+         * @return a new {@link ConverterStep}
+         * @throws NullPointerException if {@code converter} is {@code null}
+         */
+        public ConverterStep withConverter(KeyValueEntityConverter converter) {
+            Objects.requireNonNull(converter, "converter is required");
+            return new ConverterStep(converter);
+        }
+
+        /**
+         * Advances to {@link ManagerStep} with the given manager.
+         *
+         * @param manager the bucket manager; must not be {@code null}
+         * @return a new {@link ManagerStep}
+         * @throws NullPointerException if {@code converter} (held in this step) or {@code manager} is {@code null}
+         */
+        public ManagerStep withManager(BucketManager manager) {
+            Objects.requireNonNull(converter, "converter is required");
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converter, manager);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 2 — ManagerStep
+    // -------------------------------------------------------------------------
+
+    /**
+     * Second step of the builder. Holds the converter and the {@link BucketManager}.
+     * Allows adding an optional pre-persist consumer or directly building the template.
+     *
+     * @param converter the entity converter
+     * @param manager   the bucket manager
+     */
+    record ManagerStep(KeyValueEntityConverter converter,
+                       BucketManager manager) implements KeyValueTemplateBuilder {
+
+        /**
+         * Returns a new {@link ManagerStep} with a replaced converter.
+         *
+         * @param converter the converter; must not be {@code null}
+         * @return a new {@link ManagerStep}
+         */
+        public ManagerStep withConverter(KeyValueEntityConverter converter) {
+            Objects.requireNonNull(converter, "converter is required");
+            return new ManagerStep(converter, manager);
+        }
+
+        /**
+         * Returns a new {@link ManagerStep} with a replaced manager.
+         *
+         * @param manager the bucket manager; must not be {@code null}
+         * @return a new {@link ManagerStep}
+         */
+        public ManagerStep withManager(BucketManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new ManagerStep(converter, manager);
+        }
+
+        /**
+         * Advances to {@link PrePersistStep} with the given pre-persist consumer.
+         *
+         * @param prePersist the consumer invoked before persistence; {@code null} is silently replaced by a no-op
+         * @return a new {@link PrePersistStep}
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            Consumer<EntityPrePersist> consumer = prePersist != null ? prePersist : e -> {};
+            return new PrePersistStep(converter, manager, consumer);
+        }
+
+        /**
+         * Builds a {@link KeyValueTemplate} using no-op consumers for both pre- and post-persist events.
+         *
+         * @return a new {@link KeyValueTemplate}
+         */
+        public KeyValueTemplate build() {
+            Consumer<EntityPrePersist> noOpPre = e -> {};
+            Consumer<EntityPostPersist> noOpPost = e -> {};
+            KeyValueEventPersistManager eventManager =
+                    new KeyValueEventPersistManager(noOpPre, noOpPost);
+            return new KeyValueTemplateProducer.ProducerKeyValueTemplate(converter, manager, eventManager);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 3 — PrePersistStep
+    // -------------------------------------------------------------------------
+
+    /**
+     * Third step of the builder. Holds converter, manager, and a pre-persist consumer.
+     * Allows adding an optional post-persist consumer or directly building the template.
+     *
+     * @param converter   the entity converter
+     * @param manager     the bucket manager
+     * @param prePersist  the consumer invoked before persistence
+     */
+    record PrePersistStep(KeyValueEntityConverter converter,
+                          BucketManager manager,
+                          Consumer<EntityPrePersist> prePersist) implements KeyValueTemplateBuilder {
+
+        /**
+         * Returns a new {@link PrePersistStep} with a replaced converter.
+         *
+         * @param converter the converter; must not be {@code null}
+         * @return a new {@link PrePersistStep}
+         */
+        public PrePersistStep withConverter(KeyValueEntityConverter converter) {
+            Objects.requireNonNull(converter, "converter is required");
+            return new PrePersistStep(converter, manager, prePersist);
+        }
+
+        /**
+         * Returns a new {@link PrePersistStep} with a replaced manager.
+         *
+         * @param manager the bucket manager; must not be {@code null}
+         * @return a new {@link PrePersistStep}
+         */
+        public PrePersistStep withManager(BucketManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new PrePersistStep(converter, manager, prePersist);
+        }
+
+        /**
+         * Returns a new {@link PrePersistStep} with a replaced pre-persist consumer.
+         *
+         * @param prePersist the consumer; {@code null} is silently replaced by a no-op
+         * @return a new {@link PrePersistStep}
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            Consumer<EntityPrePersist> consumer = prePersist != null ? prePersist : e -> {};
+            return new PrePersistStep(converter, manager, consumer);
+        }
+
+        /**
+         * Advances to {@link PostPersistStep} with the given post-persist consumer.
+         *
+         * @param postPersist the consumer invoked after persistence; {@code null} is silently replaced by a no-op
+         * @return a new {@link PostPersistStep}
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            Consumer<EntityPostPersist> consumer = postPersist != null ? postPersist : e -> {};
+            return new PostPersistStep(converter, manager, prePersist, consumer);
+        }
+
+        /**
+         * Builds a {@link KeyValueTemplate} using the provided pre-persist consumer and a no-op post-persist consumer.
+         *
+         * @return a new {@link KeyValueTemplate}
+         */
+        public KeyValueTemplate build() {
+            Consumer<EntityPostPersist> noOpPost = e -> {};
+            KeyValueEventPersistManager eventManager =
+                    new KeyValueEventPersistManager(prePersist, noOpPost);
+            return new KeyValueTemplateProducer.ProducerKeyValueTemplate(converter, manager, eventManager);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 4 — PostPersistStep
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fourth (final) step of the builder. Holds all required and optional fields.
+     *
+     * @param converter   the entity converter
+     * @param manager     the bucket manager
+     * @param prePersist  the consumer invoked before persistence
+     * @param postPersist the consumer invoked after persistence
+     */
+    record PostPersistStep(KeyValueEntityConverter converter,
+                           BucketManager manager,
+                           Consumer<EntityPrePersist> prePersist,
+                           Consumer<EntityPostPersist> postPersist) implements KeyValueTemplateBuilder {
+
+        /**
+         * Returns a new {@link PostPersistStep} with a replaced converter.
+         *
+         * @param converter the converter; must not be {@code null}
+         * @return a new {@link PostPersistStep}
+         */
+        public PostPersistStep withConverter(KeyValueEntityConverter converter) {
+            Objects.requireNonNull(converter, "converter is required");
+            return new PostPersistStep(converter, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Returns a new {@link PostPersistStep} with a replaced manager.
+         *
+         * @param manager the bucket manager; must not be {@code null}
+         * @return a new {@link PostPersistStep}
+         */
+        public PostPersistStep withManager(BucketManager manager) {
+            Objects.requireNonNull(manager, "manager is required");
+            return new PostPersistStep(converter, manager, prePersist, postPersist);
+        }
+
+        /**
+         * Returns a new {@link PostPersistStep} with a replaced pre-persist consumer.
+         *
+         * @param prePersist the consumer; {@code null} is silently replaced by a no-op
+         * @return a new {@link PostPersistStep}
+         */
+        public PostPersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            Consumer<EntityPrePersist> consumer = prePersist != null ? prePersist : e -> {};
+            return new PostPersistStep(converter, manager, consumer, postPersist);
+        }
+
+        /**
+         * Returns a new {@link PostPersistStep} with a replaced post-persist consumer.
+         *
+         * @param postPersist the consumer; {@code null} is silently replaced by a no-op
+         * @return a new {@link PostPersistStep}
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            Consumer<EntityPostPersist> consumer = postPersist != null ? postPersist : e -> {};
+            return new PostPersistStep(converter, manager, prePersist, consumer);
+        }
+
+        /**
+         * Builds a {@link KeyValueTemplate} using all provided consumers.
+         *
+         * @return a new {@link KeyValueTemplate}
+         */
+        public KeyValueTemplate build() {
+            KeyValueEventPersistManager eventManager =
+                    new KeyValueEventPersistManager(prePersist, postPersist);
+            return new KeyValueTemplateProducer.ProducerKeyValueTemplate(converter, manager, eventManager);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/KeyValueEventPersistManagerTest.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/KeyValueEventPersistManagerTest.java
@@ -11,19 +11,25 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.mapping.keyvalue;
 
-import jakarta.enterprise.event.Event;
 import org.eclipse.jnosql.mapping.EntityPostPersist;
 import org.eclipse.jnosql.mapping.EntityPrePersist;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 
@@ -31,16 +37,18 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class KeyValueEventPersistManagerTest {
 
-    @InjectMocks
     private KeyValueEventPersistManager subject;
 
+    @Mock
+    private Consumer<EntityPrePersist> entityPrePersistEvent;
 
     @Mock
-    private Event<EntityPrePersist> entityPrePersistEvent;
+    private Consumer<EntityPostPersist> entityPostPersistEvent;
 
-    @Mock
-    private Event<EntityPostPersist> entityPostPersistEvent;
-
+    @BeforeEach
+    void setUp() {
+        subject = new KeyValueEventPersistManager(entityPrePersistEvent, entityPostPersistEvent);
+    }
 
     @Test
     void shouldFirePreEntity() {
@@ -48,7 +56,7 @@ class KeyValueEventPersistManagerTest {
         actor.name = "Luke";
         subject.firePreEntity(actor);
         ArgumentCaptor<EntityPrePersist> captor = ArgumentCaptor.forClass(EntityPrePersist.class);
-        verify(entityPrePersistEvent).fire(captor.capture());
+        verify(entityPrePersistEvent).accept(captor.capture());
         EntityPrePersist value = captor.getValue();
         assertEquals(actor, value.get());
     }
@@ -59,9 +67,137 @@ class KeyValueEventPersistManagerTest {
         actor.name = "Luke";
         subject.firePostEntity(actor);
         ArgumentCaptor<EntityPostPersist> captor = ArgumentCaptor.forClass(EntityPostPersist.class);
-        verify(entityPostPersistEvent).fire(captor.capture());
+        verify(entityPostPersistEvent).accept(captor.capture());
         EntityPostPersist value = captor.getValue();
         assertEquals(actor, value.get());
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for the package-private Consumer-based constructor (non-CDI path)
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("Package-private constructor with Consumer delegates")
+    class ConsumerConstructorTests {
+
+        @Test
+        @DisplayName("Should firePreEntity invoke the pre-persist consumer with the correct entity")
+        void shouldFirePreEntityInvokeConsumer() {
+            Actor actor = new Actor();
+            actor.name = "Leia";
+
+            AtomicReference<EntityPrePersist> captured = new AtomicReference<>();
+            Consumer<EntityPrePersist> prePersistConsumer = captured::set;
+            Consumer<EntityPostPersist> noOp = e -> {};
+
+            KeyValueEventPersistManager manager =
+                    new KeyValueEventPersistManager(prePersistConsumer, noOp);
+
+            manager.firePreEntity(actor);
+
+            assertSoftly(softly -> {
+                softly.assertThat(captured.get())
+                        .as("pre-persist event was captured")
+                        .isNotNull();
+                softly.assertThat(captured.get().get())
+                        .as("event holds the original entity")
+                        .isSameAs(actor);
+            });
+        }
+
+        @Test
+        @DisplayName("Should firePostEntity invoke the post-persist consumer with the correct entity")
+        void shouldFirePostEntityInvokeConsumer() {
+            Actor actor = new Actor();
+            actor.name = "Han";
+
+            Consumer<EntityPrePersist> noOp = e -> {};
+            AtomicReference<EntityPostPersist> captured = new AtomicReference<>();
+            Consumer<EntityPostPersist> postPersistConsumer = captured::set;
+
+            KeyValueEventPersistManager manager =
+                    new KeyValueEventPersistManager(noOp, postPersistConsumer);
+
+            manager.firePostEntity(actor);
+
+            assertSoftly(softly -> {
+                softly.assertThat(captured.get())
+                        .as("post-persist event was captured")
+                        .isNotNull();
+                softly.assertThat(captured.get().get())
+                        .as("event holds the original entity")
+                        .isSameAs(actor);
+            });
+        }
+
+        @Test
+        @DisplayName("Should firePreEntity invoke pre-persist consumer and not post-persist consumer")
+        void shouldFirePreEntityInvokeOnlyPreConsumer() {
+            Actor actor = new Actor();
+            actor.name = "Yoda";
+
+            AtomicReference<EntityPrePersist> preCaptured = new AtomicReference<>();
+            AtomicReference<EntityPostPersist> postCaptured = new AtomicReference<>();
+
+            KeyValueEventPersistManager manager = new KeyValueEventPersistManager(
+                    preCaptured::set,
+                    postCaptured::set
+            );
+
+            manager.firePreEntity(actor);
+
+            assertSoftly(softly -> {
+                softly.assertThat(preCaptured.get()).as("pre-persist consumer was invoked").isNotNull();
+                softly.assertThat(postCaptured.get()).as("post-persist consumer was NOT invoked").isNull();
+            });
+        }
+
+        @Test
+        @DisplayName("Should firePostEntity invoke post-persist consumer and not pre-persist consumer")
+        void shouldFirePostEntityInvokeOnlyPostConsumer() {
+            Actor actor = new Actor();
+            actor.name = "Obi-Wan";
+
+            AtomicReference<EntityPrePersist> preCaptured = new AtomicReference<>();
+            AtomicReference<EntityPostPersist> postCaptured = new AtomicReference<>();
+
+            KeyValueEventPersistManager manager = new KeyValueEventPersistManager(
+                    preCaptured::set,
+                    postCaptured::set
+            );
+
+            manager.firePostEntity(actor);
+
+            assertSoftly(softly -> {
+                softly.assertThat(preCaptured.get()).as("pre-persist consumer was NOT invoked").isNull();
+                softly.assertThat(postCaptured.get()).as("post-persist consumer was invoked").isNotNull();
+            });
+        }
+
+        @Test
+        @DisplayName("Should both consumers be invokable independently in sequence")
+        void shouldBothConsumersBeInvokableInSequence() {
+            Actor actor = new Actor();
+            actor.name = "R2-D2";
+
+            AtomicReference<EntityPrePersist> preCaptured = new AtomicReference<>();
+            AtomicReference<EntityPostPersist> postCaptured = new AtomicReference<>();
+
+            KeyValueEventPersistManager manager = new KeyValueEventPersistManager(
+                    preCaptured::set,
+                    postCaptured::set
+            );
+
+            manager.firePreEntity(actor);
+            manager.firePostEntity(actor);
+
+            assertSoftly(softly -> {
+                softly.assertThat(preCaptured.get()).as("pre-persist event captured").isNotNull();
+                softly.assertThat(preCaptured.get().get()).as("pre-persist entity matches").isSameAs(actor);
+                softly.assertThat(postCaptured.get()).as("post-persist event captured").isNotNull();
+                softly.assertThat(postCaptured.get().get()).as("post-persist entity matches").isSameAs(actor);
+            });
+        }
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/KeyValueTemplateBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/KeyValueTemplateBuilderTest.java
@@ -1,0 +1,340 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.keyvalue;
+
+import org.eclipse.jnosql.communication.keyvalue.BucketManager;
+import org.eclipse.jnosql.mapping.EntityPostPersist;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class KeyValueTemplateBuilderTest {
+
+    // ----------------------------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------------------------
+
+    private KeyValueEntityConverter mockConverter() {
+        return Mockito.mock(KeyValueEntityConverter.class);
+    }
+
+    private BucketManager mockManager() {
+        return Mockito.mock(BucketManager.class);
+    }
+
+    // ----------------------------------------------------------------------------------
+    // builder() static method
+    // ----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Should return ConverterStep from builder()")
+    void shouldReturnConverterStepFromBuilder() {
+        KeyValueTemplateBuilder step = KeyValueTemplateBuilder.builder();
+        assertThat(step).isInstanceOf(KeyValueTemplateBuilder.ConverterStep.class);
+    }
+
+    // ----------------------------------------------------------------------------------
+    // ConverterStep
+    // ----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Should withConverter return new ConverterStep")
+    void shouldWithConverterReturnConverterStep() {
+        KeyValueEntityConverter converter = mockConverter();
+        KeyValueTemplateBuilder.ConverterStep step = KeyValueTemplateBuilder.builder()
+                .withConverter(converter);
+        assertThat(step).isInstanceOf(KeyValueTemplateBuilder.ConverterStep.class);
+        assertThat(step.converter()).isSameAs(converter);
+    }
+
+    @Test
+    @DisplayName("Should withConverter throw NullPointerException when converter is null")
+    void shouldWithConverterThrowNullPointerExceptionWhenNull() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> KeyValueTemplateBuilder.builder().withConverter(null))
+                .withMessageContaining("converter");
+    }
+
+    @Test
+    @DisplayName("Should withManager return ManagerStep")
+    void shouldWithManagerReturnManagerStep() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+        KeyValueTemplateBuilder.ManagerStep step = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager);
+
+        assertSoftly(softly -> {
+            softly.assertThat(step).as("step is ManagerStep").isInstanceOf(KeyValueTemplateBuilder.ManagerStep.class);
+            softly.assertThat(step.converter()).as("converter is preserved").isSameAs(converter);
+            softly.assertThat(step.manager()).as("manager is preserved").isSameAs(manager);
+        });
+    }
+
+    @Test
+    @DisplayName("Should withManager throw NullPointerException when manager is null")
+    void shouldWithManagerThrowNullPointerExceptionWhenNull() {
+        KeyValueEntityConverter converter = mockConverter();
+        assertThatNullPointerException()
+                .isThrownBy(() -> KeyValueTemplateBuilder.builder()
+                        .withConverter(converter)
+                        .withManager(null))
+                .withMessageContaining("manager");
+    }
+
+    // ----------------------------------------------------------------------------------
+    // ManagerStep — build()
+    // ----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Should build from ManagerStep return KeyValueTemplate")
+    void shouldBuildFromManagerStepReturnKeyValueTemplate() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+
+        KeyValueTemplate template = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager)
+                .build();
+
+        assertThat(template).as("instance implements KeyValueTemplate").isInstanceOf(KeyValueTemplate.class);
+    }
+
+    @Test
+    @DisplayName("Should build from ManagerStep use no-op consumers by default")
+    void shouldBuildFromManagerStepUseNoOpConsumersByDefault() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+
+        // Must not throw even without CDI – consumers are no-ops
+        KeyValueTemplate template = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager)
+                .build();
+
+        assertThat(template).isNotNull();
+    }
+
+    // ----------------------------------------------------------------------------------
+    // ManagerStep — re-configuration
+    // ----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Should ManagerStep.withConverter return new step without affecting original")
+    void shouldManagerStepWithConverterBeImmutable() {
+        KeyValueEntityConverter converter1 = mockConverter();
+        KeyValueEntityConverter converter2 = mockConverter();
+        BucketManager manager = mockManager();
+
+        KeyValueTemplateBuilder.ManagerStep original = KeyValueTemplateBuilder.builder()
+                .withConverter(converter1)
+                .withManager(manager);
+
+        KeyValueTemplateBuilder.ManagerStep reconfigured = original.withConverter(converter2);
+
+        assertSoftly(softly -> {
+            softly.assertThat(original.converter()).as("original converter unchanged").isSameAs(converter1);
+            softly.assertThat(reconfigured.converter()).as("reconfigured has new converter").isSameAs(converter2);
+            softly.assertThat(reconfigured.manager()).as("manager is preserved").isSameAs(manager);
+        });
+    }
+
+    @Test
+    @DisplayName("Should ManagerStep.withManager return new step without affecting original")
+    void shouldManagerStepWithManagerBeImmutable() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager1 = mockManager();
+        BucketManager manager2 = mockManager();
+
+        KeyValueTemplateBuilder.ManagerStep original = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager1);
+
+        KeyValueTemplateBuilder.ManagerStep reconfigured = original.withManager(manager2);
+
+        assertSoftly(softly -> {
+            softly.assertThat(original.manager()).as("original manager unchanged").isSameAs(manager1);
+            softly.assertThat(reconfigured.manager()).as("reconfigured has new manager").isSameAs(manager2);
+        });
+    }
+
+    // ----------------------------------------------------------------------------------
+    // PrePersistStep
+    // ----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Should withPrePersist return PrePersistStep")
+    void shouldWithPrePersistReturnPrePersistStep() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+        Consumer<EntityPrePersist> consumer = e -> {};
+
+        KeyValueTemplateBuilder.PrePersistStep step = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager)
+                .withPrePersist(consumer);
+
+        assertSoftly(softly -> {
+            softly.assertThat(step).as("step is PrePersistStep").isInstanceOf(KeyValueTemplateBuilder.PrePersistStep.class);
+            softly.assertThat(step.prePersist()).as("consumer is preserved").isSameAs(consumer);
+        });
+    }
+
+    @Test
+    @DisplayName("Should withPrePersist replace null consumer with no-op silently")
+    void shouldWithPrePersistReplaceNullWithNoOp() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+
+        KeyValueTemplateBuilder.PrePersistStep step = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager)
+                .withPrePersist(null);
+
+        assertThat(step.prePersist()).as("consumer is not null (no-op)").isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should build from PrePersistStep invoke pre-persist consumer on put")
+    void shouldPrePersistConsumerBeInvoked() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+
+        AtomicReference<EntityPrePersist> captured = new AtomicReference<>();
+        Consumer<EntityPrePersist> prePersistConsumer = captured::set;
+
+        // We just need to verify the consumer is wired in; invoking firePreEntity directly
+        // on the event manager (which is package-private) is exercised via the manager test.
+        // Here we verify that the template is built without error with the consumer wired in.
+        KeyValueTemplate template = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager)
+                .withPrePersist(prePersistConsumer)
+                .build();
+
+        assertThat(template).isNotNull();
+    }
+
+    // ----------------------------------------------------------------------------------
+    // PostPersistStep
+    // ----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Should withPostPersist return PostPersistStep")
+    void shouldWithPostPersistReturnPostPersistStep() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+        Consumer<EntityPrePersist> prePersist = e -> {};
+        Consumer<EntityPostPersist> postPersist = e -> {};
+
+        KeyValueTemplateBuilder.PostPersistStep step = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager)
+                .withPrePersist(prePersist)
+                .withPostPersist(postPersist);
+
+        assertSoftly(softly -> {
+            softly.assertThat(step).as("step is PostPersistStep").isInstanceOf(KeyValueTemplateBuilder.PostPersistStep.class);
+            softly.assertThat(step.prePersist()).as("pre-persist consumer preserved").isSameAs(prePersist);
+            softly.assertThat(step.postPersist()).as("post-persist consumer preserved").isSameAs(postPersist);
+        });
+    }
+
+    @Test
+    @DisplayName("Should withPostPersist replace null consumer with no-op silently")
+    void shouldWithPostPersistReplaceNullWithNoOp() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+
+        KeyValueTemplateBuilder.PostPersistStep step = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager)
+                .withPrePersist(e -> {})
+                .withPostPersist(null);
+
+        assertThat(step.postPersist()).as("post-persist consumer is not null (no-op)").isNotNull();
+    }
+
+    @Test
+    @DisplayName("Should build from PostPersistStep return KeyValueTemplate")
+    void shouldBuildFromPostPersistStepReturnKeyValueTemplate() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+
+        KeyValueTemplate template = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager)
+                .withPrePersist(e -> {})
+                .withPostPersist(e -> {})
+                .build();
+
+        assertThat(template).as("result implements KeyValueTemplate").isInstanceOf(KeyValueTemplate.class);
+    }
+
+    // ----------------------------------------------------------------------------------
+    // Immutability of PostPersistStep
+    // ----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Should PostPersistStep.withManager return new step without affecting original")
+    void shouldPostPersistStepWithManagerBeImmutable() {
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager1 = mockManager();
+        BucketManager manager2 = mockManager();
+
+        KeyValueTemplateBuilder.PostPersistStep original = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager1)
+                .withPrePersist(e -> {})
+                .withPostPersist(e -> {});
+
+        KeyValueTemplateBuilder.PostPersistStep reconfigured = original.withManager(manager2);
+
+        assertSoftly(softly -> {
+            softly.assertThat(original.manager()).as("original manager unchanged").isSameAs(manager1);
+            softly.assertThat(reconfigured.manager()).as("reconfigured has new manager").isSameAs(manager2);
+        });
+    }
+
+    // ----------------------------------------------------------------------------------
+    // No CDI — purely unit-level instantiation check
+    // ----------------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Should instantiate KeyValueTemplate without CDI container")
+    void shouldInstantiateWithoutCDI() {
+        // This test deliberately avoids any CDI/Weld infrastructure.
+        KeyValueEntityConverter converter = mockConverter();
+        BucketManager manager = mockManager();
+
+        KeyValueTemplate template = KeyValueTemplateBuilder.builder()
+                .withConverter(converter)
+                .withManager(manager)
+                .build();
+
+        assertThat(template)
+                .as("should be non-null KeyValueTemplate without CDI")
+                .isNotNull()
+                .isInstanceOf(KeyValueTemplate.class);
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultEntitiesMetadata.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.mapping.reflection;
 
@@ -70,6 +71,12 @@ class DefaultEntitiesMetadata implements EntitiesMetadata {
         this.converter = new ReflectionClassConverter();
         this.projections = new ConcurrentHashMap<>();
         this.findByMappingName = new ConcurrentHashMap<>();
+    }
+
+    DefaultEntitiesMetadata(GroupEntityMetadata extension) {
+        this();
+        this.extension = Objects.requireNonNull(extension, "extension is required");
+        this.init();
     }
 
     @PostConstruct

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/ReflectionEntitiesMetadataBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/ReflectionEntitiesMetadataBuilder.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.reflection;
+
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.metadata.GroupEntityMetadata;
+
+import java.util.Objects;
+
+/**
+ * Step builder for creating {@link EntitiesMetadata} instances using reflection-based discovery.
+ *
+ * <p>Usage example:</p>
+ * <pre>{@code
+ * GroupEntityMetadata group = ReflectionGroupEntityMetadataBuilder.builder()
+ *         .withScanner(scanner)
+ *         .withConverter(converter)
+ *         .build();
+ *
+ * EntitiesMetadata entities = ReflectionEntitiesMetadataBuilder.builder()
+ *         .withGroup(group)
+ *         .build();
+ * }</pre>
+ */
+public sealed interface ReflectionEntitiesMetadataBuilder permits ReflectionEntitiesMetadataBuilder.GroupStep {
+
+    /**
+     * Returns a new builder starting from {@link GroupStep}.
+     *
+     * @return the first step of the builder
+     */
+    static GroupStep builder() {
+        return new GroupStep(null);
+    }
+
+    /**
+     * Step of the builder that holds the {@link GroupEntityMetadata}.
+     */
+    record GroupStep(GroupEntityMetadata group) implements ReflectionEntitiesMetadataBuilder {
+
+        /**
+         * Returns a new {@code GroupStep} with the given group metadata.
+         *
+         * @param group the group entity metadata
+         * @return a new {@code GroupStep}
+         * @throws NullPointerException if {@code group} is null
+         */
+        public GroupStep withGroup(GroupEntityMetadata group) {
+            Objects.requireNonNull(group, "group is required");
+            return new GroupStep(group);
+        }
+
+        /**
+         * Builds an {@link EntitiesMetadata} instance using the provided group metadata.
+         *
+         * @return a new {@link EntitiesMetadata} instance
+         * @throws NullPointerException if {@code group} is null
+         */
+        public EntitiesMetadata build() {
+            Objects.requireNonNull(group, "group is required");
+            return new DefaultEntitiesMetadata(group);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/ReflectionGroupEntityMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/ReflectionGroupEntityMetadata.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.reflection;
+
+import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.GroupEntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.ProjectionMetadata;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A static, immutable implementation of {@link GroupEntityMetadata}.
+ * It holds the maps of {@link EntityMetadata} and {@link ProjectionMetadata} discovered during the scanning phase.
+ */
+record ReflectionGroupEntityMetadata(Map<String, EntityMetadata> mappings,
+                                    Map<Class<?>, EntityMetadata> classes,
+                                    Map<Class<?>, ProjectionMetadata> projections)
+        implements GroupEntityMetadata {
+
+    ReflectionGroupEntityMetadata {
+        Objects.requireNonNull(mappings, "mappings is required");
+        Objects.requireNonNull(classes, "classes is required");
+        Objects.requireNonNull(projections, "projections is required");
+        mappings = Collections.unmodifiableMap(mappings);
+        classes = Collections.unmodifiableMap(classes);
+        projections = Collections.unmodifiableMap(projections);
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/ReflectionGroupEntityMetadataBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/ReflectionGroupEntityMetadataBuilder.java
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.reflection;
+
+import org.eclipse.jnosql.mapping.metadata.ClassConverter;
+import org.eclipse.jnosql.mapping.metadata.ClassScanner;
+import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.GroupEntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.ProjectionMetadata;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.logging.Logger;
+
+/**
+ * Step builder for creating {@link GroupEntityMetadata} instances outside a CDI container
+ * using reflection-based scanning.
+ *
+ * <p>Usage example:</p>
+ * <pre>{@code
+ * GroupEntityMetadata metadata = ReflectionGroupEntityMetadataBuilder.builder()
+ *         .withScanner(ClassScanner.load())
+ *         .withConverter(ClassConverter.load())
+ *         .build();
+ * }</pre>
+ */
+public sealed interface ReflectionGroupEntityMetadataBuilder permits ReflectionGroupEntityMetadataBuilder.ScannerStep,
+        ReflectionGroupEntityMetadataBuilder.ConverterStep {
+
+    /**
+     * Returns a new builder starting from {@link ScannerStep}.
+     *
+     * @return the first step of the builder
+     */
+    static ScannerStep builder() {
+        return new ScannerStep(null);
+    }
+
+    /**
+     * First step of the builder. Holds the {@link ClassScanner}.
+     */
+    record ScannerStep(ClassScanner scanner) implements ReflectionGroupEntityMetadataBuilder {
+
+        /**
+         * Returns a new {@code ScannerStep} with the given scanner.
+         *
+         * @param scanner the class scanner
+         * @return a new {@code ScannerStep}
+         * @throws NullPointerException if {@code scanner} is null
+         */
+        public ScannerStep withScanner(ClassScanner scanner) {
+            Objects.requireNonNull(scanner, "scanner is required");
+            return new ScannerStep(scanner);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link ClassConverter}.
+         *
+         * @param converter the class converter
+         * @return a {@link ConverterStep}
+         * @throws NullPointerException if {@code converter} is null
+         */
+        public ConverterStep withConverter(ClassConverter converter) {
+            Objects.requireNonNull(converter, "converter is required");
+            return new ConverterStep(scanner, converter);
+        }
+    }
+
+    /**
+     * Second step of the builder. Holds both {@link ClassScanner} and {@link ClassConverter}
+     * and provides {@code build()}.
+     */
+    record ConverterStep(ClassScanner scanner, ClassConverter converter) implements ReflectionGroupEntityMetadataBuilder {
+
+        private static final Logger LOGGER = Logger.getLogger(ReflectionGroupEntityMetadataBuilder.class.getName());
+
+        /**
+         * Builds a {@link GroupEntityMetadata} by performing a reflection-based scan.
+         *
+         * @return a new {@link GroupEntityMetadata} instance
+         */
+        public GroupEntityMetadata build() {
+            Objects.requireNonNull(scanner, "scanner is required");
+            Objects.requireNonNull(converter, "converter is required");
+
+            LOGGER.fine("Starting the scanning process for Entity and Embeddable annotations (manual): ");
+
+            Map<Class<?>, EntityMetadata> entityMetadataByClass = new HashMap<>();
+            Map<String, EntityMetadata> entityMetadataByEntityName = new HashMap<>();
+            Map<Class<?>, ProjectionMetadata> projectorMetadataByClass = new HashMap<>();
+            Function<Class<?>, ProjectionMetadata> projectionConverter = new ProjectionConverter();
+
+            scanner.entities().forEach(entity -> {
+                EntityMetadata entityMetadata = converter.apply(entity);
+                if (entityMetadata.hasEntityName()) {
+                    entityMetadataByEntityName.put(entityMetadata.name(), entityMetadata);
+                }
+                entityMetadataByClass.put(entity, entityMetadata);
+            });
+
+            scanner.embeddables().forEach(embeddable -> {
+                EntityMetadata entityMetadata = converter.apply(embeddable);
+                entityMetadataByClass.put(embeddable, entityMetadata);
+            });
+
+            scanner.projections().forEach(projection -> {
+                ProjectionMetadata projectionMetadata = projectionConverter.apply(projection);
+                projectorMetadataByClass.put(projection, projectionMetadata);
+            });
+
+            LOGGER.fine(() -> "Finishing the scanning with: %d Entity and Embeddable scanned classes and %d Named entities"
+                    .formatted(entityMetadataByClass.size(), entityMetadataByEntityName.size()));
+
+            return new ReflectionGroupEntityMetadata(entityMetadataByEntityName, entityMetadataByClass, projectorMetadataByClass);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/repository/ReflectionRepositoriesMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/repository/ReflectionRepositoriesMetadata.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.mapping.reflection.repository;
 
@@ -28,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 
 
@@ -39,15 +41,20 @@ class ReflectionRepositoriesMetadata implements RepositoriesMetadata {
     private final Map<Class<?>, RepositoryMetadata> repositories = new HashMap<>();
 
 
-    private final Event<ProjectionFound> projectionFoundEvent;
+    private final Consumer<ProjectionFound> projectionFoundConsumer;
 
     @Inject
     ReflectionRepositoriesMetadata(Event<ProjectionFound> projectionFoundEvent) {
-        this.projectionFoundEvent = projectionFoundEvent;
+        this.projectionFoundConsumer = projectionFoundEvent::fire;
+    }
+
+    ReflectionRepositoriesMetadata(Consumer<ProjectionFound> projectionFoundConsumer) {
+        this.projectionFoundConsumer = Objects.requireNonNull(projectionFoundConsumer, "projectionFoundConsumer is required");
+        this.init();
     }
 
     ReflectionRepositoriesMetadata() {
-        this(null);
+        this.projectionFoundConsumer = null;
     }
 
     @Inject
@@ -62,7 +69,7 @@ class ReflectionRepositoriesMetadata implements RepositoriesMetadata {
         LOGGER.fine("Found repositories: " + repositoriesType);
         var supplier = ReflectionRepositorySupplier.INSTANCE;
         for (Class<?> type : repositoriesType) {
-            RepositoryMetadata metadata = supplier.apply(type, projectionFoundEvent);
+            RepositoryMetadata metadata = supplier.apply(type, projectionFoundConsumer);
             repositories.put(type, metadata);
         }
 

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/repository/ReflectionRepositoriesMetadataBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/repository/ReflectionRepositoriesMetadataBuilder.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.reflection.repository;
+
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoriesMetadata;
+import org.eclipse.jnosql.mapping.reflection.ProjectionFound;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Step builder for creating {@link RepositoriesMetadata} instances using reflection-based discovery.
+ *
+ * <p>Usage example:</p>
+ * <pre>{@code
+ * RepositoriesMetadata repositories = ReflectionRepositoriesMetadataBuilder.builder()
+ *         .withObserver(projectionFound -> {
+ *             // handle projection found event
+ *         })
+ *         .build();
+ * }</pre>
+ */
+public sealed interface ReflectionRepositoriesMetadataBuilder permits ReflectionRepositoriesMetadataBuilder.ConsumerStep {
+
+    /**
+     * Returns a new builder starting from {@link ConsumerStep}.
+     *
+     * @return the first step of the builder
+     */
+    static ConsumerStep builder() {
+        return new ConsumerStep(null);
+    }
+
+    /**
+     * Step of the builder that holds the projection found observer.
+     */
+    record ConsumerStep(Consumer<ProjectionFound> observer) implements ReflectionRepositoriesMetadataBuilder {
+
+        /**
+         * Returns a new {@code ConsumerStep} with the given observer.
+         *
+         * @param observer the projection found observer
+         * @return a new {@code ConsumerStep}
+         * @throws NullPointerException if {@code observer} is null
+         */
+        public ConsumerStep withObserver(Consumer<ProjectionFound> observer) {
+            Objects.requireNonNull(observer, "observer is required");
+            return new ConsumerStep(observer);
+        }
+
+        /**
+         * Builds a {@link RepositoriesMetadata} instance using the provided observer.
+         * If no observer is provided, a no-op one will be used.
+         *
+         * @return a new {@link RepositoriesMetadata} instance
+         */
+        public RepositoriesMetadata build() {
+            Consumer<ProjectionFound> actualObserver = observer != null ? observer : p -> {};
+            return new ReflectionRepositoriesMetadata(actualObserver);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/repository/ReflectionRepositorySupplier.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/repository/ReflectionRepositorySupplier.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Maximillian Arruda
  */
 package org.eclipse.jnosql.mapping.reflection.repository;
 
@@ -24,7 +25,6 @@ import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Select;
-import jakarta.enterprise.event.Event;
 import jakarta.nosql.Entity;
 import jakarta.nosql.Projection;
 import org.eclipse.jnosql.mapping.ProviderQuery;
@@ -49,6 +49,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.logging.Logger;
 
 import static java.util.Optional.ofNullable;
@@ -62,7 +63,7 @@ enum ReflectionRepositorySupplier {
         return apply(type, null);
     }
 
-    public RepositoryMetadata apply(Class<?> type, Event<ProjectionFound> projectionFoundEvent) {
+    public RepositoryMetadata apply(Class<?> type, Consumer<ProjectionFound> projectionFoundConsumer) {
         Objects.requireNonNull(type, "type is required");
         if (!type.isInterface()) {
             throw new IllegalArgumentException("The repository type " + type.getName() + " is not an interface");
@@ -72,7 +73,7 @@ enum ReflectionRepositorySupplier {
         List<RepositoryMethod> methods = new ArrayList<>(declaredMethods.size());
         Map<Method, RepositoryMethod> methodByMethodReflection = new HashMap<>(declaredMethods.size());
         for (Method method : declaredMethods) {
-            RepositoryMethod repositoryMethod = to(method, projectionFoundEvent);
+            RepositoryMethod repositoryMethod = to(method, projectionFoundConsumer);
             methods.add(repositoryMethod);
             methodByMethodReflection.put(method, repositoryMethod);
         }
@@ -118,7 +119,7 @@ enum ReflectionRepositorySupplier {
     }
 
 
-    private RepositoryMethod to(Method method, Event<ProjectionFound> projectionFoundEvent) {
+    private RepositoryMethod to(Method method, Consumer<ProjectionFound> projectionFoundConsumer) {
 
         String name = method.getName();
         String queryValue = ofNullable(method.getAnnotation(Query.class))
@@ -129,9 +130,9 @@ enum ReflectionRepositorySupplier {
                 .map(Find::value).orElse(null);
         Class<?> returnTypeValue = method.getReturnType();
         Class<?> elementTypeValue = getElementTypeValue(method);
-        if (projectionFoundEvent != null) {
-            checkProjectionFound(returnTypeValue, projectionFoundEvent);
-            checkProjectionFound(elementTypeValue, projectionFoundEvent);
+        if (projectionFoundConsumer != null) {
+            checkProjectionFound(returnTypeValue, projectionFoundConsumer);
+            checkProjectionFound(elementTypeValue, projectionFoundConsumer);
         }
 
         List<RepositoryParam> params = to(method.getParameters());
@@ -167,12 +168,12 @@ enum ReflectionRepositorySupplier {
      * Verifies if the record does not have the {@link Projection} annotation, in this case, it will accepted as
      * projection, because of the Jakarta Data spec
      *
-     * @param type                 the type
-     * @param projectionFoundEvent the event to be fired
+     * @param type                    the type
+     * @param projectionFoundConsumer the consumer to be called
      */
-    private void checkProjectionFound(Class<?> type, Event<ProjectionFound> projectionFoundEvent) {
+    private void checkProjectionFound(Class<?> type, Consumer<ProjectionFound> projectionFoundConsumer) {
         if (type != null && type.isRecord() && type.getAnnotation(Projection.class) == null) {
-            projectionFoundEvent.fire(new ProjectionFound(type));
+            projectionFoundConsumer.accept(new ProjectionFound(type));
         }
 
     }

--- a/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionBuildersTest.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/test/java/org/eclipse/jnosql/mapping/reflection/ReflectionBuildersTest.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.reflection;
+
+import org.eclipse.jnosql.mapping.metadata.ClassConverter;
+import org.eclipse.jnosql.mapping.metadata.ClassScanner;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.metadata.GroupEntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoriesMetadata;
+import org.eclipse.jnosql.mapping.reflection.repository.ReflectionRepositoriesMetadataBuilder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("Unit tests for reflection-based builders")
+class ReflectionBuildersTest {
+
+    @Test
+    @DisplayName("shouldCreateReflectionGroupEntityMetadataUsingBuilder")
+    void shouldCreateReflectionGroupEntityMetadataUsingBuilder() {
+        GroupEntityMetadata metadata = ReflectionGroupEntityMetadataBuilder.builder()
+                .withScanner(ClassScanner.load())
+                .withConverter(ClassConverter.load())
+                .build();
+
+        assertSoftly(softly -> {
+            softly.assertThat(metadata).isNotNull();
+            softly.assertThat(metadata.classes()).isNotEmpty();
+            softly.assertThat(metadata.mappings()).isNotEmpty();
+            softly.assertThat(metadata.projections()).isNotNull();
+        });
+    }
+
+    @Test
+    @DisplayName("shouldThrowExceptionWhenScannerIsNullInGroupBuilder")
+    void shouldThrowExceptionWhenScannerIsNullInGroupBuilder() {
+        assertThrows(NullPointerException.class, () ->
+                ReflectionGroupEntityMetadataBuilder.builder().withScanner(null));
+    }
+
+    @Test
+    @DisplayName("shouldCreateEntitiesMetadataUsingBuilder")
+    void shouldCreateEntitiesMetadataUsingBuilder() {
+        GroupEntityMetadata group = ReflectionGroupEntityMetadataBuilder.builder()
+                .withScanner(ClassScanner.load())
+                .withConverter(ClassConverter.load())
+                .build();
+
+        EntitiesMetadata entities = ReflectionEntitiesMetadataBuilder.builder()
+                .withGroup(group)
+                .build();
+
+        assertThat(entities).isNotNull();
+    }
+
+    @Test
+    @DisplayName("shouldCreateRepositoriesMetadataUsingBuilder")
+    void shouldCreateRepositoriesMetadataUsingBuilder() {
+        AtomicBoolean observerCalled = new AtomicBoolean(false);
+        RepositoriesMetadata repositories = ReflectionRepositoriesMetadataBuilder.builder()
+                .withObserver(projectionFound -> observerCalled.set(true))
+                .build();
+
+        assertSoftly(softly -> {
+            softly.assertThat(repositories).isNotNull();
+            // Since repositories are loaded via ClassScanner, we just check it doesn't throw
+        });
+    }
+
+    @Test
+    @DisplayName("shouldCreateRepositoriesMetadataWithNoOpObserver")
+    void shouldCreateRepositoriesMetadataWithNoOpObserver() {
+        RepositoriesMetadata repositories = ReflectionRepositoriesMetadataBuilder.builder()
+                .build();
+
+        assertThat(repositories).isNotNull();
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/EntityConverterFactoryBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/EntityConverterFactoryBuilder.java
@@ -1,0 +1,156 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.semistructured;
+
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+
+import java.util.Objects;
+
+/**
+ * Step builder for creating {@link EntityConverterFactory} instances outside a
+ * CDI container.
+ *
+ * <p>
+ * Usage example:
+ * 
+ * <pre>{@code
+ * EntityConverterFactory factory = EntityConverterFactoryBuilder.builder()
+ *         .withEntities(entitiesMetadata)
+ *         .withConverters(converters)
+ *         .build();
+ * }</pre>
+ *
+ * <p>
+ * All steps are immutable records. Each {@code withXxx()} call returns a new
+ * record
+ * with the updated value, leaving the original step unchanged.
+ * </p>
+ *
+ * <p>
+ * The {@code build()} method is available once both {@link EntitiesMetadata}
+ * and
+ * {@link Converters} have been provided (from {@link ConvertersStep} onward).
+ * The builder
+ * internally creates the required {@link ProjectorConverter} and
+ * {@link DefaultEntityConverterFactory}
+ * without any container.
+ * </p>
+ *
+ * <p>
+ * <strong>Note:</strong> Instances created by this builder are not managed by
+ * any CDI
+ * container. The caller is responsible for lifecycle management.
+ * </p>
+ */
+public sealed interface EntityConverterFactoryBuilder permits EntityConverterFactoryBuilder.EntitiesStep,
+        EntityConverterFactoryBuilder.ConvertersStep {
+
+    /**
+     * Returns a new builder starting from {@link EntitiesStep}.
+     * Call {@link EntitiesStep#withEntities(EntitiesMetadata)} to provide the
+     * required
+     * {@link EntitiesMetadata}.
+     *
+     * @return the first step of the builder
+     */
+    static EntitiesStep builder() {
+        return new EntitiesStep(null);
+    }
+
+    /**
+     * First step of the builder. Holds the {@link EntitiesMetadata}.
+     *
+     * @param entities the entities metadata; may be {@code null} only in the
+     *                 initial step returned by {@link #builder()}
+     */
+    record EntitiesStep(EntitiesMetadata entities) implements EntityConverterFactoryBuilder {
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata.
+         *
+         * @param entities the entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is null
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(entities);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link Converters}.
+         *
+         * @param converters the converters to use
+         * @return a {@link ConvertersStep} holding both dependencies
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ConvertersStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ConvertersStep(entities, converters);
+        }
+    }
+
+    /**
+     * Second step of the builder. Holds both {@link EntitiesMetadata} and
+     * {@link Converters}
+     * and provides {@code build()}.
+     *
+     * @param entities   the entities metadata; must not be null
+     * @param converters the converters; must not be null
+     */
+    record ConvertersStep(EntitiesMetadata entities, Converters converters) implements EntityConverterFactoryBuilder {
+
+        /**
+         * Returns a new {@code ConvertersStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code ConvertersStep} with the updated metadata
+         */
+        public ConvertersStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new ConvertersStep(entities, converters);
+        }
+
+        /**
+         * Returns a new {@code ConvertersStep} with the given converters.
+         *
+         * @param converters the new converters
+         * @return a new {@code ConvertersStep} with the updated converters
+         * @throws NullPointerException if {@code converters} is null
+         */
+        public ConvertersStep withConverters(Converters converters) {
+            Objects.requireNonNull(converters, "converters is required");
+            return new ConvertersStep(entities, converters);
+        }
+
+        /**
+         * Builds an {@link EntityConverterFactory} using the accumulated dependencies.
+         * Internally creates a {@link ProjectorConverter} from {@code entities} and
+         * then
+         * a {@link DefaultEntityConverterFactory} from all three dependencies.
+         *
+         * @return a new {@link EntityConverterFactory} instance
+         * @throws NullPointerException if {@code entities} or {@code converters} is
+         *                              null
+         */
+        public EntityConverterFactory build() {
+            Objects.requireNonNull(entities, "entities is required");
+            Objects.requireNonNull(converters, "converters is required");
+            ProjectorConverter projectorConverter = new ProjectorConverter(entities);
+            return new DefaultEntityConverterFactory(entities, converters, projectorConverter);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManager.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManager.java
@@ -21,6 +21,8 @@ import jakarta.inject.Inject;
 import org.eclipse.jnosql.mapping.EntityPostPersist;
 import org.eclipse.jnosql.mapping.EntityPrePersist;
 
+import java.util.function.Consumer;
+
 /**
  * This class represents the manager of events for entity persistence operations.
  * When an entity is either saved or updated, events will be fired in the following order:
@@ -32,12 +34,39 @@ import org.eclipse.jnosql.mapping.EntityPrePersist;
 @ApplicationScoped
 public class EventPersistManager {
 
+    private final Consumer<EntityPrePersist> entityPrePersistEvent;
+
+    private final Consumer<EntityPostPersist> entityPostPersistEvent;
 
     @Inject
-    private Event<EntityPrePersist> entityPrePersistEvent;
+    EventPersistManager(Event<EntityPrePersist> entityPrePersistEvent,
+                        Event<EntityPostPersist> entityPostPersistEvent) {
+        this.entityPrePersistEvent = entityPrePersistEvent::fire;
+        this.entityPostPersistEvent = entityPostPersistEvent::fire;
+    }
 
-    @Inject
-    private Event<EntityPostPersist> entityPostPersistEvent;
+    /**
+     * Package-private constructor for use outside a CDI container.
+     * Accepts {@link Consumer} instances as substitutes for CDI {@link Event} objects,
+     * enabling instantiation in non-CDI environments such as Spring, Guice, or plain unit tests.
+     *
+     * <p>The caller is responsible for the lifecycle of the created instance.</p>
+     *
+     * @param prePersistConsumer  consumer invoked before entity persistence; must not be null
+     * @param postPersistConsumer consumer invoked after entity persistence; must not be null
+     */
+    EventPersistManager(Consumer<EntityPrePersist> prePersistConsumer,
+                        Consumer<EntityPostPersist> postPersistConsumer) {
+        this.entityPrePersistEvent = prePersistConsumer;
+        this.entityPostPersistEvent = postPersistConsumer;
+    }
+
+    /**
+     * CDI no-arg constructor required for proxy creation.
+     */
+    EventPersistManager() {
+        this(e -> {}, e -> {});
+    }
 
     /**
      * Fires an event before an entity is persisted.
@@ -46,7 +75,7 @@ public class EventPersistManager {
      * @param <T>    the type of the entity
      */
     public <T> void firePreEntity(T entity) {
-        entityPrePersistEvent.fire(EntityPrePersist.of(entity));
+        entityPrePersistEvent.accept(EntityPrePersist.of(entity));
     }
 
     /**
@@ -56,7 +85,7 @@ public class EventPersistManager {
      * @param <T>    the type of the entity
      */
     public <T> void firePostEntity(T entity) {
-        entityPostPersistEvent.fire(EntityPostPersist.of(entity));
+        entityPostPersistEvent.accept(EntityPostPersist.of(entity));
     }
 
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManagerBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManagerBuilder.java
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.semistructured;
+
+import org.eclipse.jnosql.mapping.EntityPostPersist;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+
+import java.util.function.Consumer;
+
+/**
+ * Step builder for creating {@link EventPersistManager} instances outside a CDI
+ * container.
+ *
+ * <p>
+ * Usage example:
+ * 
+ * <pre>{@code
+ * EventPersistManager manager = EventPersistManagerBuilder.builder()
+ *         .withPostPersist(event -> System.out.println("Post: " + event.get()))
+ *         .build();
+ * }</pre>
+ *
+ * <p>
+ * All steps are immutable records. Each {@code withXxx()} call returns a new
+ * record
+ * with the updated value, leaving the original step unchanged.
+ * </p>
+ *
+ * <p>
+ * The {@code build()} method is available from the first step
+ * ({@link PrePersistStep})
+ * onward. Any consumer not explicitly supplied defaults to a no-op
+ * ({@code t -> {}}).
+ * </p>
+ *
+ * <p>
+ * <strong>Note:</strong> Instances created by this builder are not managed by
+ * any CDI
+ * container. The caller is responsible for lifecycle management.
+ * </p>
+ */
+public sealed interface EventPersistManagerBuilder permits EventPersistManagerBuilder.PrePersistStep,
+        EventPersistManagerBuilder.PostPersistStep {
+
+    /**
+     * Returns a new builder starting from {@link PrePersistStep} with a no-op
+     * pre-persist consumer.
+     *
+     * @return the first step of the builder
+     */
+    static PrePersistStep builder() {
+        return new PrePersistStep(t -> {
+        });
+    }
+
+    /**
+     * First step of the builder. Holds the {@link EntityPrePersist} consumer.
+     * {@code build()} is available here with a no-op post-persist consumer.
+     *
+     * @param prePersist the consumer to be invoked before entity persistence; must
+     *                   not be null
+     */
+    record PrePersistStep(Consumer<EntityPrePersist> prePersist) implements EventPersistManagerBuilder {
+
+        /**
+         * Returns a new {@code PrePersistStep} with the given pre-persist consumer.
+         * If {@code prePersist} is {@code null}, a no-op consumer is used.
+         *
+         * @param prePersist the new pre-persist consumer; {@code null} is treated as
+         *                   no-op
+         * @return a new {@code PrePersistStep} with the updated consumer
+         */
+        public PrePersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            return new PrePersistStep(prePersist != null ? prePersist : t -> {
+            });
+        }
+
+        /**
+         * Advances to the next step by providing a post-persist consumer.
+         * If {@code postPersist} is {@code null}, a no-op consumer is used.
+         *
+         * @param postPersist the consumer to be invoked after entity persistence;
+         *                    {@code null} is treated as no-op
+         * @return a {@link PostPersistStep} holding both consumers
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            return new PostPersistStep(prePersist, postPersist != null ? postPersist : t -> {
+            });
+        }
+
+        /**
+         * Builds an {@link EventPersistManager} using the current pre-persist consumer
+         * and a no-op post-persist consumer.
+         *
+         * @return a new {@link EventPersistManager} instance
+         */
+        public EventPersistManager build() {
+            return new EventPersistManager(prePersist, t -> {
+            });
+        }
+    }
+
+    /**
+     * Second step of the builder. Holds both consumers and provides
+     * {@code build()}.
+     *
+     * @param prePersist  the consumer to be invoked before entity persistence; must
+     *                    not be null
+     * @param postPersist the consumer to be invoked after entity persistence; must
+     *                    not be null
+     */
+    record PostPersistStep(Consumer<EntityPrePersist> prePersist,
+            Consumer<EntityPostPersist> postPersist) implements EventPersistManagerBuilder {
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given pre-persist consumer.
+         * If {@code prePersist} is {@code null}, a no-op consumer is used.
+         *
+         * @param prePersist the new pre-persist consumer; {@code null} is treated as
+         *                   no-op
+         * @return a new {@code PostPersistStep} with the updated pre-persist consumer
+         */
+        public PostPersistStep withPrePersist(Consumer<EntityPrePersist> prePersist) {
+            return new PostPersistStep(prePersist != null ? prePersist : t -> {
+            }, postPersist);
+        }
+
+        /**
+         * Returns a new {@code PostPersistStep} with the given post-persist consumer.
+         * If {@code postPersist} is {@code null}, a no-op consumer is used.
+         *
+         * @param postPersist the new post-persist consumer; {@code null} is treated as
+         *                    no-op
+         * @return a new {@code PostPersistStep} with the updated post-persist consumer
+         */
+        public PostPersistStep withPostPersist(Consumer<EntityPostPersist> postPersist) {
+            return new PostPersistStep(prePersist, postPersist != null ? postPersist : t -> {
+            });
+        }
+
+        /**
+         * Builds an {@link EventPersistManager} using both consumers.
+         *
+         * @return a new {@link EventPersistManager} instance
+         */
+        public EventPersistManager build() {
+            return new EventPersistManager(prePersist, postPersist);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
@@ -187,7 +187,7 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
     }
 
     protected SelectQuery toQuery(Map<String, ParamValue> parameters, Method method) {
-        return SemiStructuredParameterBasedQuery.INSTANCE.toQuery(parameters, getSorts(method, entityMetadata()), entityMetadata());
+        return SemiStructuredParameterBasedQuery.INSTANCE.toQuery(parameters, getSorts(method, entityMetadata()), entityMetadata(), converters());
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredParameterBasedQuery.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredParameterBasedQuery.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.IntFunction;
 
 import static org.eclipse.jnosql.mapping.core.util.ConverterUtil.getValue;
@@ -59,6 +60,24 @@ public enum SemiStructuredParameterBasedQuery {
                                                                                List<Sort<?>> sorts,
                                                                                EntityMetadata entityMetadata) {
         var convert = CDI.current().select(Converters.class).get();
+        return toQuery(params, sorts, entityMetadata, convert);
+    }
+
+    /**
+     * Constructs a ColumnQuery based on the provided parameters, PageRequest information, and entity metadata.
+     * This method avoids implicit CDI lookup by using a provided {@link Converters} instance.
+     *
+     * @param params          The map of parameters used for filtering columns.
+     * @param sorts           The list of sorting instructions to to sort the query results.
+     * @param entityMetadata  Metadata describing the structure of the entity.
+     * @param convert         Converters used to transform values according to entity metadata.
+     * @return                A ColumnQuery instance tailored for the specified entity.
+     */
+    public org.eclipse.jnosql.communication.semistructured.SelectQuery toQuery(Map<String, ParamValue> params,
+                                                                               List<Sort<?>> sorts,
+                                                                               EntityMetadata entityMetadata,
+                                                                               Converters convert) {
+        Objects.requireNonNull(convert, "The converters is required");
         List<CriteriaCondition> conditions = new ArrayList<>();
         for (Map.Entry<String, ParamValue> entry : params.entrySet()) {
             conditions.add(condition(convert, entityMetadata, entry));

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredCursorPaginationOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredCursorPaginationOperation.java
@@ -20,6 +20,7 @@ import jakarta.data.page.impl.CursoredPageRecord;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.core.repository.DynamicReturn;
 import org.eclipse.jnosql.mapping.core.repository.RepositoryMetadataUtils;
 import org.eclipse.jnosql.mapping.core.repository.SpecialParameters;
@@ -41,15 +42,21 @@ class SemistructuredCursorPaginationOperation implements CursorPaginationOperati
 
     private final SemistructuredReturnType returnType;
 
+    private final Converters converters;
+
     @Inject
-    SemistructuredCursorPaginationOperation(SemistructuredQueryBuilder queryBuilder, SemistructuredReturnType returnType) {
+    SemistructuredCursorPaginationOperation(SemistructuredQueryBuilder queryBuilder,
+                                            SemistructuredReturnType returnType,
+                                            Converters converters) {
         this.queryBuilder = queryBuilder;
         this.returnType = returnType;
+        this.converters = converters;
     }
 
     SemistructuredCursorPaginationOperation() {
         this.queryBuilder = null;
         this.returnType = null;
+        this.converters = null;
     }
 
 
@@ -69,7 +76,8 @@ class SemistructuredCursorPaginationOperation implements CursorPaginationOperati
 
     private CursoredPage<?> executeFindAnnotation(RepositoryInvocationContext context, RepositoryMethod method, EntityMetadata entityMetadata, SemiStructuredTemplate template) {
         var paramValueMap = RepositoryMetadataUtils.INSTANCE.getBy(method, context.parameters());
-        var query = SemiStructuredParameterBasedQuery.INSTANCE.toQuery(paramValueMap, Collections.emptyList(), entityMetadata);
+        var query = SemiStructuredParameterBasedQuery.INSTANCE
+                .toQuery(paramValueMap, Collections.emptyList(), entityMetadata, converters);
         var updateDynamicQuery = queryBuilder.updateDynamicQuery(query, context);
         var special = DynamicReturn.findSpecialParameters(context.parameters(), Function.identity());
         var pageRequest = pageRequest(method, special);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredParameterBasedOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredParameterBasedOperation.java
@@ -16,6 +16,7 @@ package org.eclipse.jnosql.mapping.semistructured.repository;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.core.repository.ParamValue;
 import org.eclipse.jnosql.mapping.core.repository.RepositoryMetadataUtils;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
@@ -37,19 +38,24 @@ class SemistructuredParameterBasedOperation implements ParameterBasedOperation {
 
     private final EntitiesMetadata entitiesMetadata;
 
+    private final Converters converters;
+
     @Inject
     SemistructuredParameterBasedOperation(SemistructuredQueryBuilder semistructuredQueryBuilder,
-                                                 SemistructuredReturnType semistructuredReturnType,
-                                          EntitiesMetadata entitiesMetadata) {
+                                          SemistructuredReturnType semistructuredReturnType,
+                                          EntitiesMetadata entitiesMetadata,
+                                          Converters converters) {
         this.semistructuredQueryBuilder = semistructuredQueryBuilder;
         this.semistructuredReturnType = semistructuredReturnType;
         this.entitiesMetadata = entitiesMetadata;
+        this.converters = converters;
     }
 
     SemistructuredParameterBasedOperation() {
         this.semistructuredQueryBuilder = null;
         this.semistructuredReturnType = null;
         this.entitiesMetadata = null;
+        this.converters = null;
     }
 
     @SuppressWarnings("unchecked")
@@ -61,7 +67,8 @@ class SemistructuredParameterBasedOperation implements ParameterBasedOperation {
                 .orElse(context.entityMetadata());
         var parameters = context.parameters();
         Map<String, ParamValue> paramValueMap = RepositoryMetadataUtils.INSTANCE.getBy(method, parameters);
-        var query = SemiStructuredParameterBasedQuery.INSTANCE.toQuery(paramValueMap, Collections.emptyList(), entityMetadata);
+        var query = SemiStructuredParameterBasedQuery.INSTANCE
+                .toQuery(paramValueMap, Collections.emptyList(), entityMetadata, converters);
         try {
             var updateDynamicQuery = semistructuredQueryBuilder.updateDynamicQuery(query, context(context, entityMetadata));
             return (T) semistructuredReturnType.executeFindByQuery(context, updateDynamicQuery);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducer.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducer.java
@@ -19,6 +19,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.jnosql.mapping.core.repository.CoreRepositoryInvocationHandler;
 import org.eclipse.jnosql.mapping.core.repository.InfrastructureOperatorProvider;
+import org.eclipse.jnosql.mapping.core.repository.RepositoryOperationProvider;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 import org.eclipse.jnosql.mapping.metadata.repository.RepositoriesMetadata;
 import org.eclipse.jnosql.mapping.metadata.repository.RepositoryMetadata;
@@ -33,17 +34,37 @@ import java.util.Objects;
 @ApplicationScoped
 public class SemistructuredRepositoryProducer {
 
-    @Inject
-    private EntitiesMetadata entities;
+    private final EntitiesMetadata entities;
+    private final RepositoriesMetadata repositoriesMetadata;
+    private final InfrastructureOperatorProvider infrastructureOperatorProvider;
+    private final RepositoryOperationProvider repositoryOperationProvider;
 
+    /**
+     * CDI constructor injection. All four dependencies are required.
+     *
+     * @param entities                    entity reflection metadata
+     * @param repositoriesMetadata        repository interface metadata
+     * @param infrastructureOperatorProvider proxy infrastructure operators
+     * @param repositoryOperationProvider semistructured repository operations
+     */
     @Inject
-    private InfrastructureOperatorProvider infrastructureOperatorProvider;
+    public SemistructuredRepositoryProducer(EntitiesMetadata entities,
+                                            RepositoriesMetadata repositoriesMetadata,
+                                            InfrastructureOperatorProvider infrastructureOperatorProvider,
+                                            RepositoryOperationProvider repositoryOperationProvider) {
+        this.entities = entities;
+        this.repositoriesMetadata = repositoriesMetadata;
+        this.infrastructureOperatorProvider = infrastructureOperatorProvider;
+        this.repositoryOperationProvider = repositoryOperationProvider;
+    }
 
-    @Inject
-    private SemistructuredRepositoryOperationProvider semistructuredRepositoryOperationProvider;
-
-    @Inject
-    private RepositoriesMetadata repositoriesMetadata;
+    /**
+     * Package-private no-arg constructor for CDI proxy compatibility.
+     * Do not use directly.
+     */
+    SemistructuredRepositoryProducer() {
+        this(null, null, null, null);
+    }
 
     /**
      * Returns a fully functional repository implementation for the given
@@ -70,7 +91,7 @@ public class SemistructuredRepositoryProducer {
                 entityMetadata,
                 repositoryMetadata,
                 infrastructureOperatorProvider,
-                semistructuredRepositoryOperationProvider,
+                repositoryOperationProvider,
                 template);
 
         return (R) Proxy.newProxyInstance(repositoryClass.getClassLoader(),

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerBuilder.java
@@ -1,0 +1,312 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.semistructured.repository;
+
+import org.eclipse.jnosql.mapping.core.repository.InfrastructureOperatorProvider;
+import org.eclipse.jnosql.mapping.core.repository.RepositoryOperationProvider;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoriesMetadata;
+
+import java.util.Objects;
+
+/**
+ * Step builder for creating {@link SemistructuredRepositoryProducer} instances outside a
+ * CDI container.
+ *
+ * <p>
+ * Usage example:
+ *
+ * <pre>{@code
+ * SemistructuredRepositoryProducer producer = SemistructuredRepositoryProducerBuilder.builder()
+ *         .withEntities(entitiesMetadata)
+ *         .withRepositories(repositoriesMetadata)
+ *         .withInfrastructure(infrastructureOperatorProvider)
+ *         .withOperations(repositoryOperationProvider)
+ *         .build();
+ * }</pre>
+ *
+ * <p>
+ * All steps are immutable records. Each {@code withXxx()} call returns a new
+ * record with the updated value, leaving the original step unchanged.
+ * </p>
+ *
+ * <p>
+ * Required dependencies (in order):
+ * <ol>
+ *   <li>{@link EntitiesMetadata} — entity reflection metadata</li>
+ *   <li>{@link RepositoriesMetadata} — repository interface metadata</li>
+ *   <li>{@link InfrastructureOperatorProvider} — proxy infrastructure operators</li>
+ *   <li>{@link RepositoryOperationProvider} — query and operation execution</li>
+ * </ol>
+ * </p>
+ *
+ * <p>
+ * The {@code build()} method is available only from {@link OperationsStep}, once all
+ * four required dependencies have been provided.
+ * </p>
+ *
+ * <p>
+ * <strong>Note:</strong> Instances created by this builder are not managed by
+ * any CDI container. The caller is responsible for lifecycle management.
+ * If a repository method uses a custom CDI-backed operator, invocation may
+ * fail at runtime if no CDI context is active.
+ * </p>
+ */
+public sealed interface SemistructuredRepositoryProducerBuilder
+        permits SemistructuredRepositoryProducerBuilder.EntitiesStep,
+        SemistructuredRepositoryProducerBuilder.RepositoriesStep,
+        SemistructuredRepositoryProducerBuilder.InfraStep,
+        SemistructuredRepositoryProducerBuilder.OperationsStep {
+
+    /**
+     * Returns a new builder starting from {@link EntitiesStep}.
+     * Call {@link EntitiesStep#withEntities(EntitiesMetadata)} to provide the
+     * required {@link EntitiesMetadata}.
+     *
+     * @return the first step of the builder
+     */
+    static EntitiesStep builder() {
+        return new EntitiesStep(null);
+    }
+
+    /**
+     * First step of the builder. Holds the {@link EntitiesMetadata}.
+     *
+     * @param entities the entities metadata; may be {@code null} only in the
+     *                 initial step returned by {@link #builder()}
+     */
+    record EntitiesStep(EntitiesMetadata entities) implements SemistructuredRepositoryProducerBuilder {
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is {@code null}
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(entities);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link RepositoriesMetadata}.
+         *
+         * @param repositories the repositories metadata to use
+         * @return a {@link RepositoriesStep} holding both dependencies
+         * @throws NullPointerException if {@code repositories} is {@code null}
+         */
+        public RepositoriesStep withRepositories(RepositoriesMetadata repositories) {
+            Objects.requireNonNull(repositories, "repositories is required");
+            return new RepositoriesStep(entities, repositories);
+        }
+    }
+
+    /**
+     * Second step of the builder. Holds {@link EntitiesMetadata} and {@link RepositoriesMetadata}.
+     *
+     * @param entities     the entities metadata; must not be {@code null}
+     * @param repositories the repositories metadata; must not be {@code null}
+     */
+    record RepositoriesStep(EntitiesMetadata entities, RepositoriesMetadata repositories)
+            implements SemistructuredRepositoryProducerBuilder {
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata,
+         * discarding the repositories metadata.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is {@code null}
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(entities);
+        }
+
+        /**
+         * Returns a new {@code RepositoriesStep} with the given repositories metadata,
+         * preserving the current entities metadata.
+         *
+         * @param repositories the new repositories metadata
+         * @return a new {@code RepositoriesStep} with the updated metadata
+         * @throws NullPointerException if {@code repositories} is {@code null}
+         */
+        public RepositoriesStep withRepositories(RepositoriesMetadata repositories) {
+            Objects.requireNonNull(repositories, "repositories is required");
+            return new RepositoriesStep(entities, repositories);
+        }
+
+        /**
+         * Advances to the next step by providing the {@link InfrastructureOperatorProvider}.
+         *
+         * @param infrastructure the infrastructure operator provider to use
+         * @return an {@link InfraStep} holding all three dependencies
+         * @throws NullPointerException if {@code infrastructure} is {@code null}
+         */
+        public InfraStep withInfrastructure(InfrastructureOperatorProvider infrastructure) {
+            Objects.requireNonNull(infrastructure, "infrastructure is required");
+            return new InfraStep(entities, repositories, infrastructure);
+        }
+    }
+
+    /**
+     * Third step of the builder. Holds {@link EntitiesMetadata}, {@link RepositoriesMetadata},
+     * and {@link InfrastructureOperatorProvider}.
+     *
+     * @param entities       the entities metadata; must not be {@code null}
+     * @param repositories   the repositories metadata; must not be {@code null}
+     * @param infrastructure the infrastructure operator provider; must not be {@code null}
+     */
+    record InfraStep(EntitiesMetadata entities, RepositoriesMetadata repositories,
+                     InfrastructureOperatorProvider infrastructure)
+            implements SemistructuredRepositoryProducerBuilder {
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata,
+         * discarding the repositories and infrastructure dependencies.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is {@code null}
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(entities);
+        }
+
+        /**
+         * Returns a new {@code RepositoriesStep} with the given repositories metadata,
+         * discarding the infrastructure dependency.
+         *
+         * @param repositories the new repositories metadata
+         * @return a new {@code RepositoriesStep} preserving entities
+         * @throws NullPointerException if {@code repositories} is {@code null}
+         */
+        public RepositoriesStep withRepositories(RepositoriesMetadata repositories) {
+            Objects.requireNonNull(repositories, "repositories is required");
+            return new RepositoriesStep(entities, repositories);
+        }
+
+        /**
+         * Returns a new {@code InfraStep} with the given infrastructure operator provider,
+         * preserving the current entities and repositories metadata.
+         *
+         * @param infrastructure the new infrastructure operator provider
+         * @return a new {@code InfraStep} with the updated infrastructure
+         * @throws NullPointerException if {@code infrastructure} is {@code null}
+         */
+        public InfraStep withInfrastructure(InfrastructureOperatorProvider infrastructure) {
+            Objects.requireNonNull(infrastructure, "infrastructure is required");
+            return new InfraStep(entities, repositories, infrastructure);
+        }
+
+        /**
+         * Advances to the final step by providing the {@link RepositoryOperationProvider}.
+         *
+         * @param operations the repository operation provider to use
+         * @return an {@link OperationsStep} holding all four dependencies, ready to build
+         * @throws NullPointerException if {@code operations} is {@code null}
+         */
+        public OperationsStep withOperations(RepositoryOperationProvider operations) {
+            Objects.requireNonNull(operations, "operations is required");
+            return new OperationsStep(entities, repositories, infrastructure, operations);
+        }
+    }
+
+    /**
+     * Final step of the builder. Holds all four required dependencies.
+     * Exposes re-configure methods for each dependency and the {@link #build()} terminal method.
+     *
+     * @param entities       the entities metadata; must not be {@code null}
+     * @param repositories   the repositories metadata; must not be {@code null}
+     * @param infrastructure the infrastructure operator provider; must not be {@code null}
+     * @param operations     the repository operation provider; must not be {@code null}
+     */
+    record OperationsStep(EntitiesMetadata entities, RepositoriesMetadata repositories,
+                          InfrastructureOperatorProvider infrastructure,
+                          RepositoryOperationProvider operations)
+            implements SemistructuredRepositoryProducerBuilder {
+
+        /**
+         * Returns a new {@code EntitiesStep} with the given entities metadata,
+         * discarding all subsequent dependencies.
+         *
+         * @param entities the new entities metadata
+         * @return a new {@code EntitiesStep} with the updated metadata
+         * @throws NullPointerException if {@code entities} is {@code null}
+         */
+        public EntitiesStep withEntities(EntitiesMetadata entities) {
+            Objects.requireNonNull(entities, "entities is required");
+            return new EntitiesStep(entities);
+        }
+
+        /**
+         * Returns a new {@code RepositoriesStep} with the given repositories metadata,
+         * discarding the infrastructure and operations dependencies.
+         *
+         * @param repositories the new repositories metadata
+         * @return a new {@code RepositoriesStep} preserving entities
+         * @throws NullPointerException if {@code repositories} is {@code null}
+         */
+        public RepositoriesStep withRepositories(RepositoriesMetadata repositories) {
+            Objects.requireNonNull(repositories, "repositories is required");
+            return new RepositoriesStep(entities, repositories);
+        }
+
+        /**
+         * Returns a new {@code InfraStep} with the given infrastructure operator provider,
+         * discarding the operations dependency.
+         *
+         * @param infrastructure the new infrastructure operator provider
+         * @return a new {@code InfraStep} preserving entities and repositories
+         * @throws NullPointerException if {@code infrastructure} is {@code null}
+         */
+        public InfraStep withInfrastructure(InfrastructureOperatorProvider infrastructure) {
+            Objects.requireNonNull(infrastructure, "infrastructure is required");
+            return new InfraStep(entities, repositories, infrastructure);
+        }
+
+        /**
+         * Returns a new {@code OperationsStep} with the given repository operation provider,
+         * preserving all other dependencies.
+         *
+         * @param operations the new repository operation provider
+         * @return a new {@code OperationsStep} with the updated operations
+         * @throws NullPointerException if {@code operations} is {@code null}
+         */
+        public OperationsStep withOperations(RepositoryOperationProvider operations) {
+            Objects.requireNonNull(operations, "operations is required");
+            return new OperationsStep(entities, repositories, infrastructure, operations);
+        }
+
+        /**
+         * Builds a {@link SemistructuredRepositoryProducer} using the accumulated dependencies.
+         *
+         * <p>All four dependencies must be non-null. This method validates each one
+         * with {@link Objects#requireNonNull}.</p>
+         *
+         * @return a new, unmanaged {@link SemistructuredRepositoryProducer} instance
+         * @throws NullPointerException if any dependency is {@code null}
+         */
+        public SemistructuredRepositoryProducer build() {
+            Objects.requireNonNull(entities, "entities is required");
+            Objects.requireNonNull(repositories, "repositories is required");
+            Objects.requireNonNull(infrastructure, "infrastructure is required");
+            Objects.requireNonNull(operations, "operations is required");
+            return new SemistructuredRepositoryProducer(entities, repositories, infrastructure, operations);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerBuilder.java
@@ -42,7 +42,6 @@ import java.util.Objects;
  * record with the updated value, leaving the original step unchanged.
  * </p>
  *
- * <p>
  * Required dependencies (in order):
  * <ol>
  *   <li>{@link EntitiesMetadata} — entity reflection metadata</li>
@@ -50,7 +49,6 @@ import java.util.Objects;
  *   <li>{@link InfrastructureOperatorProvider} — proxy infrastructure operators</li>
  *   <li>{@link RepositoryOperationProvider} — query and operation execution</li>
  * </ol>
- * </p>
  *
  * <p>
  * The {@code build()} method is available only from {@link OperationsStep}, once all

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/EntityConverterFactoryBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/EntityConverterFactoryBuilderTest.java
@@ -1,0 +1,228 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.semistructured;
+
+import jakarta.inject.Inject;
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
+import org.eclipse.jnosql.communication.semistructured.Element;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.entities.Person;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EntityConverterFactoryBuilderTest {
+
+    // -----------------------------------------------------------------------
+    // Structural / immutability tests — pure unit tests, no CDI
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    @DisplayName("Builder structure and immutability (no CDI)")
+    class StructureTests {
+
+        @Mock
+        EntitiesMetadata entities;
+
+        @Mock
+        EntitiesMetadata otherEntities;
+
+        @Mock
+        Converters converters;
+
+        @Mock
+        Converters otherConverters;
+
+        @Test
+        @DisplayName("builder() should return an EntitiesStep instance")
+        void shouldReturnEntitiesStepFromBuilder() {
+            EntityConverterFactoryBuilder builder = EntityConverterFactoryBuilder.builder();
+            assertThat(builder).isInstanceOf(EntityConverterFactoryBuilder.EntitiesStep.class);
+        }
+
+        @Test
+        @DisplayName("withEntities() on EntitiesStep should return a new step without modifying the original")
+        void shouldBeImmutableOnEntitiesStep() {
+            EntityConverterFactoryBuilder.EntitiesStep original = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities);
+            EntityConverterFactoryBuilder.EntitiesStep updated = original.withEntities(otherEntities);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.entities())
+                        .as("original step should still hold the first entities metadata")
+                        .isSameAs(entities);
+                softly.assertThat(updated.entities())
+                        .as("updated step should hold the second entities metadata")
+                        .isSameAs(otherEntities);
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withConverters() on EntitiesStep should advance to ConvertersStep")
+        void shouldAdvanceToConvertersStep() {
+            EntityConverterFactoryBuilder next = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters);
+            assertThat(next).isInstanceOf(EntityConverterFactoryBuilder.ConvertersStep.class);
+        }
+
+        @Test
+        @DisplayName("withEntities() on ConvertersStep should return a new step without modifying the original")
+        void shouldBeImmutableOnConvertersStepEntities() {
+            EntityConverterFactoryBuilder.ConvertersStep original = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters);
+            EntityConverterFactoryBuilder.ConvertersStep updated = original.withEntities(otherEntities);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.entities())
+                        .as("original step should still hold the first entities metadata")
+                        .isSameAs(entities);
+                softly.assertThat(updated.entities())
+                        .as("updated step should hold the other entities metadata")
+                        .isSameAs(otherEntities);
+                softly.assertThat(original.converters())
+                        .as("converters should be unchanged in both")
+                        .isSameAs(updated.converters());
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withConverters() on ConvertersStep should return a new step without modifying the original")
+        void shouldBeImmutableOnConvertersStepConverters() {
+            EntityConverterFactoryBuilder.ConvertersStep original = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters);
+            EntityConverterFactoryBuilder.ConvertersStep updated = original.withConverters(otherConverters);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.converters())
+                        .as("original step should still hold the first converters")
+                        .isSameAs(converters);
+                softly.assertThat(updated.converters())
+                        .as("updated step should hold the other converters")
+                        .isSameAs(otherConverters);
+                softly.assertThat(original.entities())
+                        .as("entities should be unchanged in both")
+                        .isSameAs(updated.entities());
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("build() should return a non-null EntityConverterFactory")
+        void shouldBuildEntityConverterFactory() {
+            EntityConverterFactory factory = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entities)
+                    .withConverters(converters)
+                    .build();
+            assertThat(factory).isNotNull();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Functional tests — uses CDI to get real EntitiesMetadata and Converters
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @EnableAutoWeld
+    @AddPackages(value = {Converters.class, EntityConverter.class})
+    @AddPackages(MockProducer.class)
+    @AddPackages(Reflections.class)
+    @AddExtensions(ReflectionEntityMetadataExtension.class)
+    @DisplayName("Functional tests (with real EntitiesMetadata and Converters via CDI)")
+    class FunctionalTests {
+
+        private static final String ID = "~id";
+
+        @Inject
+        EntitiesMetadata entitiesMetadata;
+
+        @Inject
+        Converters converters;
+
+        @Test
+        @DisplayName("build() should produce an EntityConverterFactory that creates a functional EntityConverter")
+        void shouldProduceFunctionalEntityConverter() {
+            EntityConverterFactory factory = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entitiesMetadata)
+                    .withConverters(converters)
+                    .build();
+
+            assertThat(factory).isNotNull();
+
+            EntityConverter converter = factory.create(() -> Optional.of(ID));
+            assertThat(converter).isNotNull();
+
+            Person person = Person.builder()
+                    .id(42)
+                    .name("Ada")
+                    .age()
+                    .phones(Arrays.asList("111", "222"))
+                    .build();
+
+            CommunicationEntity communication = converter.toCommunication(person);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(communication).as("communication entity should not be null").isNotNull();
+                softly.assertThat(communication.name()).as("entity name should be 'Person'").isEqualTo("Person");
+                softly.assertThat(communication.find(ID).map(Element::get).orElse(null))
+                        .as("~id field should be 42L")
+                        .isEqualTo(42L);
+                softly.assertThat(communication.find("name").map(Element::get).orElse(null))
+                        .as("name field should be 'Ada'")
+                        .isEqualTo("Ada");
+            });
+        }
+
+        @Test
+        @DisplayName("ConvertersStep should allow re-configuration and produce a new factory each time")
+        void shouldAllowReconfiguration() {
+            EntityConverterFactoryBuilder.ConvertersStep step = EntityConverterFactoryBuilder.builder()
+                    .withEntities(entitiesMetadata)
+                    .withConverters(converters);
+
+            EntityConverterFactory factory1 = step.build();
+            EntityConverterFactory factory2 = step.withConverters(converters).build();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(factory1).as("first factory should not be null").isNotNull();
+                softly.assertThat(factory2).as("second factory should not be null").isNotNull();
+                softly.assertThat(factory1).as("each build() call should return a new instance").isNotSameAs(factory2);
+            });
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManagerBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManagerBuilderTest.java
@@ -1,0 +1,202 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.semistructured;
+
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.mapping.EntityPostPersist;
+import org.eclipse.jnosql.mapping.EntityPrePersist;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventPersistManagerBuilderTest {
+
+    static class Jedi {
+        final String name;
+
+        Jedi(String name) {
+            this.name = name;
+        }
+    }
+
+    @Test
+    @DisplayName("builder() should return a PrePersistStep instance")
+    void shouldReturnPrePersistStepFromBuilder() {
+        EventPersistManagerBuilder builder = EventPersistManagerBuilder.builder();
+        assertThat(builder).isInstanceOf(EventPersistManagerBuilder.PrePersistStep.class);
+    }
+
+    @Test
+    @DisplayName("build() from PrePersistStep should return a non-null EventPersistManager")
+    void shouldBuildFromPrePersistStep() {
+        EventPersistManager manager = EventPersistManagerBuilder.builder().build();
+        assertThat(manager).isNotNull();
+    }
+
+    @Test
+    @DisplayName("build() without consumers should not throw when firePreEntity is called")
+    void shouldNotThrowWhenFirePreEntityWithNoOp() {
+        EventPersistManager manager = EventPersistManagerBuilder.builder().build();
+        org.assertj.core.api.Assertions.assertThatCode(() -> manager.firePreEntity(new Jedi("Luke")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("build() without consumers should not throw when firePostEntity is called")
+    void shouldNotThrowWhenFirePostEntityWithNoOp() {
+        EventPersistManager manager = EventPersistManagerBuilder.builder().build();
+        org.assertj.core.api.Assertions.assertThatCode(() -> manager.firePostEntity(new Jedi("Luke")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("firePreEntity should invoke the pre-persist consumer with the correct entity")
+    void shouldInvokePrePersistConsumer() {
+        List<EntityPrePersist> captured = new ArrayList<>();
+        Jedi jedi = new Jedi("Luke");
+
+        EventPersistManager manager = EventPersistManagerBuilder.builder()
+                .withPrePersist(captured::add)
+                .build();
+
+        manager.firePreEntity(jedi);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(captured).as("pre-persist consumer should have been called once").hasSize(1);
+            softly.assertThat(captured.get(0).get()).as("captured entity should match").isSameAs(jedi);
+        });
+    }
+
+    @Test
+    @DisplayName("firePostEntity should invoke the post-persist consumer with the correct entity")
+    void shouldInvokePostPersistConsumer() {
+        List<EntityPostPersist> captured = new ArrayList<>();
+        Jedi jedi = new Jedi("Luke");
+
+        EventPersistManager manager = EventPersistManagerBuilder.builder()
+                .withPostPersist(captured::add)
+                .build();
+
+        manager.firePostEntity(jedi);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(captured).as("post-persist consumer should have been called once").hasSize(1);
+            softly.assertThat(captured.get(0).get()).as("captured entity should match").isSameAs(jedi);
+        });
+    }
+
+    @Test
+    @DisplayName("withPostPersist() from PrePersistStep should advance to PostPersistStep")
+    void shouldAdvanceToPostPersistStep() {
+        EventPersistManagerBuilder.PrePersistStep prePersistStep = EventPersistManagerBuilder.builder();
+        EventPersistManagerBuilder next = prePersistStep.withPostPersist(e -> {});
+        assertThat(next).isInstanceOf(EventPersistManagerBuilder.PostPersistStep.class);
+    }
+
+    @Test
+    @DisplayName("build() from PostPersistStep should invoke both consumers")
+    void shouldInvokeBothConsumersFromPostPersistStep() {
+        List<EntityPrePersist> preCaptured = new ArrayList<>();
+        List<EntityPostPersist> postCaptured = new ArrayList<>();
+        Jedi jedi = new Jedi("Yoda");
+
+        EventPersistManager manager = EventPersistManagerBuilder.builder()
+                .withPrePersist(preCaptured::add)
+                .withPostPersist(postCaptured::add)
+                .build();
+
+        manager.firePreEntity(jedi);
+        manager.firePostEntity(jedi);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(preCaptured).as("pre-persist consumer should have been called once").hasSize(1);
+            softly.assertThat(preCaptured.get(0).get()).as("pre-persist captured entity should match").isSameAs(jedi);
+            softly.assertThat(postCaptured).as("post-persist consumer should have been called once").hasSize(1);
+            softly.assertThat(postCaptured.get(0).get()).as("post-persist captured entity should match").isSameAs(jedi);
+        });
+    }
+
+    @Test
+    @DisplayName("withPrePersist() on PrePersistStep should return a new step without modifying the original")
+    void shouldBeImmutableOnPrePersistStep() {
+        Consumer<EntityPrePersist> firstConsumer = e -> {};
+        Consumer<EntityPrePersist> secondConsumer = e -> {};
+
+        EventPersistManagerBuilder.PrePersistStep original = EventPersistManagerBuilder.builder()
+                .withPrePersist(firstConsumer);
+        EventPersistManagerBuilder.PrePersistStep updated = original.withPrePersist(secondConsumer);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(original.prePersist())
+                    .as("original step should still hold the first consumer")
+                    .isSameAs(firstConsumer);
+            softly.assertThat(updated.prePersist())
+                    .as("updated step should hold the second consumer")
+                    .isSameAs(secondConsumer);
+            softly.assertThat(original).as("original and updated should be different instances").isNotSameAs(updated);
+        });
+    }
+
+    @Test
+    @DisplayName("withPrePersist() on PostPersistStep should return a new step without modifying the original")
+    void shouldBeImmutableOnPostPersistStepPrePersist() {
+        Consumer<EntityPrePersist> firstConsumer = e -> {};
+        Consumer<EntityPrePersist> secondConsumer = e -> {};
+        Consumer<EntityPostPersist> postConsumer = e -> {};
+
+        EventPersistManagerBuilder.PostPersistStep original = EventPersistManagerBuilder.builder()
+                .withPrePersist(firstConsumer)
+                .withPostPersist(postConsumer);
+        EventPersistManagerBuilder.PostPersistStep updated = original.withPrePersist(secondConsumer);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(original.prePersist())
+                    .as("original step should still hold the first pre-persist consumer")
+                    .isSameAs(firstConsumer);
+            softly.assertThat(updated.prePersist())
+                    .as("updated step should hold the second pre-persist consumer")
+                    .isSameAs(secondConsumer);
+            softly.assertThat(original.postPersist())
+                    .as("post-persist consumer should be unchanged in both")
+                    .isSameAs(updated.postPersist());
+        });
+    }
+
+    @Test
+    @DisplayName("withPostPersist() on PostPersistStep should return a new step without modifying the original")
+    void shouldBeImmutableOnPostPersistStepPostPersist() {
+        Consumer<EntityPostPersist> firstPostConsumer = e -> {};
+        Consumer<EntityPostPersist> secondPostConsumer = e -> {};
+
+        EventPersistManagerBuilder.PostPersistStep original = EventPersistManagerBuilder.builder()
+                .withPostPersist(firstPostConsumer);
+        EventPersistManagerBuilder.PostPersistStep updated = original.withPostPersist(secondPostConsumer);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(original.postPersist())
+                    .as("original step should still hold the first post-persist consumer")
+                    .isSameAs(firstPostConsumer);
+            softly.assertThat(updated.postPersist())
+                    .as("updated step should hold the second post-persist consumer")
+                    .isSameAs(secondPostConsumer);
+            softly.assertThat(original).as("original and updated should be different instances").isNotSameAs(updated);
+        });
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManagerTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/EventPersistManagerTest.java
@@ -14,15 +14,16 @@
  */
 package org.eclipse.jnosql.mapping.semistructured;
 
-import jakarta.enterprise.event.Event;
 import org.eclipse.jnosql.mapping.EntityPostPersist;
 import org.eclipse.jnosql.mapping.EntityPrePersist;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
@@ -30,21 +31,18 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class EventPersistManagerTest {
 
-
-    @InjectMocks
     private EventPersistManager subject;
 
+    @Mock
+    private Consumer<EntityPrePersist> entityPrePersistEvent;
 
     @Mock
-    private Event<EntityPrePersist> entityPrePersistEvent;
+    private Consumer<EntityPostPersist> entityPostPersistEvent;
 
-    @Mock
-    private Event<EntityPostPersist> entityPostPersistEvent;
-
-
-
-
-
+    @BeforeEach
+    void setUp() {
+        subject = new EventPersistManager(entityPrePersistEvent, entityPostPersistEvent);
+    }
 
     @Test
     void shouldFirePreEntity() {
@@ -52,7 +50,7 @@ class EventPersistManagerTest {
         jedi.name = "Luke";
         subject.firePreEntity(jedi);
         ArgumentCaptor<EntityPrePersist> captor = ArgumentCaptor.forClass(EntityPrePersist.class);
-        verify(entityPrePersistEvent).fire(captor.capture());
+        verify(entityPrePersistEvent).accept(captor.capture());
         EntityPrePersist value = captor.getValue();
         assertEquals(jedi, value.get());
     }
@@ -63,7 +61,7 @@ class EventPersistManagerTest {
         jedi.name = "Luke";
         subject.firePostEntity(jedi);
         ArgumentCaptor<EntityPostPersist> captor = ArgumentCaptor.forClass(EntityPostPersist.class);
-        verify(entityPostPersistEvent).fire(captor.capture());
+        verify(entityPostPersistEvent).accept(captor.capture());
         EntityPostPersist value = captor.getValue();
         assertEquals(jedi, value.get());
     }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredParameterBasedQueryTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/SemiStructuredParameterBasedQueryTest.java
@@ -80,6 +80,24 @@ class SemiStructuredParameterBasedQueryTest {
     }
 
     @Test
+    void shouldCreateQuerySingleParameterWithExplicitConverters() {
+        Map<String, ParamValue> params = Map.of("name", new ParamValue(Condition.EQUALS, "Ada", false));
+        var query = SemiStructuredParameterBasedQuery.INSTANCE
+                .toQuery(params, Collections.emptyList(), metadata, Converters.autoResolver());
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(query.limit()).isEqualTo(0L);
+            soft.assertThat(query.skip()).isEqualTo(0L);
+            soft.assertThat(query.name()).isEqualTo("Person");
+            soft.assertThat(query.sorts()).isEmpty();
+            soft.assertThat(query.condition()).isNotEmpty();
+            var condition = query.condition().orElseThrow();
+            soft.assertThat(condition.condition()).isEqualTo(Condition.EQUALS);
+            soft.assertThat(query.condition()).get().isEqualTo(CriteriaCondition.eq(Element.of("name", "Ada")));
+        });
+    }
+
+    @Test
     void shouldCreateQueryGreaterThan() {
         Map<String, ParamValue> params = Map.of("name", new ParamValue(Condition.GREATER_THAN, "Ada", false));
         var query = SemiStructuredParameterBasedQuery.INSTANCE.toQuery(params, Collections.emptyList(), metadata);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerBuilderTest.java
@@ -1,0 +1,472 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Maximillian Arruda
+ */
+package org.eclipse.jnosql.mapping.semistructured.repository;
+
+import jakarta.inject.Inject;
+import org.assertj.core.api.SoftAssertions;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.core.repository.InfrastructureOperatorProvider;
+import org.eclipse.jnosql.mapping.core.repository.RepositoryOperationProvider;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoriesMetadata;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.eclipse.jnosql.mapping.semistructured.MockProducer;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class SemistructuredRepositoryProducerBuilderTest {
+
+    // -----------------------------------------------------------------------
+    // Structural / immutability tests — pure unit tests, no CDI
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @ExtendWith(MockitoExtension.class)
+    @DisplayName("Builder structure and immutability (no CDI)")
+    class StructureTests {
+
+        @Mock
+        EntitiesMetadata entities;
+
+        @Mock
+        EntitiesMetadata otherEntities;
+
+        @Mock
+        RepositoriesMetadata repositories;
+
+        @Mock
+        RepositoriesMetadata otherRepositories;
+
+        @Mock
+        InfrastructureOperatorProvider infrastructure;
+
+        @Mock
+        InfrastructureOperatorProvider otherInfrastructure;
+
+        @Mock
+        RepositoryOperationProvider operations;
+
+        @Mock
+        RepositoryOperationProvider otherOperations;
+
+        @Test
+        @DisplayName("builder() should return an EntitiesStep instance")
+        void shouldReturnEntitiesStepFromBuilder() {
+            SemistructuredRepositoryProducerBuilder builder = SemistructuredRepositoryProducerBuilder.builder();
+            assertThat(builder).isInstanceOf(SemistructuredRepositoryProducerBuilder.EntitiesStep.class);
+        }
+
+        @Test
+        @DisplayName("withEntities() on EntitiesStep should return a new step without modifying the original")
+        void shouldBeImmutableOnEntitiesStep() {
+            SemistructuredRepositoryProducerBuilder.EntitiesStep original =
+                    SemistructuredRepositoryProducerBuilder.builder().withEntities(entities);
+            SemistructuredRepositoryProducerBuilder.EntitiesStep updated = original.withEntities(otherEntities);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.entities())
+                        .as("original step should still hold the first entities")
+                        .isSameAs(entities);
+                softly.assertThat(updated.entities())
+                        .as("updated step should hold the other entities")
+                        .isSameAs(otherEntities);
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withRepositories() on EntitiesStep should advance to RepositoriesStep")
+        void shouldAdvanceToRepositoriesStep() {
+            SemistructuredRepositoryProducerBuilder next =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories);
+            assertThat(next).isInstanceOf(SemistructuredRepositoryProducerBuilder.RepositoriesStep.class);
+        }
+
+        @Test
+        @DisplayName("withEntities() on RepositoriesStep should return a new EntitiesStep")
+        void shouldResetToEntitiesStepFromRepositoriesStep() {
+            SemistructuredRepositoryProducerBuilder.RepositoriesStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories);
+            SemistructuredRepositoryProducerBuilder.EntitiesStep reset = step.withEntities(otherEntities);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(reset).as("should be an EntitiesStep")
+                        .isInstanceOf(SemistructuredRepositoryProducerBuilder.EntitiesStep.class);
+                softly.assertThat(reset.entities())
+                        .as("reset step should hold the new entities")
+                        .isSameAs(otherEntities);
+            });
+        }
+
+        @Test
+        @DisplayName("withRepositories() on RepositoriesStep should return a new step without modifying the original")
+        void shouldBeImmutableOnRepositoriesStep() {
+            SemistructuredRepositoryProducerBuilder.RepositoriesStep original =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories);
+            SemistructuredRepositoryProducerBuilder.RepositoriesStep updated = original.withRepositories(otherRepositories);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.repositories())
+                        .as("original step should still hold the first repositories")
+                        .isSameAs(repositories);
+                softly.assertThat(updated.repositories())
+                        .as("updated step should hold the other repositories")
+                        .isSameAs(otherRepositories);
+                softly.assertThat(original.entities())
+                        .as("entities should be preserved in both")
+                        .isSameAs(updated.entities());
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withInfrastructure() on RepositoriesStep should advance to InfraStep")
+        void shouldAdvanceToInfraStep() {
+            SemistructuredRepositoryProducerBuilder next =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure);
+            assertThat(next).isInstanceOf(SemistructuredRepositoryProducerBuilder.InfraStep.class);
+        }
+
+        @Test
+        @DisplayName("withEntities() on InfraStep should reset to EntitiesStep")
+        void shouldResetToEntitiesStepFromInfraStep() {
+            SemistructuredRepositoryProducerBuilder.InfraStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure);
+            SemistructuredRepositoryProducerBuilder.EntitiesStep reset = step.withEntities(otherEntities);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(reset).as("should be an EntitiesStep")
+                        .isInstanceOf(SemistructuredRepositoryProducerBuilder.EntitiesStep.class);
+                softly.assertThat(reset.entities())
+                        .as("reset step should hold the new entities")
+                        .isSameAs(otherEntities);
+            });
+        }
+
+        @Test
+        @DisplayName("withRepositories() on InfraStep should reset to RepositoriesStep")
+        void shouldResetToRepositoriesStepFromInfraStep() {
+            SemistructuredRepositoryProducerBuilder.InfraStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure);
+            SemistructuredRepositoryProducerBuilder.RepositoriesStep reset = step.withRepositories(otherRepositories);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(reset).as("should be a RepositoriesStep")
+                        .isInstanceOf(SemistructuredRepositoryProducerBuilder.RepositoriesStep.class);
+                softly.assertThat(reset.repositories())
+                        .as("reset step should hold the new repositories")
+                        .isSameAs(otherRepositories);
+                softly.assertThat(reset.entities())
+                        .as("entities should be preserved")
+                        .isSameAs(entities);
+            });
+        }
+
+        @Test
+        @DisplayName("withInfrastructure() on InfraStep should return a new step without modifying the original")
+        void shouldBeImmutableOnInfraStep() {
+            SemistructuredRepositoryProducerBuilder.InfraStep original =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure);
+            SemistructuredRepositoryProducerBuilder.InfraStep updated = original.withInfrastructure(otherInfrastructure);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.infrastructure())
+                        .as("original step should still hold the first infrastructure")
+                        .isSameAs(infrastructure);
+                softly.assertThat(updated.infrastructure())
+                        .as("updated step should hold the other infrastructure")
+                        .isSameAs(otherInfrastructure);
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        @Test
+        @DisplayName("withOperations() on InfraStep should advance to OperationsStep")
+        void shouldAdvanceToOperationsStep() {
+            SemistructuredRepositoryProducerBuilder next =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure)
+                            .withOperations(operations);
+            assertThat(next).isInstanceOf(SemistructuredRepositoryProducerBuilder.OperationsStep.class);
+        }
+
+        @Test
+        @DisplayName("withEntities() on OperationsStep should reset to EntitiesStep")
+        void shouldResetToEntitiesStepFromOperationsStep() {
+            SemistructuredRepositoryProducerBuilder.OperationsStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure)
+                            .withOperations(operations);
+            SemistructuredRepositoryProducerBuilder.EntitiesStep reset = step.withEntities(otherEntities);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(reset).as("should be an EntitiesStep")
+                        .isInstanceOf(SemistructuredRepositoryProducerBuilder.EntitiesStep.class);
+                softly.assertThat(reset.entities())
+                        .as("reset step should hold the new entities")
+                        .isSameAs(otherEntities);
+            });
+        }
+
+        @Test
+        @DisplayName("withRepositories() on OperationsStep should reset to RepositoriesStep")
+        void shouldResetToRepositoriesStepFromOperationsStep() {
+            SemistructuredRepositoryProducerBuilder.OperationsStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure)
+                            .withOperations(operations);
+            SemistructuredRepositoryProducerBuilder.RepositoriesStep reset = step.withRepositories(otherRepositories);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(reset).as("should be a RepositoriesStep")
+                        .isInstanceOf(SemistructuredRepositoryProducerBuilder.RepositoriesStep.class);
+                softly.assertThat(reset.repositories())
+                        .as("reset step should hold the new repositories")
+                        .isSameAs(otherRepositories);
+                softly.assertThat(reset.entities())
+                        .as("entities should be preserved")
+                        .isSameAs(entities);
+            });
+        }
+
+        @Test
+        @DisplayName("withInfrastructure() on OperationsStep should reset to InfraStep")
+        void shouldResetToInfraStepFromOperationsStep() {
+            SemistructuredRepositoryProducerBuilder.OperationsStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure)
+                            .withOperations(operations);
+            SemistructuredRepositoryProducerBuilder.InfraStep reset = step.withInfrastructure(otherInfrastructure);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(reset).as("should be an InfraStep")
+                        .isInstanceOf(SemistructuredRepositoryProducerBuilder.InfraStep.class);
+                softly.assertThat(reset.infrastructure())
+                        .as("reset step should hold the new infrastructure")
+                        .isSameAs(otherInfrastructure);
+                softly.assertThat(reset.entities())
+                        .as("entities should be preserved")
+                        .isSameAs(entities);
+                softly.assertThat(reset.repositories())
+                        .as("repositories should be preserved")
+                        .isSameAs(repositories);
+            });
+        }
+
+        @Test
+        @DisplayName("withOperations() on OperationsStep should return a new step without modifying the original")
+        void shouldBeImmutableOnOperationsStep() {
+            SemistructuredRepositoryProducerBuilder.OperationsStep original =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure)
+                            .withOperations(operations);
+            SemistructuredRepositoryProducerBuilder.OperationsStep updated = original.withOperations(otherOperations);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(original.operations())
+                        .as("original step should still hold the first operations")
+                        .isSameAs(operations);
+                softly.assertThat(updated.operations())
+                        .as("updated step should hold the other operations")
+                        .isSameAs(otherOperations);
+                softly.assertThat(original).as("original and updated should be different instances")
+                        .isNotSameAs(updated);
+            });
+        }
+
+        // -------------------------------------------------------------------
+        // Null checks
+        // -------------------------------------------------------------------
+
+        @Test
+        @DisplayName("null entities should throw NullPointerException on withEntities() at EntitiesStep")
+        void shouldThrowOnNullEntitiesAtEntitiesStep() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> SemistructuredRepositoryProducerBuilder.builder().withEntities(null))
+                    .withMessage("entities is required");
+        }
+
+        @Test
+        @DisplayName("null repositories should throw NullPointerException on withRepositories()")
+        void shouldThrowOnNullRepositories() {
+            SemistructuredRepositoryProducerBuilder.EntitiesStep step =
+                    SemistructuredRepositoryProducerBuilder.builder().withEntities(entities);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withRepositories(null))
+                    .withMessage("repositories is required");
+        }
+
+        @Test
+        @DisplayName("null infrastructure should throw NullPointerException on withInfrastructure()")
+        void shouldThrowOnNullInfrastructure() {
+            SemistructuredRepositoryProducerBuilder.RepositoriesStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withInfrastructure(null))
+                    .withMessage("infrastructure is required");
+        }
+
+        @Test
+        @DisplayName("null operations should throw NullPointerException on withOperations()")
+        void shouldThrowOnNullOperations() {
+            SemistructuredRepositoryProducerBuilder.InfraStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withOperations(null))
+                    .withMessage("operations is required");
+        }
+
+        @Test
+        @DisplayName("null entities on RepositoriesStep.withEntities() should throw NullPointerException")
+        void shouldThrowOnNullEntitiesAtRepositoriesStep() {
+            SemistructuredRepositoryProducerBuilder.RepositoriesStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withEntities(null))
+                    .withMessage("entities is required");
+        }
+
+        @Test
+        @DisplayName("null entities on InfraStep.withEntities() should throw NullPointerException")
+        void shouldThrowOnNullEntitiesAtInfraStep() {
+            SemistructuredRepositoryProducerBuilder.InfraStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withEntities(null))
+                    .withMessage("entities is required");
+        }
+
+        @Test
+        @DisplayName("null entities on OperationsStep.withEntities() should throw NullPointerException")
+        void shouldThrowOnNullEntitiesAtOperationsStep() {
+            SemistructuredRepositoryProducerBuilder.OperationsStep step =
+                    SemistructuredRepositoryProducerBuilder.builder()
+                            .withEntities(entities)
+                            .withRepositories(repositories)
+                            .withInfrastructure(infrastructure)
+                            .withOperations(operations);
+            assertThatNullPointerException()
+                    .isThrownBy(() -> step.withEntities(null))
+                    .withMessage("entities is required");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Functional tests — uses CDI to get real dependencies
+    // -----------------------------------------------------------------------
+
+    @Nested
+    @EnableAutoWeld
+    @AddPackages(value = {Converters.class, EntityConverter.class})
+    @AddPackages(MockProducer.class)
+    @AddPackages(Reflections.class)
+    @AddExtensions({ReflectionEntityMetadataExtension.class})
+    @ExtendWith(MockitoExtension.class)
+    @DisplayName("Builder functional tests with real CDI dependencies")
+    class FunctionalTests {
+
+        @Inject
+        private EntitiesMetadata entities;
+
+        @Inject
+        private RepositoriesMetadata repositoriesMetadata;
+
+        @Inject
+        private InfrastructureOperatorProvider infrastructureOperatorProvider;
+
+        @Inject
+        private RepositoryOperationProvider repositoryOperationProvider;
+
+        @Test
+        @DisplayName("should build a SemistructuredRepositoryProducer with all dependencies")
+        void shouldBuildProducerWithAllDependencies() {
+            SemistructuredRepositoryProducer producer = SemistructuredRepositoryProducerBuilder.builder()
+                    .withEntities(entities)
+                    .withRepositories(repositoriesMetadata)
+                    .withInfrastructure(infrastructureOperatorProvider)
+                    .withOperations(repositoryOperationProvider)
+                    .build();
+
+            assertThat(producer).isNotNull()
+                    .isInstanceOf(SemistructuredRepositoryProducer.class);
+        }
+
+        @Test
+        @DisplayName("should build a SemistructuredRepositoryProducer usable outside CDI")
+        void shouldBuildProducerOutsideCDI() {
+            SemistructuredRepositoryProducer producer = SemistructuredRepositoryProducerBuilder.builder()
+                    .withEntities(entities)
+                    .withRepositories(repositoriesMetadata)
+                    .withInfrastructure(infrastructureOperatorProvider)
+                    .withOperations(repositoryOperationProvider)
+                    .build();
+
+            assertThat(producer).isNotNull();
+        }
+    }
+}


### PR DESCRIPTION
### 🎯 Objective
This Pull Request decouples the core metadata discovery and instantiation logic in `jnosql-mapping-reflection` from CDI. This allows the framework to be used in standalone Java SE applications or integrated with other IoC containers (like Spring or Guice) while maintaining full backward compatibility with CDI.
### 🚀 Key Changes
- **Metadata Scanning**: Introduced `ReflectionGroupEntityMetadataBuilder` to perform reflection-based scanning for entities, embeddables, and projections using `ClassScanner` and `ClassConverter` without requiring a CDI extension.
- **Entities Metadata**: Added `ReflectionEntitiesMetadataBuilder` for manual instantiation of `DefaultEntitiesMetadata`.
- **Repository Metadata**:
  - Refactored `ReflectionRepositoriesMetadata` to use a `Consumer<ProjectionFound>` observer pattern instead of CDI `Event<ProjectionFound>`.
  - Added `ReflectionRepositoriesMetadataBuilder` to facilitate IoC-agnostic repository registry creation.
- **Infrastructure Refactoring**: Updated `ReflectionRepositorySupplier` to handle projection discovery via functional interfaces.
- **Naming Convention**: New implementation classes and builders use the `Reflection` prefix to allow for future non-reflection based metadata implementations (e.g., APT).
### 🔄 Update (2026-03-13)
- Added `SemistructuredRepositoryProducerBuilder` in `jnosql-mapping-semistructured` to enable explicit producer setup outside CDI.
- Added `SemistructuredRepositoryProducerBuilderTest` and did a follow-up cleanup of builder comments.
### 🧪 Verification and Tests
- Added `ReflectionBuildersTest` to verify the correct behavior of all new builders outside a container.
- Ran the full suite of 323 existing tests in `jnosql-mapping-reflection` to ensure zero regressions for CDI users.
### ✅ Checklist
- [x] Code follows the project's coding style and conventions.
- [x] Unit tests for new features included.
- [x] License headers (EPL v1.0) and sign-off present.
