### PR TITLE
Include LazyPagination at the Repository Page

### DIFF
--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
@@ -16,6 +16,36 @@ package org.eclipse.jnosql.mapping.core;
 
 import java.util.function.LongSupplier;
 
+
+/**
+ * A {@link LongSupplier} implementation that lazily computes a {@code long}
+ * value once and caches the result for subsequent accesses.
+ *
+ * <p>The wrapped supplier is only invoked during the first call to
+ * {@link #getAsLong()}. After the value is computed, the cached value is
+ * returned for all future invocations.</p>
+ *
+ * <p>This implementation is thread-safe and guarantees that the delegate
+ * supplier is executed at most once.</p>
+ *
+ * <p>This utility is useful for expensive operations such as database
+ * aggregation queries, count operations, or remote service calls that should
+ * be deferred until explicitly needed.</p>
+ *
+ * <pre>{@code
+ * LongSupplier supplier = new LazyLongSupplier(
+ *         () -> repository.count()
+ * );
+ *
+ * // Count query executes here
+ * long total = supplier.getAsLong();
+ *
+ * // Cached value reused
+ * long cached = supplier.getAsLong();
+ * }</pre>
+ *
+ * @since 1.0
+ */
 final class LazyLongSupplier implements LongSupplier {
 
     private final LongSupplier delegate;
@@ -23,7 +53,7 @@ final class LazyLongSupplier implements LongSupplier {
     private volatile boolean loaded;
     private long value;
 
-    public LazyLongSupplier(LongSupplier delegate) {
+    private LazyLongSupplier(LongSupplier delegate) {
         this.delegate = delegate;
     }
 
@@ -40,5 +70,9 @@ final class LazyLongSupplier implements LongSupplier {
         }
 
         return value;
+    }
+
+    static LongSupplier of(LongSupplier delegate) {
+        return new LazyLongSupplier(delegate);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
@@ -43,8 +43,6 @@ import java.util.function.LongSupplier;
  * // Cached value reused
  * long cached = supplier.getAsLong();
  * }</pre>
- *
- * @since 1.0
  */
 final class LazyLongSupplier implements LongSupplier {
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
@@ -70,7 +70,7 @@ final class LazyLongSupplier implements LongSupplier {
         return value;
     }
 
-    static LongSupplier of(LongSupplier delegate) {
+    static LazyLongSupplier of(LongSupplier delegate) {
         return new LazyLongSupplier(delegate);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
@@ -14,5 +14,31 @@
  */
 package org.eclipse.jnosql.mapping.core;
 
-public class LazyLongSupplier {
+import java.util.function.LongSupplier;
+
+final class LazyLongSupplier implements LongSupplier {
+
+    private final LongSupplier delegate;
+
+    private volatile boolean loaded;
+    private long value;
+
+    public LazyLongSupplier(LongSupplier delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public long getAsLong() {
+
+        if (!loaded) {
+            synchronized (this) {
+                if (!loaded) {
+                    value = delegate.getAsLong();
+                    loaded = true;
+                }
+            }
+        }
+
+        return value;
+    }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.core;
+
+public class LazyLongSupplier {
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
@@ -49,7 +49,10 @@ final class LazyLongSupplier implements LongSupplier {
     private final LongSupplier delegate;
 
     private volatile boolean loaded;
+
     private long value;
+
+    private RuntimeException failure;
 
     private LazyLongSupplier(LongSupplier delegate) {
         this.delegate = delegate;
@@ -61,10 +64,19 @@ final class LazyLongSupplier implements LongSupplier {
         if (!loaded) {
             synchronized (this) {
                 if (!loaded) {
-                    value = delegate.getAsLong();
-                    loaded = true;
+                    try {
+                        value = delegate.getAsLong();
+                    } catch (RuntimeException exception) {
+                        failure = exception;
+                    } finally {
+                        loaded = true;
+                    }
                 }
             }
+        }
+
+        if (failure != null) {
+            throw failure;
         }
 
         return value;

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -95,7 +95,15 @@ public class NoSQLPage<T> implements Page<T> {
     public PageRequest nextPageRequest() {
 
         if (hasTotals() && !hasNext()) {
-            throw new NoSuchElementException("No next page available");
+            throw new NoSuchElementException(
+                    String.format(
+                            "Unable to navigate to next page. " +
+                                    "Current page: %d, page size: %d, total pages: %d",
+                            this.pageRequest.page(),
+                            this.pageRequest.size(),
+                            totalPages()
+                    )
+            );
         }
         return PageRequest.ofPage(this.pageRequest.page() + 1, this.pageRequest.size(), this.pageRequest.requestTotal());
     }
@@ -103,7 +111,24 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public PageRequest previousPageRequest() {
-        return PageRequest.ofPage(this.pageRequest.page() - 1, this.pageRequest.size(), this.pageRequest.requestTotal());
+        if (!hasPrevious()) {
+
+            throw new NoSuchElementException(
+                    String.format(
+                            "Unable to navigate to previous page. " +
+                                    "Current page: %d, page size: %d. " +
+                                    "Page numbers start at 1.",
+                            this.pageRequest.page(),
+                            this.pageRequest.size()
+                    )
+            );
+        }
+
+        return PageRequest.ofPage(
+                this.pageRequest.page() - 1,
+                this.pageRequest.size(),
+                this.pageRequest.requestTotal()
+        );
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -172,13 +172,16 @@ public class NoSQLPage<T> implements Page<T> {
                 '}';
     }
 
+
     /**
-     * Creates a {@link  Page} implementation from entities and a PageRequest
-     * @param entities the entities
-     * @param pageRequest the PageRequest
-     * @param totalSupplier the total supplier
-     * @return a {@link Page} instance
-     * @param <T> the entity type
+     * Creates a pageable representation of a given list of entities with the provided page request and total supplier.
+     *
+     * @param entities the list of entities to include in the page; must not be null
+     * @param pageRequest the page request specifying pagination details; must not be null
+     * @param totalSupplier a supplier to lazily calculate the total number of elements; must not be null
+     * @param <T> the type of the elements in the page
+     * @return a new {@code Page} instance containing the specified entities, page request, and total elements supplier
+     * @throws NullPointerException if any of the provided parameters is null
      */
     public static <T> Page<T> of(List<T> entities, PageRequest pageRequest, LongSupplier totalSupplier) {
         Objects.requireNonNull(entities, "entities is required");

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -151,6 +151,20 @@ public class NoSQLPage<T> implements Page<T> {
         return new NoSQLPage<>(entities, pageRequest, LazyLongSupplier.of(totalSupplier));
     }
 
+    /**
+     * Creates a {@link Page} instance based on the provided entities and page request.
+     * The created page does not support total elements calculation and will throw
+     * an {@link UnsupportedOperationException} if an attempt is made to access total elements.
+     *
+     * @param <T> the type of entity in the page
+     * @param entities the list of entities to populate the page; must not be null
+     * @param pageRequest the pagination details, including page number and size; must not be null
+     * @return a {@link Page} containing the provided entities and pagination details
+     * @throws NullPointerException if entities or pageRequest is null
+     * @deprecated This method is deprecated and may be removed in future versions,
+     * as it does not support total elements computation for NoSQL databases.
+     */
+    @Deprecated
     public static <T> Page<T> of(List<T> entities, PageRequest pageRequest) {
         Objects.requireNonNull(entities, "entities is required");
         Objects.requireNonNull(pageRequest, "pageRequest is required");

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 /**
  * A JNoSQL implementation of {@link  Page}
@@ -33,6 +35,8 @@ public class NoSQLPage<T> implements Page<T> {
     private final List<T> entities;
 
     private final PageRequest pageRequest;
+
+    private final LongSupplier totalSupplier;
 
     private NoSQLPage(List<T> entities, PageRequest pageRequest) {
         this.entities = entities;

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -38,9 +38,10 @@ public class NoSQLPage<T> implements Page<T> {
 
     private final LongSupplier totalSupplier;
 
-    private NoSQLPage(List<T> entities, PageRequest pageRequest) {
+    private NoSQLPage(List<T> entities, PageRequest pageRequest, LongSupplier totalSupplier) {
         this.entities = entities;
         this.pageRequest = pageRequest;
+        this.totalSupplier = totalSupplier;
     }
 
     @Override
@@ -135,13 +136,14 @@ public class NoSQLPage<T> implements Page<T> {
      * Creates a {@link  Page} implementation from entities and a PageRequest
      * @param entities the entities
      * @param pageRequest the PageRequest
+     * @param totalSupplier the total supplier
      * @return a {@link Page} instance
      * @param <T> the entity type
      */
-    public static <T> Page<T> of(List<T> entities, PageRequest pageRequest) {
+    public static <T> Page<T> of(List<T> entities, PageRequest pageRequest, LongSupplier totalSupplier) {
         Objects.requireNonNull(entities, "entities is required");
         Objects.requireNonNull(pageRequest, "pageRequest is required");
-        return new NoSQLPage<>(entities, pageRequest);
+        return new NoSQLPage<>(entities, pageRequest, LazyLongSupplier.of(totalSupplier));
     }
 
     /**

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -72,12 +72,12 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public boolean hasNext() {
-      return hasContent() && this.entities.size() == this.pageRequest.size();
+        return hasTotals() && this.pageRequest.page() < totalPages();
     }
 
     @Override
     public boolean hasPrevious() {
-        return hasContent();
+        return this.pageRequest.page() > 1;
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -151,6 +151,14 @@ public class NoSQLPage<T> implements Page<T> {
         return new NoSQLPage<>(entities, pageRequest, LazyLongSupplier.of(totalSupplier));
     }
 
+    public static <T> Page<T> of(List<T> entities, PageRequest pageRequest) {
+        Objects.requireNonNull(entities, "entities is required");
+        Objects.requireNonNull(pageRequest, "pageRequest is required");
+        return new NoSQLPage<>(entities, pageRequest, LazyLongSupplier.of(() -> {
+            throw new UnsupportedOperationException("JNoSQL has no support for this feature yet");
+        }));
+    }
+
     /**
      * Create skip formula from pageRequest instance
      * @param pageRequest the pageRequest

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -46,7 +46,7 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public long totalElements() {
-        throw new UnsupportedOperationException("JNoSQL has no support for this feature yet");
+        return totalSupplier.getAsLong();
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -187,28 +187,6 @@ public class NoSQLPage<T> implements Page<T> {
     }
 
     /**
-     * Creates a {@link Page} instance based on the provided entities and page request.
-     * The created page does not support total elements calculation and will throw
-     * an {@link UnsupportedOperationException} if an attempt is made to access total elements.
-     *
-     * @param <T> the type of entity in the page
-     * @param entities the list of entities to populate the page; must not be null
-     * @param pageRequest the pagination details, including page number and size; must not be null
-     * @return a {@link Page} containing the provided entities and pagination details
-     * @throws NullPointerException if entities or pageRequest is null
-     * @deprecated This method is deprecated and may be removed in future versions,
-     * as it does not support total elements computation for NoSQL databases.
-     */
-    @Deprecated
-    public static <T> Page<T> of(List<T> entities, PageRequest pageRequest) {
-        Objects.requireNonNull(entities, "entities is required");
-        Objects.requireNonNull(pageRequest, "pageRequest is required");
-        return new NoSQLPage<>(entities, pageRequest, LazyLongSupplier.of(() -> {
-            throw new UnsupportedOperationException("JNoSQL has no support for this feature yet");
-        }));
-    }
-
-    /**
      * Create skip formula from pageRequest instance
      * @param pageRequest the pageRequest
      * @param <T> the entity type

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -72,7 +72,11 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public boolean hasNext() {
-        return hasTotals() && this.pageRequest.page() < totalPages();
+        if (hasTotals()) {
+            return this.pageRequest.page() < totalPages();
+        }
+
+        return hasContent() && this.entities.size() == this.pageRequest.size();
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -99,7 +99,12 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public boolean hasTotals() {
-        throw new UnsupportedOperationException("Eclipse JNoSQL has no support for this feature hasTotals");
+        try {
+            totalSupplier.getAsLong();
+            return true;
+        } catch (UnsupportedOperationException exception) {
+            return false;
+        }
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.LongSupplier;
-import java.util.function.Supplier;
 
 /**
  * A JNoSQL implementation of {@link  Page}

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -51,7 +51,8 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public long totalPages() {
-        throw new UnsupportedOperationException("JNoSQL has no support for this feature yet");
+        long totalElements = totalElements();
+        return (long) Math.ceil((double) totalElements / pageRequest.size());
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -21,6 +21,7 @@ import jakarta.data.page.PageRequest;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -92,6 +93,10 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public PageRequest nextPageRequest() {
+
+        if (hasTotals() && !hasNext()) {
+            throw new NoSuchElementException("No next page available");
+        }
         return PageRequest.ofPage(this.pageRequest.page() + 1, this.pageRequest.size(), this.pageRequest.requestTotal());
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturn.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturn.java
@@ -21,6 +21,7 @@ import org.eclipse.jnosql.mapping.PreparedStatement;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 /**
@@ -35,8 +36,8 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
     private final Supplier<String> querySupplier;
     private final Supplier<Map<String, Object>> paramsSupplier;
     private final Class<?> returnType;
-
     private final String methodName;
+    private final LongSupplier totalSupplier;
 
     private DynamicQueryMethodReturn(Object[] args, Class<?> typeClass,
                                      Function<String,
@@ -46,7 +47,8 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
                                      Supplier<String> querySupplier,
                                      Supplier<Map<String, Object>> paramsSupplier,
                                      Class<?> returnType,
-                                     String methodName) {
+                                     String methodName,
+                                     LongSupplier totalSupplier) {
         this.querySupplier = querySupplier;
         this.args = args;
         this.typeClass = typeClass;
@@ -56,6 +58,7 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
         this.paramsSupplier = paramsSupplier;
         this.returnType = returnType;
         this.methodName = methodName;
+        this.totalSupplier = totalSupplier;
     }
 
     String querySupplier() {
@@ -124,6 +127,7 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
         private Class<?> returnType;
 
         private String methodName;
+        private LongSupplier totalSupplier;
 
         private DynamicQueryMethodReturnBuilder() {
         }
@@ -175,6 +179,11 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
             return this;
         }
 
+        public DynamicQueryMethodReturnBuilder<T> totalSupplier(LongSupplier totalSupplier) {
+            this.totalSupplier = totalSupplier;
+            return this;
+        }
+
         public DynamicQueryMethodReturn<T> build() {
             Objects.requireNonNull(typeClass, "typeClass is required");
             Objects.requireNonNull(prepareConverter, "prepareConverter is required");
@@ -183,6 +192,7 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
             Objects.requireNonNull(queryMapper, "queryMapper is required");
             Objects.requireNonNull(returnType, "returnType is required");
             Objects.requireNonNull(methodName, "methodName is required");
+            Objects.requireNonNull(totalSupplier, "totalSupplier is required");
             return new DynamicQueryMethodReturn<>(args,
                     typeClass,
                     prepareConverter,
@@ -191,7 +201,8 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
                     querySupplier,
                     paramsSupplier,
                     returnType,
-                    methodName);
+                    methodName,
+                    totalSupplier);
         }
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturn.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturn.java
@@ -97,6 +97,10 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
         return queryMapper;
     }
 
+    LongSupplier totalSupplier() {
+        return totalSupplier;
+    }
+
     boolean hasPagination() {
         return pageRequest != null;
     }

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturn.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturn.java
@@ -21,7 +21,9 @@ import jakarta.data.page.PageRequest;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -244,7 +246,7 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
 
         private Function<PageRequest, Stream<T>> streamPagination;
 
-        private Function<PageRequest, Page<T>> page;
+        private BiFunction<PageRequest, LongSupplier, Page<T>> page;
 
         private String methodName;
 
@@ -321,7 +323,7 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
          * @param page the page
          * @return the builder instance
          */
-        public DefaultDynamicReturnBuilder page(Function<PageRequest, Page<T>> page) {
+        public DefaultDynamicReturnBuilder page(BiFunction<PageRequest, LongSupplier, Page<T>> page) {
             this.page = page;
             return this;
         }

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturn.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturn.java
@@ -358,6 +358,7 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
                 requireNonNull(singleResultPagination, "singleResultPagination is required when pagination is not null");
                 requireNonNull(streamPagination, "listPagination is required when pagination is not null");
                 requireNonNull(page, "page is required when pagination is not null");
+                requireNonNull(totalSupplier, "totalSupplier is required when pagination is not null");
             }
 
             return new DynamicReturn(classSource, singleResult, result,

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturn.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturn.java
@@ -50,11 +50,13 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
 
     private final Function<PageRequest, Stream<T>> streamPagination;
 
-    private final Function<PageRequest, Page<T>> page;
+    private final BiFunction<PageRequest, LongSupplier, Page<T>> page;
 
     private final String methodName;
 
     private final Class<?> returnType;
+
+    private final LongSupplier totalSupplier;
 
     /**
      * A predicate to check it the object is instance of {@link PageRequest}
@@ -140,9 +142,10 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
                           Supplier<Stream<T>> result, PageRequest pageRequest,
                           Function<PageRequest, Optional<T>> singleResultPagination,
                           Function<PageRequest, Stream<T>> streamPagination,
-                          Function<PageRequest, Page<T>> page,
+                          BiFunction<PageRequest, LongSupplier, Page<T>> page,
                           String methodName,
-                          Class<?> returnType) {
+                          Class<?> returnType,
+                          LongSupplier totalSupplier) {
         this.classSource = classSource;
         this.singleResult = singleResult;
         this.result = result;
@@ -152,6 +155,7 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
         this.page = page;
         this.methodName = methodName;
         this.returnType = returnType;
+        this.totalSupplier = totalSupplier;
     }
 
     /**
@@ -206,7 +210,7 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
      * @return the page
      */
     public Page<T> getPage() {
-        return page.apply(pageRequest);
+        return page.apply(pageRequest, totalSupplier);
     }
 
     /**
@@ -251,6 +255,8 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
         private String methodName;
 
         private Class<?> returnType;
+
+        private LongSupplier totalSupplier;
 
         private DefaultDynamicReturnBuilder() {
         }
@@ -328,6 +334,11 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
             return this;
         }
 
+        public DefaultDynamicReturnBuilder totalSupplier(LongSupplier totalSupplier) {
+            this.totalSupplier = totalSupplier;
+            return this;
+        }
+
         /**
          * Creates a {@link DynamicReturn} from the parameters, all fields are required
          *
@@ -342,6 +353,7 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
             requireNonNull(methodName, "the method name is required");
             requireNonNull(returnType, "the return type is required");
 
+
             if (pageRequest != null) {
                 requireNonNull(singleResultPagination, "singleResultPagination is required when pagination is not null");
                 requireNonNull(streamPagination, "listPagination is required when pagination is not null");
@@ -349,7 +361,8 @@ public final class DynamicReturn<T> implements MethodDynamicExecutable {
             }
 
             return new DynamicReturn(classSource, singleResult, result,
-                    pageRequest, singleResultPagination, streamPagination, page, methodName, returnType);
+                    pageRequest, singleResultPagination, streamPagination, page, methodName, returnType,
+                    totalSupplier);
         }
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
@@ -102,7 +102,7 @@ public enum DynamicReturnConverter {
                 .singleResultPagination(p -> prepare.singleResult().map(dynamicQueryMethod.queryMapper()))
                 .page((p, l) -> {
                     Stream<?> entities = prepare.result().map(dynamicQueryMethod.queryMapper());
-                    return NoSQLPage.of(entities.toList(), p, l);
+                    return NoSQLPage.of(entities.toList(), (PageRequest) p, (LongSupplier) l);
                 }).build();
 
         return convert(dynamicReturn);

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
@@ -100,6 +100,7 @@ public enum DynamicReturnConverter {
                 .pagination(pageRequest)
                 .streamPagination(p -> prepare.result().map(dynamicQueryMethod.queryMapper()))
                 .singleResultPagination(p -> prepare.singleResult().map(dynamicQueryMethod.queryMapper()))
+                .totalSupplier(dynamicQueryMethod.totalSupplier())
                 .page((p, l) -> {
                     Stream<?> entities = prepare.result().map(dynamicQueryMethod.queryMapper());
                     return NoSQLPage.of(entities.toList(), (PageRequest) p, (LongSupplier) l);

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
@@ -99,9 +99,9 @@ public enum DynamicReturnConverter {
                 .pagination(pageRequest)
                 .streamPagination(p -> prepare.result().map(dynamicQueryMethod.queryMapper()))
                 .singleResultPagination(p -> prepare.singleResult().map(dynamicQueryMethod.queryMapper()))
-                .page(p -> {
+                .page((p, l) -> {
                     Stream<?> entities = prepare.result().map(dynamicQueryMethod.queryMapper());
-                    return NoSQLPage.of(entities.toList(), (PageRequest) p);
+                    return NoSQLPage.of(entities.toList(), (PageRequest) p, l);
                 }).build();
 
         return convert(dynamicReturn);

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import java.util.stream.Stream;
 
 /**
@@ -101,7 +102,7 @@ public enum DynamicReturnConverter {
                 .singleResultPagination(p -> prepare.singleResult().map(dynamicQueryMethod.queryMapper()))
                 .page((p, l) -> {
                     Stream<?> entities = prepare.result().map(dynamicQueryMethod.queryMapper());
-                    return NoSQLPage.of(entities.toList(), (PageRequest) p, l);
+                    return NoSQLPage.of(entities.toList(), p, l);
                 }).build();
 
         return convert(dynamicReturn);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
@@ -1,7 +1,149 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
 package org.eclipse.jnosql.mapping.core;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class LazyLongSupplierTest {
 
+    @Nested
+    @DisplayName("getAsLong")
+    class GetAsLong {
+
+        @Test
+        @DisplayName("should load value lazily only once")
+        void shouldLoadValueLazilyOnlyOnce() throws Exception {
+
+            // given
+            AtomicInteger counter = new AtomicInteger();
+
+            LongSupplier delegate = () -> {
+                counter.incrementAndGet();
+                return 42L;
+            };
+
+            LazyLongSupplier supplier = LazyLongSupplier.of(delegate);
+
+            // when
+            long first = supplier.getAsLong();
+            long second = supplier.getAsLong();
+            long third = supplier.getAsLong();
+
+            // then
+            assertThat(first).isEqualTo(42L);
+            assertThat(second).isEqualTo(42L);
+            assertThat(third).isEqualTo(42L);
+            assertThat(counter.get()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("should not execute supplier before first access")
+        void shouldNotExecuteSupplierBeforeFirstAccess() {
+
+            // given
+            AtomicInteger counter = new AtomicInteger();
+
+            LongSupplier delegate = () -> {
+                counter.incrementAndGet();
+                return 10L;
+            };
+
+            new LazyLongSupplier(delegate);
+
+            // then
+            assertThat(counter.get()).isZero();
+        }
+
+        @Test
+        @DisplayName("should cache computed value")
+        void shouldCacheComputedValue() {
+
+            // given
+            AtomicInteger counter = new AtomicInteger();
+
+            LongSupplier delegate = () -> {
+                counter.incrementAndGet();
+                return counter.get();
+            };
+
+            LazyLongSupplier supplier = new LazyLongSupplier(delegate);
+
+            // when
+            long first = supplier.getAsLong();
+            long second = supplier.getAsLong();
+
+            // then
+            assertThat(first).isEqualTo(1L);
+            assertThat(second).isEqualTo(1L);
+            assertThat(counter.get()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("should execute supplier only once under concurrent access")
+        void shouldExecuteSupplierOnlyOnceUnderConcurrentAccess() throws Exception {
+
+            // given
+            AtomicInteger counter = new AtomicInteger();
+
+            LongSupplier delegate = () -> {
+                counter.incrementAndGet();
+
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ignored) {
+                }
+
+                return 99L;
+            };
+
+            LazyLongSupplier supplier = new LazyLongSupplier(delegate);
+
+            var executor = Executors.newFixedThreadPool(10);
+            CountDownLatch latch = new CountDownLatch(1);
+
+            // when
+            Future<Long>[] futures = new Future[10];
+
+            for (int index = 0; index < futures.length; index++) {
+
+                futures[index] = executor.submit(() -> {
+                    latch.await();
+                    return supplier.getAsLong();
+                });
+            }
+
+            latch.countDown();
+
+            // then
+            for (Future<Long> future : futures) {
+                assertThat(future.get()).isEqualTo(99L);
+            }
+
+            assertThat(counter.get()).isEqualTo(1);
+
+            executor.shutdown();
+        }
+    }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
@@ -1,0 +1,7 @@
+package org.eclipse.jnosql.mapping.core;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LazyLongSupplierTest {
+
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 class LazyLongSupplierTest {
 
@@ -139,6 +140,124 @@ class LazyLongSupplierTest {
             // then
             for (Future<Long> future : futures) {
                 assertThat(future.get()).isEqualTo(99L);
+            }
+
+            assertThat(counter.get()).isEqualTo(1);
+
+            executor.shutdown();
+        }
+    }
+
+    @Nested
+    @DisplayName("error handling")
+    class ErrorHandling {
+
+        @Test
+        @DisplayName("should cache unsupported operation exception")
+        void shouldCacheUnsupportedOperationException() {
+
+            // given
+            AtomicInteger counter = new AtomicInteger();
+
+            LongSupplier delegate = () -> {
+                counter.incrementAndGet();
+                throw new UnsupportedOperationException("Totals are not supported");
+            };
+
+            LazyLongSupplier supplier = (LazyLongSupplier)
+                    LazyLongSupplier.of(delegate);
+
+            // when
+            Throwable first = catchThrowable(supplier::getAsLong);
+            Throwable second = catchThrowable(supplier::getAsLong);
+
+            // then
+            assertThat(first)
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessage("Totals are not supported");
+
+            assertThat(second)
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessage("Totals are not supported");
+
+            assertThat(counter.get()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("should cache runtime exception")
+        void shouldCacheRuntimeException() {
+
+            // given
+            AtomicInteger counter = new AtomicInteger();
+
+            LongSupplier delegate = () -> {
+                counter.incrementAndGet();
+                throw new IllegalStateException("Database failure");
+            };
+
+            LazyLongSupplier supplier = (LazyLongSupplier)
+                    LazyLongSupplier.of(delegate);
+
+            // when
+            Throwable first = catchThrowable(supplier::getAsLong);
+            Throwable second = catchThrowable(supplier::getAsLong);
+
+            // then
+            assertThat(first)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Database failure");
+
+            assertThat(second)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Database failure");
+
+            assertThat(counter.get()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("should execute supplier only once when exception happens concurrently")
+        void shouldExecuteSupplierOnlyOnceWhenExceptionHappensConcurrently() throws Exception {
+
+            // given
+            AtomicInteger counter = new AtomicInteger();
+
+            LongSupplier delegate = () -> {
+                counter.incrementAndGet();
+
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ignored) {
+                }
+
+                throw new UnsupportedOperationException("Totals unsupported");
+            };
+
+            LazyLongSupplier supplier = (LazyLongSupplier)
+                    LazyLongSupplier.of(delegate);
+
+            var executor = Executors.newFixedThreadPool(10);
+
+            CountDownLatch latch = new CountDownLatch(1);
+
+            Future<Throwable>[] futures = new Future[10];
+
+            // when
+            for (int index = 0; index < futures.length; index++) {
+
+                futures[index] = executor.submit(() -> {
+                    latch.await();
+                    return catchThrowable(supplier::getAsLong);
+                });
+            }
+
+            latch.countDown();
+
+            // then
+            for (Future<Throwable> future : futures) {
+
+                assertThat(future.get())
+                        .isInstanceOf(UnsupportedOperationException.class)
+                        .hasMessage("Totals unsupported");
             }
 
             assertThat(counter.get()).isEqualTo(1);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
@@ -70,7 +70,7 @@ class LazyLongSupplierTest {
                 return 10L;
             };
 
-            new LazyLongSupplier(delegate);
+            LazyLongSupplier.of(delegate);
 
             // then
             assertThat(counter.get()).isZero();
@@ -88,7 +88,7 @@ class LazyLongSupplierTest {
                 return counter.get();
             };
 
-            LazyLongSupplier supplier = new LazyLongSupplier(delegate);
+            LazyLongSupplier supplier = LazyLongSupplier.of(delegate);
 
             // when
             long first = supplier.getAsLong();
@@ -118,7 +118,7 @@ class LazyLongSupplierTest {
                 return 99L;
             };
 
-            LazyLongSupplier supplier = new LazyLongSupplier(delegate);
+            LazyLongSupplier supplier = LazyLongSupplier.of(delegate);
 
             var executor = Executors.newFixedThreadPool(10);
             CountDownLatch latch = new CountDownLatch(1);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
@@ -208,7 +208,11 @@ class NoSQLPageTest {
 
             Page<Person> page = NoSQLPage.of(
                     people(),
-                    PageRequest.ofPage(1).size(1)
+                    PageRequest.ofPage(1).size(1),
+                    () -> {
+                        throw new UnsupportedOperationException(
+                                "JNoSQL has no support for this feature yet");
+                    }
             );
 
             assertThat(page.hasNext()).isTrue();
@@ -458,7 +462,11 @@ class NoSQLPageTest {
     private static Page<Person> page(long page) {
         return NoSQLPage.of(
                 people(),
-                PageRequest.ofPage(page)
+                PageRequest.ofPage(page),
+                () -> {
+                    throw new UnsupportedOperationException(
+                            "JNoSQL has no support for this feature yet");
+                }
         );
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
@@ -18,170 +18,269 @@ import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import org.assertj.core.api.SoftAssertions;
 import org.eclipse.jnosql.mapping.core.entities.Person;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NoSQLPageTest {
 
-    @Test
-    void shouldReturnErrorWhenNull() {
-        assertThrows(NullPointerException.class, ()->
-                NoSQLPage.of(Collections.emptyList(), null));
 
-        assertThrows(NullPointerException.class, ()->
-                NoSQLPage.of(null, PageRequest.ofPage(2)));
+    @Nested
+    @DisplayName("When creating a page")
+    class WhenCreatePage {
+
+        @Test
+        @DisplayName("should reject null page request")
+        void shouldRejectNullPageRequest() {
+
+            assertThatThrownBy(() ->
+                    NoSQLPage.of(Collections.emptyList(), null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("pageRequest is required");
+        }
+
+        @Test
+        @DisplayName("should reject null entities")
+        void shouldRejectNullEntities() {
+
+            assertThatThrownBy(() ->
+                    NoSQLPage.of(null, PageRequest.ofPage(1)))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("entities is required");
+        }
     }
 
-    @Test
-    void shouldReturnUnsupportedOperation() {
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
 
-        assertThrows(UnsupportedOperationException.class, page::totalPages);
-        assertThrows(UnsupportedOperationException.class, page::totalElements);
-        assertThrows(UnsupportedOperationException.class, page::hasTotals);
+    @Nested
+    @DisplayName("When getting total elements")
+    class WhenGetTotalElements {
+
+        @Test
+        @DisplayName("should return false when totals are unsupported")
+        void shouldReturnFalseWhenTotalsAreUnsupported() {
+
+            Page<Person> page = unsupportedTotalsPage();
+
+            assertThat(page.hasTotals()).isFalse();
+        }
+
+        @Test
+        @DisplayName("should throw exception when total elements are unsupported")
+        void shouldThrowExceptionWhenTotalElementsAreUnsupported() {
+
+            Page<Person> page = unsupportedTotalsPage();
+
+            assertThatThrownBy(page::totalElements)
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("should calculate total pages")
+        void shouldCalculateTotalPages() {
+
+            Page<Person> page = pageWithTotals(25L, 10);
+
+            assertThat(page.totalPages())
+                    .isEqualTo(3);
+        }
     }
 
-    @Test
-    void shouldReturnTrueHasNext(){
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2).size(1));
+    @Nested
+    @DisplayName("Navigation")
+    class Navigation {
 
-        org.assertj.core.api.Assertions.assertThat(page.hasNext()).isTrue();
+        @Test
+        @DisplayName("should identify next page")
+        void shouldIdentifyNextPage() {
+
+            Page<Person> page = pageWithTotals(30L, 10);
+
+            assertThat(page.hasNext()).isTrue();
+        }
+
+        @Test
+        @DisplayName("should identify last page")
+        void shouldIdentifyLastPage() {
+
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(3).size(10),
+                    () -> 30L
+            );
+
+            assertThat(page.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("should identify previous page")
+        void shouldIdentifyPreviousPage() {
+
+            Page<Person> page = page(2);
+
+            assertThat(page.hasPrevious()).isTrue();
+        }
+
+        @Test
+        @DisplayName("should identify first page")
+        void shouldIdentifyFirstPage() {
+
+            Page<Person> page = page(1);
+
+            assertThat(page.hasPrevious()).isFalse();
+        }
+
+        @Test
+        @DisplayName("should navigate to next page")
+        void shouldNavigateToNextPage() {
+
+            Page<Person> page = page(2);
+
+            PageRequest next = page.nextPageRequest();
+
+            assertThat(next.page()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("should navigate to previous page")
+        void shouldNavigateToPreviousPage() {
+
+            Page<Person> page = page(2);
+
+            PageRequest previous = page.previousPageRequest();
+
+            assertThat(previous.page()).isEqualTo(1);
+        }
     }
 
-    @Test
-    void shouldReturnFalseHasNextWhenIsEmpty(){
-        var page = NoSQLPage.of(Collections.emptyList(), PageRequest.ofPage(2).size(1));
-        org.assertj.core.api.Assertions.assertThat(page.hasNext()).isFalse();
+    @Nested
+    @DisplayName("Content")
+    class Content {
+
+        @Test
+        @DisplayName("should contain entities")
+        void shouldContainEntities() {
+
+            Page<Person> page = page(1);
+
+            assertThat(page.hasContent()).isTrue();
+            assertThat(page.numberOfElements()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("should support empty content")
+        void shouldSupportEmptyContent() {
+
+            Page<Person> page = NoSQLPage.of(
+                    Collections.emptyList(),
+                    PageRequest.ofPage(1)
+            );
+
+            assertThat(page.hasContent()).isFalse();
+            assertThat(page.numberOfElements()).isZero();
+        }
+
+        @Test
+        @DisplayName("should expose immutable content")
+        void shouldExposeImmutableContent() {
+
+            Page<Person> page = page(1);
+
+            assertThatThrownBy(() -> page.content().add(person()))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
     }
 
-    @Test
-    void shouldReturnFalseHasNextWhenElementHasLessThanSize(){
-        var page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2).size(2));
-        org.assertj.core.api.Assertions.assertThat(page.hasNext()).isFalse();
+    @Nested
+    @DisplayName("Identity")
+    class Identity {
+
+        @Test
+        @DisplayName("should implement equals and hashcode")
+        void shouldImplementEqualsAndHashcode() {
+
+            Page<Person> first = page(1);
+            Page<Person> second = page(1);
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(first).isEqualTo(second);
+                softly.assertThat(first.hashCode())
+                        .isEqualTo(second.hashCode());
+            });
+        }
+
+        @Test
+        @DisplayName("should implement toString")
+        void shouldImplementToString() {
+
+            Page<Person> page = page(1);
+
+            assertThat(page.toString()).isNotBlank();
+        }
     }
 
-    @Test
-    void shouldReturnTrueHasPrevious(){
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
+    @Nested
+    @DisplayName("Skip")
+    class Skip {
 
-        org.assertj.core.api.Assertions.assertThat(page.hasPrevious()).isTrue();
+        @Test
+        @DisplayName("should calculate skip")
+        void shouldCalculateSkip() {
+
+            long skip = NoSQLPage.skip(
+                    PageRequest.ofPage(2).size(10));
+
+            assertThat(skip).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("should reject null page request")
+        void shouldRejectNullPageRequest() {
+
+            assertThatThrownBy(() -> NoSQLPage.skip(null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("pageRequest is required");
+        }
     }
 
-    @Test
-    void shouldReturnHasContent() {
-
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-
-        Assertions.assertTrue(page.hasContent());
-        page = NoSQLPage.of(Collections.emptyList(),
-                PageRequest.ofPage(2));
-        Assertions.assertFalse(page.hasContent());
+    private static Page<Person> page(long page) {
+        return NoSQLPage.of(
+                people(),
+                PageRequest.ofPage(page)
+        );
     }
 
-    @Test
-    void shouldNumberOfElements() {
-
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-
-        assertEquals(1, page.numberOfElements());
+    private static Page<Person> pageWithTotals(long total, int size) {
+        return NoSQLPage.of(
+                people(),
+                PageRequest.ofPage(1).size(size),
+                () -> total
+        );
     }
 
-    @Test
-    void shouldIterator() {
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-        Assertions.assertNotNull(page.iterator());
+    private static Page<Person> unsupportedTotalsPage() {
+        return NoSQLPage.of(
+                people(),
+                PageRequest.ofPage(1),
+                () -> {
+                    throw new UnsupportedOperationException();
+                }
+        );
     }
 
-    @Test
-    void shouldPageRequest() {
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-        PageRequest pageRequest = page.pageRequest();
-        Assertions.assertNotNull(pageRequest);
-        assertEquals(PageRequest.ofPage(2), pageRequest);
+    private static List<Person> people() {
+        return Collections.singletonList(person());
     }
 
-    @Test
-    void shouldNextPageRequest() {
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-        PageRequest pageRequest = page.nextPageRequest();
-        assertEquals(PageRequest.ofPage(3), pageRequest);
-    }
-
-    @Test
-    void shouldThrowNullPointerExceptionWhenPageRequestIsNull() {
-        assertThrows(NullPointerException.class, () -> NoSQLPage.skip(null));
-    }
-
-    @Test
-    void shouldCalculateSkip() {
-        long skipValue = NoSQLPage.skip(PageRequest.ofPage(2).size(10));
-        assertEquals(10, skipValue);
-    }
-
-    @Test
-    void shouldCalculateSkipForFirstPage() {
-        // Create a PageRequest with page=1 and size=5
-        long skipValue = NoSQLPage.skip(PageRequest.ofPage(1).size(5));
-        assertEquals(0, skipValue);
-    }
-
-    @Test
-    void shouldToString(){
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-
-        assertThat(page.toString()).isNotBlank();
-    }
-
-    @Test
-    void shouldEqualsHasCode(){
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-        Page<Person> page2 = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-
-        assertEquals(page, page2);
-        assertEquals(page.hashCode(), page2.hashCode());
-
-    }
-
-    @Test
-    void shouldNext(){
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-        PageRequest pageRequest = page.nextPageRequest();
-
-        SoftAssertions.assertSoftly(soft ->{
-            soft.assertThat(pageRequest.page()).isEqualTo(3);
-            soft.assertThat(pageRequest.size()).isEqualTo(10);
-        });
-    }
-
-    @Test
-    void shouldPrevious(){
-        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
-        PageRequest pageRequest = page.previousPageRequest();
-
-        SoftAssertions.assertSoftly(soft ->{
-            soft.assertThat(pageRequest.page()).isEqualTo(1);
-            soft.assertThat(pageRequest.size()).isEqualTo(10);
-        });
+    private static Person person() {
+        return Person.builder()
+                .withName("Otavio")
+                .build();
     }
 
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NoSQLPageTest {
 
+
     @Nested
     @DisplayName("When creating a page")
     class WhenCreatePage {
@@ -67,7 +68,8 @@ class NoSQLPageTest {
 
             Page<Person> page = pageWithTotals(20L, 10);
 
-            assertThat(page.totalElements()).isEqualTo(20L);
+            assertThat(page.totalElements())
+                    .isEqualTo(20L);
         }
 
         @Test
@@ -81,8 +83,8 @@ class NoSQLPageTest {
         }
 
         @Test
-        @DisplayName("should execute total supplier only once")
-        void shouldExecuteTotalSupplierOnlyOnce() {
+        @DisplayName("should execute supplier only once")
+        void shouldExecuteSupplierOnlyOnce() {
 
             AtomicInteger counter = new AtomicInteger();
 
@@ -112,7 +114,8 @@ class NoSQLPageTest {
 
             Page<Person> page = pageWithTotals(25L, 10);
 
-            assertThat(page.totalPages()).isEqualTo(3L);
+            assertThat(page.totalPages())
+                    .isEqualTo(3L);
         }
 
         @Test
@@ -121,7 +124,8 @@ class NoSQLPageTest {
 
             Page<Person> page = pageWithTotals(21L, 10);
 
-            assertThat(page.totalPages()).isEqualTo(3L);
+            assertThat(page.totalPages())
+                    .isEqualTo(3L);
         }
 
         @Test
@@ -130,7 +134,8 @@ class NoSQLPageTest {
 
             Page<Person> page = pageWithTotals(0L, 10);
 
-            assertThat(page.totalPages()).isZero();
+            assertThat(page.totalPages())
+                    .isZero();
         }
 
         @Test
@@ -172,8 +177,8 @@ class NoSQLPageTest {
     class WhenCheckNextPage {
 
         @Test
-        @DisplayName("should return true when next page exists")
-        void shouldReturnTrueWhenNextPageExists() {
+        @DisplayName("should return true when totals indicate another page")
+        void shouldReturnTrueWhenTotalsIndicateAnotherPage() {
 
             Page<Person> page = NoSQLPage.of(
                     people(),
@@ -198,10 +203,25 @@ class NoSQLPageTest {
         }
 
         @Test
-        @DisplayName("should return false when totals are unsupported")
-        void shouldReturnFalseWhenTotalsAreUnsupported() {
+        @DisplayName("should use heuristic navigation when totals are unsupported")
+        void shouldUseHeuristicNavigationWhenTotalsAreUnsupported() {
 
-            Page<Person> page = unsupportedTotalsPage();
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(1).size(1)
+            );
+
+            assertThat(page.hasNext()).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return false when page content is smaller than requested size")
+        void shouldReturnFalseWhenPageContentIsSmallerThanRequestedSize() {
+
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(1).size(10)
+            );
 
             assertThat(page.hasNext()).isFalse();
         }
@@ -235,8 +255,8 @@ class NoSQLPageTest {
     class WhenRequestNextPage {
 
         @Test
-        @DisplayName("should return next page request")
-        void shouldReturnNextPageRequest() {
+        @DisplayName("should return next page request when totals support navigation")
+        void shouldReturnNextPageRequestWhenTotalsSupportNavigation() {
 
             Page<Person> page = NoSQLPage.of(
                     people(),
@@ -253,8 +273,8 @@ class NoSQLPageTest {
         }
 
         @Test
-        @DisplayName("should throw exception when next page does not exist")
-        void shouldThrowExceptionWhenNextPageDoesNotExist() {
+        @DisplayName("should throw exception when totals indicate there is no next page")
+        void shouldThrowExceptionWhenTotalsIndicateThereIsNoNextPage() {
 
             Page<Person> page = NoSQLPage.of(
                     people(),
@@ -263,7 +283,23 @@ class NoSQLPageTest {
             );
 
             assertThatThrownBy(page::nextPageRequest)
-                    .isInstanceOf(NoSuchElementException.class);
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Current page: 3")
+                    .hasMessageContaining("total pages: 3");
+        }
+
+        @Test
+        @DisplayName("should allow exploratory navigation when totals are unsupported")
+        void shouldAllowExploratoryNavigationWhenTotalsAreUnsupported() {
+
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(1).size(1)
+            );
+
+            PageRequest next = page.nextPageRequest();
+
+            assertThat(next.page()).isEqualTo(2);
         }
     }
 
@@ -292,7 +328,9 @@ class NoSQLPageTest {
             Page<Person> page = page(1);
 
             assertThatThrownBy(page::previousPageRequest)
-                    .isInstanceOf(NoSuchElementException.class);
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Current page: 1")
+                    .hasMessageContaining("Page numbers start at 1");
         }
     }
 
@@ -335,8 +373,8 @@ class NoSQLPageTest {
         }
 
         @Test
-        @DisplayName("should return immutable content")
-        void shouldReturnImmutableContent() {
+        @DisplayName("should expose immutable content")
+        void shouldExposeImmutableContent() {
 
             Page<Person> page = page(1);
 
@@ -451,5 +489,4 @@ class NoSQLPageTest {
                 .withName("Otavio")
                 .build();
     }
-
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
@@ -24,12 +24,13 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NoSQLPageTest {
-
 
     @Nested
     @DisplayName("When creating a page")
@@ -56,10 +57,105 @@ class NoSQLPageTest {
         }
     }
 
-
     @Nested
     @DisplayName("When getting total elements")
     class WhenGetTotalElements {
+
+        @Test
+        @DisplayName("should return total elements")
+        void shouldReturnTotalElements() {
+
+            Page<Person> page = pageWithTotals(20L, 10);
+
+            assertThat(page.totalElements()).isEqualTo(20L);
+        }
+
+        @Test
+        @DisplayName("should throw exception when totals are unsupported")
+        void shouldThrowExceptionWhenTotalsAreUnsupported() {
+
+            Page<Person> page = unsupportedTotalsPage();
+
+            assertThatThrownBy(page::totalElements)
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("should execute total supplier only once")
+        void shouldExecuteTotalSupplierOnlyOnce() {
+
+            AtomicInteger counter = new AtomicInteger();
+
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(1),
+                    () -> {
+                        counter.incrementAndGet();
+                        return 100L;
+                    }
+            );
+
+            page.totalElements();
+            page.totalElements();
+
+            assertThat(counter.get()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("When getting total pages")
+    class WhenGetTotalPages {
+
+        @Test
+        @DisplayName("should calculate total pages")
+        void shouldCalculateTotalPages() {
+
+            Page<Person> page = pageWithTotals(25L, 10);
+
+            assertThat(page.totalPages()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("should round total pages")
+        void shouldRoundTotalPages() {
+
+            Page<Person> page = pageWithTotals(21L, 10);
+
+            assertThat(page.totalPages()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("should return zero when there are no elements")
+        void shouldReturnZeroWhenThereAreNoElements() {
+
+            Page<Person> page = pageWithTotals(0L, 10);
+
+            assertThat(page.totalPages()).isZero();
+        }
+
+        @Test
+        @DisplayName("should throw exception when totals are unsupported")
+        void shouldThrowExceptionWhenTotalsAreUnsupported() {
+
+            Page<Person> page = unsupportedTotalsPage();
+
+            assertThatThrownBy(page::totalPages)
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("When checking totals availability")
+    class WhenCheckTotalsAvailability {
+
+        @Test
+        @DisplayName("should return true when totals are supported")
+        void shouldReturnTrueWhenTotalsAreSupported() {
+
+            Page<Person> page = pageWithTotals(10L, 10);
+
+            assertThat(page.hasTotals()).isTrue();
+        }
 
         @Test
         @DisplayName("should return false when totals are unsupported")
@@ -69,44 +165,28 @@ class NoSQLPageTest {
 
             assertThat(page.hasTotals()).isFalse();
         }
-
-        @Test
-        @DisplayName("should throw exception when total elements are unsupported")
-        void shouldThrowExceptionWhenTotalElementsAreUnsupported() {
-
-            Page<Person> page = unsupportedTotalsPage();
-
-            assertThatThrownBy(page::totalElements)
-                    .isInstanceOf(UnsupportedOperationException.class);
-        }
-
-        @Test
-        @DisplayName("should calculate total pages")
-        void shouldCalculateTotalPages() {
-
-            Page<Person> page = pageWithTotals(25L, 10);
-
-            assertThat(page.totalPages())
-                    .isEqualTo(3);
-        }
     }
 
     @Nested
-    @DisplayName("Navigation")
-    class Navigation {
+    @DisplayName("When checking next page")
+    class WhenCheckNextPage {
 
         @Test
-        @DisplayName("should identify next page")
-        void shouldIdentifyNextPage() {
+        @DisplayName("should return true when next page exists")
+        void shouldReturnTrueWhenNextPageExists() {
 
-            Page<Person> page = pageWithTotals(30L, 10);
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(1).size(10),
+                    () -> 30L
+            );
 
             assertThat(page.hasNext()).isTrue();
         }
 
         @Test
-        @DisplayName("should identify last page")
-        void shouldIdentifyLastPage() {
+        @DisplayName("should return false when current page is the last page")
+        void shouldReturnFalseWhenCurrentPageIsTheLastPage() {
 
             Page<Person> page = NoSQLPage.of(
                     people(),
@@ -118,8 +198,22 @@ class NoSQLPageTest {
         }
 
         @Test
-        @DisplayName("should identify previous page")
-        void shouldIdentifyPreviousPage() {
+        @DisplayName("should return false when totals are unsupported")
+        void shouldReturnFalseWhenTotalsAreUnsupported() {
+
+            Page<Person> page = unsupportedTotalsPage();
+
+            assertThat(page.hasNext()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("When checking previous page")
+    class WhenCheckPreviousPage {
+
+        @Test
+        @DisplayName("should return true when current page is greater than one")
+        void shouldReturnTrueWhenCurrentPageIsGreaterThanOne() {
 
             Page<Person> page = page(2);
 
@@ -127,49 +221,102 @@ class NoSQLPageTest {
         }
 
         @Test
-        @DisplayName("should identify first page")
-        void shouldIdentifyFirstPage() {
+        @DisplayName("should return false when current page is the first page")
+        void shouldReturnFalseWhenCurrentPageIsTheFirstPage() {
 
             Page<Person> page = page(1);
 
             assertThat(page.hasPrevious()).isFalse();
         }
+    }
+
+    @Nested
+    @DisplayName("When requesting next page")
+    class WhenRequestNextPage {
 
         @Test
-        @DisplayName("should navigate to next page")
-        void shouldNavigateToNextPage() {
+        @DisplayName("should return next page request")
+        void shouldReturnNextPageRequest() {
 
-            Page<Person> page = page(2);
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(1).size(10),
+                    () -> 30L
+            );
 
             PageRequest next = page.nextPageRequest();
 
-            assertThat(next.page()).isEqualTo(3);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(next.page()).isEqualTo(2);
+                softly.assertThat(next.size()).isEqualTo(10);
+            });
         }
 
         @Test
-        @DisplayName("should navigate to previous page")
-        void shouldNavigateToPreviousPage() {
+        @DisplayName("should throw exception when next page does not exist")
+        void shouldThrowExceptionWhenNextPageDoesNotExist() {
+
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(3).size(10),
+                    () -> 30L
+            );
+
+            assertThatThrownBy(page::nextPageRequest)
+                    .isInstanceOf(NoSuchElementException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("When requesting previous page")
+    class WhenRequestPreviousPage {
+
+        @Test
+        @DisplayName("should return previous page request")
+        void shouldReturnPreviousPageRequest() {
 
             Page<Person> page = page(2);
 
             PageRequest previous = page.previousPageRequest();
 
-            assertThat(previous.page()).isEqualTo(1);
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(previous.page()).isEqualTo(1);
+                softly.assertThat(previous.size()).isEqualTo(10);
+            });
+        }
+
+        @Test
+        @DisplayName("should throw exception when previous page does not exist")
+        void shouldThrowExceptionWhenPreviousPageDoesNotExist() {
+
+            Page<Person> page = page(1);
+
+            assertThatThrownBy(page::previousPageRequest)
+                    .isInstanceOf(NoSuchElementException.class);
         }
     }
 
     @Nested
-    @DisplayName("Content")
-    class Content {
+    @DisplayName("When reading content")
+    class WhenReadContent {
 
         @Test
-        @DisplayName("should contain entities")
-        void shouldContainEntities() {
+        @DisplayName("should return content")
+        void shouldReturnContent() {
+
+            Page<Person> page = page(1);
+
+            assertThat(page.content())
+                    .hasSize(1);
+        }
+
+        @Test
+        @DisplayName("should identify content existence")
+        void shouldIdentifyContentExistence() {
 
             Page<Person> page = page(1);
 
             assertThat(page.hasContent()).isTrue();
-            assertThat(page.numberOfElements()).isEqualTo(1);
         }
 
         @Test
@@ -181,24 +328,70 @@ class NoSQLPageTest {
                     PageRequest.ofPage(1)
             );
 
-            assertThat(page.hasContent()).isFalse();
-            assertThat(page.numberOfElements()).isZero();
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(page.hasContent()).isFalse();
+                softly.assertThat(page.numberOfElements()).isZero();
+            });
         }
 
         @Test
-        @DisplayName("should expose immutable content")
-        void shouldExposeImmutableContent() {
+        @DisplayName("should return immutable content")
+        void shouldReturnImmutableContent() {
 
             Page<Person> page = page(1);
 
-            assertThatThrownBy(() -> page.content().add(person()))
+            assertThatThrownBy(() ->
+                    page.content().add(person()))
                     .isInstanceOf(UnsupportedOperationException.class);
+        }
+
+        @Test
+        @DisplayName("should expose iterator")
+        void shouldExposeIterator() {
+
+            Page<Person> page = page(1);
+
+            assertThat(page.iterator()).isNotNull();
         }
     }
 
     @Nested
-    @DisplayName("Identity")
-    class Identity {
+    @DisplayName("When calculating skip")
+    class WhenCalculateSkip {
+
+        @Test
+        @DisplayName("should calculate skip")
+        void shouldCalculateSkip() {
+
+            long skip = NoSQLPage.skip(
+                    PageRequest.ofPage(2).size(10));
+
+            assertThat(skip).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("should calculate zero for first page")
+        void shouldCalculateZeroForFirstPage() {
+
+            long skip = NoSQLPage.skip(
+                    PageRequest.ofPage(1).size(10));
+
+            assertThat(skip).isZero();
+        }
+
+        @Test
+        @DisplayName("should reject null page request")
+        void shouldRejectNullPageRequest() {
+
+            assertThatThrownBy(() -> NoSQLPage.skip(null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("pageRequest is required");
+        }
+    }
+
+    @Nested
+    @DisplayName("When comparing pages")
+    class WhenComparePages {
 
         @Test
         @DisplayName("should implement equals and hashcode")
@@ -221,30 +414,6 @@ class NoSQLPageTest {
             Page<Person> page = page(1);
 
             assertThat(page.toString()).isNotBlank();
-        }
-    }
-
-    @Nested
-    @DisplayName("Skip")
-    class Skip {
-
-        @Test
-        @DisplayName("should calculate skip")
-        void shouldCalculateSkip() {
-
-            long skip = NoSQLPage.skip(
-                    PageRequest.ofPage(2).size(10));
-
-            assertThat(skip).isEqualTo(10);
-        }
-
-        @Test
-        @DisplayName("should reject null page request")
-        void shouldRejectNullPageRequest() {
-
-            assertThatThrownBy(() -> NoSQLPage.skip(null))
-                    .isInstanceOf(NullPointerException.class)
-                    .hasMessage("pageRequest is required");
         }
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
@@ -42,7 +42,11 @@ class NoSQLPageTest {
         void shouldRejectNullPageRequest() {
 
             assertThatThrownBy(() ->
-                    NoSQLPage.of(Collections.emptyList(), null))
+                    NoSQLPage.of(Collections.emptyList(), null,
+                            () -> {
+                                throw new UnsupportedOperationException(
+                                        "JNoSQL has no support for this feature yet");
+                            }))
                     .isInstanceOf(NullPointerException.class)
                     .hasMessage("pageRequest is required");
         }
@@ -52,7 +56,7 @@ class NoSQLPageTest {
         void shouldRejectNullEntities() {
 
             assertThatThrownBy(() ->
-                    NoSQLPage.of(null, PageRequest.ofPage(1)))
+                    NoSQLPage.of(null, PageRequest.ofPage(1), () -> 10))
                     .isInstanceOf(NullPointerException.class)
                     .hasMessage("entities is required");
         }
@@ -224,7 +228,11 @@ class NoSQLPageTest {
 
             Page<Person> page = NoSQLPage.of(
                     people(),
-                    PageRequest.ofPage(1).size(10)
+                    PageRequest.ofPage(1).size(10),
+                    () -> {
+                        throw new UnsupportedOperationException(
+                                "JNoSQL has no support for this feature yet");
+                    }
             );
 
             assertThat(page.hasNext()).isFalse();
@@ -298,7 +306,11 @@ class NoSQLPageTest {
 
             Page<Person> page = NoSQLPage.of(
                     people(),
-                    PageRequest.ofPage(1).size(1)
+                    PageRequest.ofPage(1).size(1),
+                    () -> {
+                        throw new UnsupportedOperationException(
+                                "JNoSQL has no support for this feature yet");
+                    }
             );
 
             PageRequest next = page.nextPageRequest();
@@ -367,7 +379,11 @@ class NoSQLPageTest {
 
             Page<Person> page = NoSQLPage.of(
                     Collections.emptyList(),
-                    PageRequest.ofPage(1)
+                    PageRequest.ofPage(1),
+                    () -> {
+                    throw new UnsupportedOperationException(
+                            "JNoSQL has no support for this feature yet");
+                    }
             );
 
             SoftAssertions.assertSoftly(softly -> {

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DefaultRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DefaultRepositoryReturnTest.java
@@ -59,7 +59,8 @@ class DefaultRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object person = repositoryReturn.convertPageRequest(dynamic);
         Assertions.assertNotNull(person);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturnTest.java
@@ -51,6 +51,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .prepareConverter(s -> preparedStatement)
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
+                .totalSupplier(() -> 0L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof Optional);
@@ -74,6 +75,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertInstanceOf(Optional.class, execute);
@@ -98,6 +100,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
 
         Assertions.assertThrows(NonUniqueResultException.class, dynamicReturn::execute);
@@ -118,6 +121,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertInstanceOf(Person.class, execute);
@@ -139,6 +143,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
 
         Assertions.assertThrows(EmptyResultException.class, dynamicReturn::execute);
@@ -159,6 +164,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertInstanceOf(List.class, execute);
@@ -182,6 +188,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertInstanceOf(Iterable.class, execute);
@@ -202,6 +209,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertInstanceOf(Collection.class, execute);
@@ -224,6 +232,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertInstanceOf(Queue.class, execute);
@@ -245,6 +254,7 @@ class DynamicQueryMethodReturnTest {
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .returnType(method.getReturnType())
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
 
         Object execute = dynamicReturn.execute();
@@ -270,6 +280,7 @@ class DynamicQueryMethodReturnTest {
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .args(new Object[]{"Ada"})
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertInstanceOf(Iterable.class, execute);
@@ -292,6 +303,7 @@ class DynamicQueryMethodReturnTest {
                 .querySupplier(() -> RepositoryReflectionUtils.INSTANCE.getQuery(method))
                 .paramsSupplier(() -> RepositoryReflectionUtils.INSTANCE.getParams(method, new Object[]{"Ada"}))
                 .prepareConverter(s -> preparedStatement)
+                .totalSupplier(() -> 0L)
                 .build();
 
         Object execute = dynamicReturn.execute();
@@ -320,6 +332,7 @@ class DynamicQueryMethodReturnTest {
                 .args(new Object[]{"Ada", PageRequest.ofPage(10)})
                 .prepareConverter(s -> preparedStatement)
                 .pageRequest(PageRequest.ofPage(10))
+                .totalSupplier(() -> 0L)
                 .build();
         Object execute = dynamicReturn.execute();
         SoftAssertions.assertSoftly(soft -> {

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnPaginationTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnPaginationTest.java
@@ -34,7 +34,9 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -51,7 +53,7 @@ class DynamicReturnPaginationTest {
     private Function<PageRequest, Optional<Person>> singlePagination;
 
     @Mock
-    private Function<PageRequest, Page<Person>> page;
+    private BiFunction<PageRequest, LongSupplier, Page<Person>> page;
 
     @SuppressWarnings("unchecked")
     @Test
@@ -456,6 +458,7 @@ class DynamicReturnPaginationTest {
         Supplier<Stream<?>> stream = Stream::empty;
         Supplier<Optional<?>> singleResult = DynamicReturn.toSingleResult(method.getName()).apply(stream);
         PageRequest pageRequest = getPagination();
+        LongSupplier supplier = () -> 1L;
         DynamicReturn<?> dynamicReturn = DynamicReturn.builder()
                 .classSource(Person.class)
                 .returnType(method.getReturnType())
@@ -466,12 +469,13 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(supplier)
                 .build();
 
         dynamicReturn.execute();
         Mockito.verify(singlePagination, Mockito.never()).apply(pageRequest);
         Mockito.verify(streamPagination, Mockito.never()).apply(pageRequest);
-        Mockito.verify(page).apply(pageRequest);
+        Mockito.verify(page).apply(pageRequest, supplier);
     }
 
     private Method method(Class<?> repository, String methodName) throws NoSuchMethodException {

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnPaginationTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnPaginationTest.java
@@ -77,6 +77,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object execute = dynamicReturn.execute();
 
@@ -109,7 +110,9 @@ class DynamicReturnPaginationTest {
                 .pagination(pageRequest)
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
-                .page(page).build();
+                .page(page)
+                .totalSupplier(() -> 1L)
+                .build();
 
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof Optional);
@@ -140,7 +143,9 @@ class DynamicReturnPaginationTest {
                 .pagination(pageRequest)
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
-                .page(page).build();
+                .page(page)
+                .totalSupplier(() -> 1L)
+                .build();
 
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof Person);
@@ -171,6 +176,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
 
         Assertions.assertThrows(EmptyResultException.class, dynamicReturn::execute);
@@ -199,6 +205,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof List);
@@ -230,6 +237,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
 
         Object execute = dynamicReturn.execute();
@@ -260,6 +268,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof Collection);
@@ -290,6 +299,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof Set);
@@ -320,6 +330,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof Queue);
@@ -351,6 +362,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof Stream);
@@ -380,6 +392,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof SortedSet);
@@ -410,6 +423,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof NavigableSet);
@@ -441,6 +455,7 @@ class DynamicReturnPaginationTest {
                 .streamPagination(streamPagination)
                 .singleResultPagination(singlePagination)
                 .page(page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object execute = dynamicReturn.execute();
         Assertions.assertTrue(execute instanceof Deque);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/ArrayRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/ArrayRepositoryReturnTest.java
@@ -82,7 +82,8 @@ class ArrayRepositoryReturnTest {
                 .methodName(method.getName())
                 .returnType(Person[].class)
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Person[] person = (Person[]) repositoryReturn.convertPageRequest(dynamic);
         SoftAssertions.assertSoftly(s -> {

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/InstanceRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/InstanceRepositoryReturnTest.java
@@ -77,7 +77,8 @@ class InstanceRepositoryReturnTest {
                 .returnType(Person.class)
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Person person = (Person) repositoryReturn.convertPageRequest(dynamic);
         Assertions.assertNotNull(person);
@@ -96,7 +97,8 @@ class InstanceRepositoryReturnTest {
                 .returnType(Person.class)
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Assertions.assertThrows(EmptyResultException.class, () -> repositoryReturn.convertPageRequest(dynamic));
     }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/ListRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/ListRepositoryReturnTest.java
@@ -84,7 +84,8 @@ class ListRepositoryReturnTest {
                 .methodName(method.getName())
                 .returnType(method.getReturnType())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         List<Person> person = (List<Person>) repositoryReturn.convertPageRequest(dynamic);
         Assertions.assertNotNull(person);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/OptionalRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/OptionalRepositoryReturnTest.java
@@ -97,7 +97,8 @@ class OptionalRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Optional<Person> person = (Optional<Person>) repositoryReturn.convertPageRequest(dynamic);
         Assertions.assertNotNull(person);
@@ -118,7 +119,8 @@ class OptionalRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Optional<Person> person = (Optional<Person>) repositoryReturn.convertPageRequest(dynamic);
         Assertions.assertNotNull(person);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/PageRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/PageRepositoryReturnTest.java
@@ -69,7 +69,8 @@ class PageRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
 
         Page<Person> personPage = (Page<Person>) repositoryReturn.convertPageRequest(dynamic);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/QueueRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/QueueRepositoryReturnTest.java
@@ -66,7 +66,8 @@ class QueueRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         LinkedList<Person> person = (LinkedList<Person>) repositoryReturn.convertPageRequest(dynamic);
         Assertions.assertNotNull(person);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/SetRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/SetRepositoryReturnTest.java
@@ -63,7 +63,8 @@ class SetRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
 
         Set<Person> person = (Set<Person>) repositoryReturn.convert(dynamic);
@@ -85,7 +86,8 @@ class SetRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Set<Person> person = (Set<Person>) repositoryReturn.convertPageRequest(dynamic);
         Assertions.assertNotNull(person);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/SortedSetRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/SortedSetRepositoryReturnTest.java
@@ -68,7 +68,8 @@ class SortedSetRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         TreeSet<Person> person = (TreeSet<Person>) repositoryReturn.convertPageRequest(dynamic);
         Assertions.assertNotNull(person);
@@ -106,7 +107,8 @@ class SortedSetRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Assertions.assertThrows(DynamicQueryException.class, () -> repositoryReturn.convertPageRequest(dynamic));
     }
@@ -124,7 +126,8 @@ class SortedSetRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Assertions.assertThrows(DynamicQueryException.class, () -> repositoryReturn.convert(dynamic));
     }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/StreamRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/StreamRepositoryReturnTest.java
@@ -64,7 +64,8 @@ class StreamRepositoryReturnTest {
                 .returnType(method.getReturnType())
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Stream<Person> person = (Stream<Person>) repositoryReturn.convertPageRequest(dynamic);
         Assertions.assertNotNull(person);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/VoidRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/VoidRepositoryReturnTest.java
@@ -68,7 +68,8 @@ class VoidRepositoryReturnTest {
                 .returnType(Person.class)
                 .methodName(method.getName())
                 .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
+                .page((p, l) -> page)
+                .totalSupplier(() -> 1L)
                 .build();
         Object object = repositoryReturn.convertPageRequest(dynamic);
         assertNull(object);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
@@ -352,7 +352,7 @@ public abstract class AbstractSemiStructuredTemplate implements SemiStructuredTe
         var queryPage = new MappingQuery(query.sorts(), pageRequest.size(), NoSQLPage.skip(pageRequest),
                 query.condition().orElse(null), query.name(), query.columns());
         Stream<T> result = select(queryPage);
-        return NoSQLPage.of(result.toList(), pageRequest);
+        return NoSQLPage.of(result.toList(), pageRequest, () -> this.count(query));
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepository.java
@@ -59,7 +59,7 @@ public abstract class AbstractSemiStructuredRepository<T, K> extends AbstractRep
                 , null ,metadata.name(), List.of());
 
         List<T> entities = template().<T>select(query).toList();
-        return NoSQLPage.of(entities, pageRequest);
+        return NoSQLPage.of(entities, pageRequest, () -> this.template().count(query));
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
@@ -73,7 +73,7 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
         var first = method.getAnnotation(First.class);
         LOGGER.finest("Query: " + queryValue + " with type: " + queryType + " and return type: " + returnType);
         queryType.checkValidReturn(returnType, queryValue);
-        var selectQuery = new AtomicReference<SelectQuery>();
+        var selectQueryAtomicReference = new AtomicReference<SelectQuery>();
         var methodReturn = DynamicQueryMethodReturn.builder()
                 .args(params)
                 .methodName(method.getName())
@@ -83,7 +83,7 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
                 .typeClass(type)
                 .pageRequest(pageRequest)
                 .mapper(mapper(method))
-                .totalSupplier(() -> template().count(entity))
+                .totalSupplier(() -> template().count(selectQueryAtomicReference.get()))
                 .prepareConverter(textQuery -> {
                     var prepare = (org.eclipse.jnosql.mapping.semistructured.PreparedStatement) template().prepare(textQuery, entity);
                     List<Sort<?>> sortsFromAnnotation = getSorts(method, entityMetadata());
@@ -94,9 +94,11 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
                             var selectQuery = updateQueryDynamically(params, query, first);
                             List<Sort<?>> sorts = new ArrayList<>(selectQuery.sorts());
                             sorts.addAll(sortsFromAnnotation);
-                            return new MappingQuery(sorts, selectQuery.limit(), selectQuery.skip(),
+                            var updateQuery = new MappingQuery(sorts, selectQuery.limit(), selectQuery.skip(),
                                     selectQuery.condition().orElse(null)
                                     , entity, selectQuery.columns());
+                            selectQueryAtomicReference.set(updateQuery);
+                            return updateQuery;
                         });
                     }
                     return prepare;

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
@@ -82,6 +82,7 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
                 .typeClass(type)
                 .pageRequest(pageRequest)
                 .mapper(mapper(method))
+                .totalSupplier(() -> template().count(entity))
                 .prepareConverter(textQuery -> {
                     var prepare = (org.eclipse.jnosql.mapping.semistructured.PreparedStatement) template().prepare(textQuery, entity);
                     List<Sort<?>> sortsFromAnnotation = getSorts(method, entityMetadata());

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -72,7 +73,7 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
         var first = method.getAnnotation(First.class);
         LOGGER.finest("Query: " + queryValue + " with type: " + queryType + " and return type: " + returnType);
         queryType.checkValidReturn(returnType, queryValue);
-
+        var selectQuery = new AtomicReference<SelectQuery>();
         var methodReturn = DynamicQueryMethodReturn.builder()
                 .args(params)
                 .methodName(method.getName())

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -258,7 +259,7 @@ public abstract class BaseSemiStructuredRepository<T, K> extends AbstractReposit
     protected Function<PageRequest, Page<T>> getPage(SelectQuery query, Method method) {
         return p -> {
             Stream<T> entities = template().select(query).map(mapper(method));
-            return NoSQLPage.of(entities.toList(), p);
+            return NoSQLPage.of(entities.toList(), p, () -> this.template().count(query));
         };
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
@@ -53,6 +53,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
@@ -188,6 +189,7 @@ public abstract class BaseSemiStructuredRepository<T, K> extends AbstractReposit
                 .streamPagination(streamPagination(query, method))
                 .singleResultPagination(getSingleResult(query, method))
                 .page(getPage(query, method))
+                .totalSupplier(() -> this.template().count(query))
                 .build();
         return dynamicReturn.execute();
     }
@@ -256,10 +258,10 @@ public abstract class BaseSemiStructuredRepository<T, K> extends AbstractReposit
         return template().exists(query);
     }
 
-    protected Function<PageRequest, Page<T>> getPage(SelectQuery query, Method method) {
-        return p -> {
+    protected BiFunction<PageRequest, LongSupplier, Page<T>> getPage(SelectQuery query, Method method) {
+        return (p, l) -> {
             Stream<T> entities = template().select(query).map(mapper(method));
-            return NoSQLPage.of(entities.toList(), p, () -> this.template().count(query));
+            return NoSQLPage.of(entities.toList(), p, l);
         };
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredQueryOperation.java
@@ -17,6 +17,7 @@ package org.eclipse.jnosql.mapping.semistructured.repository;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.jnosql.communication.query.data.QueryType;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.mapping.core.repository.DynamicQueryMethodReturn;
 import org.eclipse.jnosql.mapping.core.repository.DynamicReturn;
 import org.eclipse.jnosql.mapping.core.repository.RepositoryMetadataUtils;
@@ -27,6 +28,7 @@ import org.eclipse.jnosql.mapping.metadata.repository.spi.QueryOperation;
 import org.eclipse.jnosql.mapping.metadata.repository.spi.RepositoryInvocationContext;
 import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
 
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 
 @ApplicationScoped
@@ -73,6 +75,8 @@ class SemistructuredQueryOperation implements QueryOperation {
         LOGGER.finest("Query: " + queryValue + " with type: " + queryType + " and return type: " + returnType);
         queryType.checkValidReturn(returnType, queryValue);
 
+        var queryAtomic = new AtomicReference<SelectQuery>();
+
         var methodReturn = DynamicQueryMethodReturn.builder()
                 .args(params)
                 .methodName(method.name())
@@ -81,10 +85,15 @@ class SemistructuredQueryOperation implements QueryOperation {
                 .paramsSupplier(() -> RepositoryMetadataUtils.INSTANCE.getParams(method, params))
                 .typeClass(type)
                 .pageRequest(pageRequest)
+                .totalSupplier(() -> template.count(queryAtomic.get()))
                 .mapper(semistructuredReturnType.mapper(method, entityMetadata))
                 .prepareConverter(textQuery -> {
                     var prepare = (org.eclipse.jnosql.mapping.semistructured.PreparedStatement) template.prepare(textQuery, entity);
-                        prepare.setSelectMapper(query -> queryBuilder.updateDynamicQuery(query, context));
+                        prepare.setSelectMapper(query -> {
+                            var selectQuery = queryBuilder.updateDynamicQuery(query, context);
+                            queryAtomic.set(selectQuery);
+                            return selectQuery;
+                        });
                     return prepare;
                 }).build();
         return (T) methodReturn.execute();

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepository.java
@@ -94,7 +94,7 @@ public class SemistructuredRepository<T, K>  extends AbstractRepository<T, K> {
                 , null ,metadata.name(), List.of());
 
         List<T> entities = template().<T>select(query).toList();
-        return NoSQLPage.of(entities, pageRequest);
+        return NoSQLPage.of(entities, pageRequest, () -> this.template().count(query));
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
@@ -34,14 +34,16 @@ import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @ApplicationScoped
 class SemistructuredReturnType {
 
-    private static final Page<Object> EMPTY_PAGINATION = NoSQLPage.of(Collections.emptyList(), PageRequest.ofSize(1));
+    private static final Page<Object> EMPTY_PAGINATION = NoSQLPage.of(Collections.emptyList(), PageRequest.ofSize(1), () -> 0L);
     private final EntitiesMetadata entitiesMetadata;
 
     private final  ProjectorConverter projectorConverter;
@@ -102,7 +104,7 @@ class SemistructuredReturnType {
                 .pagination(DynamicReturn.findPageRequest(context.parameters()))
                 .streamPagination(p -> Stream.empty())
                 .singleResultPagination(p -> Optional.empty())
-                .page(p -> EMPTY_PAGINATION)
+                .page((p, l) -> EMPTY_PAGINATION)
                 .build();
         return dynamicReturn.execute();
     }
@@ -121,13 +123,13 @@ class SemistructuredReturnType {
         return p -> template.singleResult(query).map(mapper(method, entityMetadata));
     }
 
-    protected <T>  Function<PageRequest, Page<T>> getPage(SelectQuery query,
-                                                          RepositoryMethod method,
-                                                          EntityMetadata entityMetadata,
-                                                          SemiStructuredTemplate template) {
-        return p -> {
+    protected <T> BiFunction<PageRequest, LongSupplier, Page<T>> getPage(SelectQuery query,
+                                                                         RepositoryMethod method,
+                                                                         EntityMetadata entityMetadata,
+                                                                         SemiStructuredTemplate template) {
+        return (p, l) -> {
             Stream<T> entities = template.select(query).map(mapper(method, entityMetadata));
-            return NoSQLPage.of(entities.toList(), p);
+            return NoSQLPage.of(entities.toList(), p, l);
         };
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredReturnType.java
@@ -83,6 +83,7 @@ class SemistructuredReturnType {
                 .streamPagination(streamPagination(query, method, entityMetadata, template))
                 .singleResultPagination(getSingleResult(query, method, entityMetadata, template))
                 .page(getPage(query, method, entityMetadata, template))
+                .totalSupplier(() -> template.count(query))
                 .build();
         return dynamicReturn.execute();
     }
@@ -105,6 +106,7 @@ class SemistructuredReturnType {
                 .streamPagination(p -> Stream.empty())
                 .singleResultPagination(p -> Optional.empty())
                 .page((p, l) -> EMPTY_PAGINATION)
+                .totalSupplier(() -> 0L)
                 .build();
         return dynamicReturn.execute();
     }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CrudRepositoryProxyRestrictionTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CrudRepositoryProxyRestrictionTest.java
@@ -123,6 +123,9 @@ class CrudRepositoryProxyRestrictionTest {
         when(template.select(any(SelectQuery.class)))
                 .thenReturn(Stream.of(new Product()));
 
+        when(template.count(any(SelectQuery.class)))
+                .thenReturn(10L);
+
         Page<Product> products = repository.restriction(_Product.name.equalTo("Mac"), PageRequest.ofSize(2));
         ArgumentCaptor<SelectQuery> captor = ArgumentCaptor.forClass(SelectQuery.class);
         verify(template).select(captor.capture());

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerRestrictionTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerRestrictionTest.java
@@ -111,6 +111,8 @@ class CustomRepositoryHandlerRestrictionTest {
         when(template.select(any(SelectQuery.class)))
                 .thenReturn(Stream.of(new Product()));
 
+        when(template.count(any(SelectQuery.class))).thenReturn(19L);
+
         Page<Product> products = repository.restriction(_Product.name.equalTo("Mac"), PageRequest.ofSize(2));
         ArgumentCaptor<SelectQuery> captor = ArgumentCaptor.forClass(SelectQuery.class);
         verify(template).select(captor.capture());


### PR DESCRIPTION
This pull request introduces support for lazy and thread-safe total count calculation in JNoSQL's paging implementation, improving efficiency and correctness when working with paginated results. The changes include a new `LazyLongSupplier` utility, updates to the `NoSQLPage` class to support total element and page calculations, and enhancements to repository classes to propagate and utilize a total count supplier throughout the dynamic query and return process.

**Paging and total count improvements:**

* Added a new `LazyLongSupplier` class to provide a thread-safe, lazily-evaluated, and cached `LongSupplier` implementation for expensive total count calculations.
* Updated `NoSQLPage` to accept a `LongSupplier` for total elements, enabling real total count calculation, supporting `totalElements()`, `totalPages()`, and `hasTotals()` methods, and improving navigation methods like `hasNext()`, `hasPrevious()`, `nextPageRequest()`, and `previousPageRequest()` to handle totals and edge cases correctly. [[1]](diffhunk://#diff-791901e6507a7cccac2f46812a824f2842bf1331f565f8d10dc5a0d8b055fbc9L37-R55) [[2]](diffhunk://#diff-791901e6507a7cccac2f46812a824f2842bf1331f565f8d10dc5a0d8b055fbc9R75-R84) [[3]](diffhunk://#diff-791901e6507a7cccac2f46812a824f2842bf1331f565f8d10dc5a0d8b055fbc9R95-R141) [[4]](diffhunk://#diff-791901e6507a7cccac2f46812a824f2842bf1331f565f8d10dc5a0d8b055fbc9R174-R188)
* Changed the `of` factory method in `NoSQLPage` to require a `LongSupplier` and wrap it in a `LazyLongSupplier`.

**Repository and query method enhancements:**

* Updated `DynamicQueryMethodReturn` and its builder to accept and propagate a `LongSupplier` for totals, enforcing its presence and exposing it for use in paging. [[1]](diffhunk://#diff-bd8eb3cccfbc82c334c7ef37a97c99334b672b51912beb3d36ee19edebee46e6R24) [[2]](diffhunk://#diff-bd8eb3cccfbc82c334c7ef37a97c99334b672b51912beb3d36ee19edebee46e6L38-R40) [[3]](diffhunk://#diff-bd8eb3cccfbc82c334c7ef37a97c99334b672b51912beb3d36ee19edebee46e6L49-R51) [[4]](diffhunk://#diff-bd8eb3cccfbc82c334c7ef37a97c99334b672b51912beb3d36ee19edebee46e6R61) [[5]](diffhunk://#diff-bd8eb3cccfbc82c334c7ef37a97c99334b672b51912beb3d36ee19edebee46e6R100-R103) [[6]](diffhunk://#diff-bd8eb3cccfbc82c334c7ef37a97c99334b672b51912beb3d36ee19edebee46e6R134) [[7]](diffhunk://#diff-bd8eb3cccfbc82c334c7ef37a97c99334b672b51912beb3d36ee19edebee46e6R186-R190) [[8]](diffhunk://#diff-bd8eb3cccfbc82c334c7ef37a97c99334b672b51912beb3d36ee19edebee46e6R199) [[9]](diffhunk://#diff-bd8eb3cccfbc82c334c7ef37a97c99334b672b51912beb3d36ee19edebee46e6L194-R209)
* Refactored `DynamicReturn` and its builder to use a `BiFunction<PageRequest, LongSupplier, Page<T>>` for page creation, and to propagate the `LongSupplier` for total counts, ensuring all paginated queries have access to total count logic. [[1]](diffhunk://#diff-a053fc8259ffcebb03dd254c317aa03fba20cdf9d82cb249f5bd5806ca9eac66R24-R26) [[2]](diffhunk://#diff-a053fc8259ffcebb03dd254c317aa03fba20cdf9d82cb249f5bd5806ca9eac66L51-R60) [[3]](diffhunk://#diff-a053fc8259ffcebb03dd254c317aa03fba20cdf9d82cb249f5bd5806ca9eac66L141-R148) [[4]](diffhunk://#diff-a053fc8259ffcebb03dd254c317aa03fba20cdf9d82cb249f5bd5806ca9eac66R158) [[5]](diffhunk://#diff-a053fc8259ffcebb03dd254c317aa03fba20cdf9d82cb249f5bd5806ca9eac66L207-R213) [[6]](diffhunk://#diff-a053fc8259ffcebb03dd254c317aa03fba20cdf9d82cb249f5bd5806ca9eac66L247-R260) [[7]](diffhunk://#diff-a053fc8259ffcebb03dd254c317aa03fba20cdf9d82cb249f5bd5806ca9eac66L324-R341) [[8]](diffhunk://#diff-a053fc8259ffcebb03dd254c317aa03fba20cdf9d82cb249f5bd5806ca9eac66R356-R365)

**General codebase improvements:**

* Updated relevant imports and constructors to support the new supplier-based paging and to ensure all required fields are present and non-null.

These changes collectively enable more efficient and accurate paging support in JNoSQL, especially for use cases where total counts are expensive to compute.