### PR TITLE
fix: Backport repository entity inference for FROM-less projection queries to 1.1.x

### DIFF
--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
@@ -129,9 +129,10 @@ public class CustomRepositoryHandler implements InvocationHandler {
             }
             case QUERY -> {
                 var repositoryMetadata = repositoryMetadata(method);
-                if (repositoryMetadata.metadata().isEmpty()) {
-                    var query = method.getAnnotation(Query.class);
-                    var queryType = QueryType.parse(query.value());
+                var query = method.getAnnotation(Query.class);
+                var queryType = QueryType.parse(query.value());
+                if (repositoryMetadata.metadata().isEmpty()
+                        && (this.defaultRepository == null || queryType.isNotSelect())) {
                     var returnType = method.getReturnType();
                     boolean namedParameters = queryContainsNamedParameters(query);
                     LOGGER.fine(() -> "Executing the query " + query.value()
@@ -151,8 +152,11 @@ public class CustomRepositoryHandler implements InvocationHandler {
                     }
                     Stream<?> entities = prepare.result();
                     return toResultOfQueryMethod(method, entities);
+                } else if (repositoryMetadata.metadata().isPresent()) {
+                    return unwrapInvocationTargetException(() -> repository(method).executeQuery(instance, method, params));
+                } else {
+                    return unwrapInvocationTargetException(() -> this.defaultRepository.executeQuery(instance, method, params));
                 }
-                return unwrapInvocationTargetException(() -> repository(method).executeQuery(instance, method, params));
 
             }
             case COUNT_BY, COUNT_ALL -> {

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
@@ -504,4 +504,21 @@ class CustomRepositoryHandlerTest {
                 .thenReturn(Stream.of(Person.builder().age(26).name("Ada").build()));
         Assertions.assertThat(people.updateReturnInt("Ada")).isEqualTo(1L);
     }
+
+    @Test
+    void shouldUseDefaultRepositoryEntityForFromLessCountQuery() {
+        var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
+        Mockito.when(template.prepare(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(preparedStatement);
+        Mockito.when(preparedStatement.isCount()).thenReturn(true);
+        Mockito.when(preparedStatement.count()).thenReturn(2L);
+
+        Assertions.assertThat(people.countAdults(18)).isEqualTo(2L);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(template).prepare(captor.capture(), Mockito.eq("Person"));
+        Mockito.verify(template, Mockito.never()).prepare(Mockito.anyString());
+        Mockito.verify(preparedStatement).bind("?1", 18);
+        Assertions.assertThat(captor.getValue()).isEqualTo("SELECT COUNT(THIS) WHERE age > ?1");
+    }
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/People.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/People.java
@@ -103,6 +103,10 @@ public interface People {
 
     @Query("update Person where name = :name")
     long updateReturnInt(@Param("name") String name);
+
+    @Query("SELECT COUNT(THIS) WHERE age > ?1")
+    long countAdults(int age);
+
     @Delete
     void deleteAll();
 }


### PR DESCRIPTION
(cherry picked from commit 9c71e2006ff7387989b87c3390b87aa394b3d30f)

## Description
Backports repository entity inference for FROM-less SELECT queries whose return type is a scalar or projection.

These queries now execute through the inferred default repository so that the repository's primary entity metadata is available during query preparation.

**Related Issue:** Fixes #734  

## Type of Contribution
- [X] Bug fix
- [ ] Feature request
- [ ] New database support
- [ ] Use case implementation
- [ ] Documentation update
- [ ] Other: 

## Architectural and Design Decisions
<!-- Explain WHY you chose this implementation path. Mention any impact on Mappers, Grammar, or API compatibility. -->

## Contribution Checklist
- [X] **ECA:** I have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
- [ ] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
- [X] **Conventional Commits:** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
- [X] **Tests:** I have added/updated unit and integration tests.
- [ ] **Documentation:** I have updated the relevant .adoc files.
- [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results
  - `mvn -B -pl jnosql-mapping/jnosql-mapping-semistructured -am test`
    - 425 tests
    - 0 failures
    - 0 errors
  - The standalone #734 reproducer passes against the patched 1.1.x build.
  - WLS Jakarta Data NoSQL TCK:
    - All five previous `The entity is required in the query` errors are removed.
    - Passing tests increase from 72 to 74.
    - The three newly reached projection assertions expose a separate Oracle NoSQL scalar-value conversion defect.
