### PR TITLE
chore: update release version to 1.1.13

### DIFF
--- a/jnosql-communication/jnosql-communication-core/pom.xml
+++ b/jnosql-communication/jnosql-communication-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.communication</groupId>
         <artifactId>jnosql-communication</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-communication-core</artifactId>

--- a/jnosql-communication/jnosql-communication-key-value/pom.xml
+++ b/jnosql-communication/jnosql-communication-key-value/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.communication</groupId>
         <artifactId>jnosql-communication</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-communication-key-value</artifactId>

--- a/jnosql-communication/jnosql-communication-query/pom.xml
+++ b/jnosql-communication/jnosql-communication-query/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.communication</groupId>
         <artifactId>jnosql-communication</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-communication-query</artifactId>

--- a/jnosql-communication/jnosql-communication-semistructured/pom.xml
+++ b/jnosql-communication/jnosql-communication-semistructured/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.communication</groupId>
         <artifactId>jnosql-communication</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-communication-semistructured</artifactId>

--- a/jnosql-communication/pom.xml
+++ b/jnosql-communication/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.jnosql</groupId>
         <artifactId>jnosql-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <groupId>org.eclipse.jnosql.communication</groupId>

--- a/jnosql-mapping/jnosql-mapping-api-core/pom.xml
+++ b/jnosql-mapping/jnosql-mapping-api-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-mapping-api-core</artifactId>

--- a/jnosql-mapping/jnosql-mapping-column/pom.xml
+++ b/jnosql-mapping/jnosql-mapping-column/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
     
     <artifactId>jnosql-mapping-column</artifactId>

--- a/jnosql-mapping/jnosql-mapping-core/pom.xml
+++ b/jnosql-mapping/jnosql-mapping-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-mapping-core</artifactId>

--- a/jnosql-mapping/jnosql-mapping-document/pom.xml
+++ b/jnosql-mapping/jnosql-mapping-document/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-mapping-document</artifactId>

--- a/jnosql-mapping/jnosql-mapping-graph/pom.xml
+++ b/jnosql-mapping/jnosql-mapping-graph/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-mapping-graph</artifactId>

--- a/jnosql-mapping/jnosql-mapping-key-value/pom.xml
+++ b/jnosql-mapping/jnosql-mapping-key-value/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-mapping-key-value</artifactId>

--- a/jnosql-mapping/jnosql-mapping-reflection/pom.xml
+++ b/jnosql-mapping/jnosql-mapping-reflection/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
     <artifactId>jnosql-mapping-reflection</artifactId>

--- a/jnosql-mapping/jnosql-mapping-semistructured/pom.xml
+++ b/jnosql-mapping/jnosql-mapping-semistructured/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.jnosql.mapping</groupId>
         <artifactId>jnosql-mapping-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
     
     <artifactId>jnosql-mapping-semistructured</artifactId>

--- a/jnosql-mapping/pom.xml
+++ b/jnosql-mapping/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.jnosql</groupId>
         <artifactId>jnosql-parent</artifactId>
-        <version>1.1.13-SNAPSHOT</version>
+        <version>1.1.13</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.jnosql</groupId>
     <artifactId>jnosql-parent</artifactId>
-    <version>1.1.13-SNAPSHOT</version>
+    <version>1.1.13</version>
     <packaging>pom</packaging>
     <name>Eclipse JNoSQL</name>
     <description>The Eclipse JNoSQL is a framework to help developers create enterprise-grade applications using Java


### PR DESCRIPTION
This pull request updates the project version from `1.1.13-SNAPSHOT` to the official release version `1.1.13` across all Maven `pom.xml` files in the repository. This is a standard step when preparing for a release, ensuring all modules are aligned to the same stable version.

Version update for release:

* Updated the parent and module versions from `1.1.13-SNAPSHOT` to `1.1.13` in the following files:
  - Root `pom.xml`
  - `jnosql-communication/pom.xml` and all its submodules (`jnosql-communication-core`, `jnosql-communication-key-value`, `jnosql-communication-query`, `jnosql-communication-semistructured`) [[1]](diffhunk://#diff-e174210bb543423aa6365016b3755f12933c7c0fa83e5493cfdc4d33923eedf8L26-R26) [[2]](diffhunk://#diff-1216b6cbc393123920baf6f266c8a384ba8a12a5fe50313539a0634a20fcbaf0L25-R25) [[3]](diffhunk://#diff-327c5fa56a3f37a54a529b41394c25d39f2741ead7514c576a74b4d448b5c64fL26-R26) [[4]](diffhunk://#diff-13d48d3a35add5fa7dc1aa39538d58d376767e0a9483fd82febbb284254c66c8L20-R20) [[5]](diffhunk://#diff-0b863361a8e970e4e7c82fa2daa0c0718f18ad047d3c8872006b0a0172878f28L20-R20)
  - `jnosql-mapping/pom.xml` and all its submodules (`jnosql-mapping-api-core`, `jnosql-mapping-column`, `jnosql-mapping-core`, `jnosql-mapping-document`, `jnosql-mapping-graph`, `jnosql-mapping-key-value`, `jnosql-mapping-reflection`, `jnosql-mapping-semistructured`) [[1]](diffhunk://#diff-fda7958e24e2eda24f50ca51d8bdf8077f018e883f9a1a847e8dfbdbe5db197eL25-R25) [[2]](diffhunk://#diff-6355045f3495cab3cc0844d79be0aa68d129e9180eec18b0e0dd3c5e4012db2fL24-R24) [[3]](diffhunk://#diff-ff5806ac0fd9f880c52a631f1b3e60ad20e268b9c2f776d95de31fa1d7f7600aL22-R22) [[4]](diffhunk://#diff-e65145d8a0630a9ea792cf3b6ecc2493a908470985c6eb8480b8d946ba436b4aL24-R24) [[5]](diffhunk://#diff-96318cfbbb4db53d843c0340f66479436c54e1a7096b4d7417cf6d7bebceb998L23-R23) [[6]](diffhunk://#diff-14199d1b407e01d5ca12e8a0d009a23c4b82f8840c2af03680c6cadf78460c74L23-R23) [[7]](diffhunk://#diff-1b9fb1ea215b1240e20aa8ec73a39949de67649f4cb254c29bc5d8d3425f9aceL23-R23) [[8]](diffhunk://#diff-d76b6b0b7e95a2122718d80afdbe0bfbbf30ac4926b71d7429d1651955c7b2e8L24-R24) [[9]](diffhunk://#diff-edfa85d413bcecc13593f67f32b67224ba5d4a9844a1c179ddd9504cd8b2a0edL22-R22)