### PR TITLE
fix: report affected rows for delete queries

### DIFF
--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CommunicationPreparedStatement.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CommunicationPreparedStatement.java
@@ -164,20 +164,22 @@ public final class CommunicationPreparedStatement {
     }
 
     /**
-     * Returns the number of elements in the result.
+     * Returns the number of elements in a count result or the number of entities deleted by a delete statement.
      *
      * @return the number of elements
      * @throws QueryException if there are parameters left to bind
-     * @throws IllegalArgumentException if the operation is not a count operation
+     * @throws IllegalArgumentException if the operation is neither a count nor a delete operation
      */
     public long count(){
         if (!paramsLeft.isEmpty()) {
             throw new QueryException("Check all the parameters before execute the query, params left: " + paramsLeft);
         }
-        if (PreparedStatementType.COUNT.equals(type)) {
-            return manager.count(selectQuery);
-        }
-        throw new IllegalArgumentException("The count operation is only allowed for COUNT queries");
+        return switch (type) {
+            case COUNT -> manager.count(selectQuery);
+            case DELETE -> manager.deleteAndCount(deleteQuery);
+            default -> throw new IllegalArgumentException(
+                    "The count operation is only allowed for COUNT and DELETE queries");
+        };
 
     }
 

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DatabaseManager.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DatabaseManager.java
@@ -204,6 +204,30 @@ public interface DatabaseManager extends IdFieldNameSupplier, AutoCloseable {
     void delete(DeleteQuery query);
 
     /**
+     * Deletes entities from the database and returns the number of entities deleted.
+     *
+     * <p>Reporting an affected-entity count is an optional provider capability. The default implementation
+     * validates the query and then throws {@link UnsupportedOperationException} without performing the delete.
+     * This does not affect {@link #delete(DeleteQuery)}, so delete operations whose callers do not request a
+     * count continue to use the ordinary delete contract.</p>
+     *
+     * <p>A database provider should override this method only when it can obtain an accurate count from the
+     * delete operation itself. Implementations should not derive the result by counting matching entities before
+     * deletion because that is not atomic and can report an incorrect value. Proxies, decorators, and other
+     * manager wrappers will likely need to explicitly override and delegate this method to expose an underlying
+     * provider's support; otherwise callers receive the default {@link UnsupportedOperationException}.</p>
+     *
+     * @param query the query used to select entities to be deleted
+     * @return the number of entities deleted by this operation
+     * @throws NullPointerException when the query is null
+     * @throws UnsupportedOperationException if the database cannot report an accurate delete count
+     */
+    default long deleteAndCount(DeleteQuery query) {
+        Objects.requireNonNull(query, "query is required");
+        throw new UnsupportedOperationException("The database does not support reporting the number of deleted entities");
+    }
+
+    /**
      * Finds entities in the database based on the specified query.
      *
      * @param query the query used to select entities

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DatabaseManagerTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DatabaseManagerTest.java
@@ -39,6 +39,20 @@ class DatabaseManagerTest {
     @Mock(answer = Answers.CALLS_REAL_METHODS)
     private DatabaseManager databaseManager;
 
+    @Test
+    void shouldNotSupportDeleteAndCountByDefault() {
+        DeleteQuery query = DeleteQuery.delete().from("person").build();
+
+        assertThrows(UnsupportedOperationException.class, () -> databaseManager.deleteAndCount(query));
+        Mockito.verify(databaseManager, Mockito.never()).delete(Mockito.any(DeleteQuery.class));
+    }
+
+    @Test
+    void shouldValidateDeleteAndCountQueryBeforeSupportCheck() {
+        assertThrows(NullPointerException.class, () -> databaseManager.deleteAndCount(null));
+        Mockito.verify(databaseManager, Mockito.never()).delete(Mockito.any(DeleteQuery.class));
+    }
+
 
     @Test
     void shouldReturnErrorWhenThereIsNotSort() {

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DeleteQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DeleteQueryParserTest.java
@@ -16,6 +16,7 @@ import org.eclipse.jnosql.communication.Condition;
 import org.eclipse.jnosql.communication.QueryException;
 import org.eclipse.jnosql.communication.TypeReference;
 import org.eclipse.jnosql.communication.Value;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -267,6 +268,7 @@ class DeleteQueryParserTest {
 
         var prepare = parser.prepare(query, manager, observer);
         assertThrows(QueryException.class, prepare::result);
+        assertThrows(QueryException.class, prepare::count);
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
@@ -292,6 +294,28 @@ class DeleteQueryParserTest {
         assertEquals(Condition.EQUALS, criteriaCondition.condition());
         assertEquals("age", element.name());
         assertEquals(12, element.get());
+    }
+
+    @Test
+    void shouldDelegatePreparedDeleteCount() {
+        var query = "DELETE FROM entity WHERE age = :age";
+        Mockito.when(manager.deleteAndCount(Mockito.any(DeleteQuery.class))).thenReturn(3L);
+
+        var prepare = parser.prepare(query, manager, observer);
+        prepare.bind("age", 12);
+
+        assertEquals(3L, prepare.count());
+
+        var deleteCaptor = ArgumentCaptor.forClass(DeleteQuery.class);
+        Mockito.verify(manager).deleteAndCount(deleteCaptor.capture());
+        Mockito.verify(manager, Mockito.never()).count(Mockito.any(SelectQuery.class));
+        Mockito.verify(manager, Mockito.never()).delete(Mockito.any(DeleteQuery.class));
+        var deleteQuery = deleteCaptor.getValue();
+        assertEquals("entity", deleteQuery.name());
+        var condition = deleteQuery.condition().orElseThrow();
+        assertEquals(Condition.EQUALS, condition.condition());
+        assertEquals("age", condition.element().name());
+        assertEquals(12, condition.element().get());
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
@@ -148,6 +148,14 @@ public class CustomRepositoryHandler implements InvocationHandler {
                     if (prepare.isCount()) {
                         return prepare.count();
                     }
+                    if (QueryType.DELETE.equals(queryType)) {
+                        if (returnsLong(method)) {
+                            return prepare.count();
+                        }
+                        if (returnsInt(method)) {
+                            return (int) prepare.count();
+                        }
+                    }
                     Stream<?> entities = prepare.result();
                     return toResultOfQueryMethod(method, entities);
                 } else if (repositoryMetadata.metadata().isPresent()) {

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
@@ -83,6 +83,8 @@ class CustomRepositoryHandlerTest {
 
     private UpdateArrayPersonRepository updateArrayPersonRepository;
 
+    private DeleteCountRepository deleteCountRepository;
+
     @BeforeEach
     void setUp() {
         template = Mockito.mock(SemiStructuredTemplate.class);
@@ -117,6 +119,13 @@ class CustomRepositoryHandlerTest {
                 .customRepositoryType(UpdateArrayPersonRepository.class)
                 .converters(converters).build();
 
+        var deleteCountHandler = CustomRepositoryHandler.builder()
+                .entitiesMetadata(entitiesMetadata)
+                .template(template)
+                .lifecycleEventHandler(lifecycleEventHandler)
+                .customRepositoryType(DeleteCountRepository.class)
+                .converters(converters).build();
+
         tasks = (Tasks) Proxy.newProxyInstance(Tasks.class.getClassLoader(), new Class[]{Tasks.class},
                 customRepositoryHandlerForTasks);
 
@@ -127,6 +136,10 @@ class CustomRepositoryHandlerTest {
         updateArrayPersonRepository =
                 (UpdateArrayPersonRepository) Proxy.newProxyInstance(UpdateArrayPersonRepository.class.getClassLoader(),
                 new Class[]{UpdateArrayPersonRepository.class}, updateArrayHandler);
+
+        deleteCountRepository =
+                (DeleteCountRepository) Proxy.newProxyInstance(DeleteCountRepository.class.getClassLoader(),
+                        new Class[]{DeleteCountRepository.class}, deleteCountHandler);
 
     }
 
@@ -527,25 +540,51 @@ class CustomRepositoryHandlerTest {
     }
 
     @Test
-    void shouldReturnNumberOfDeletedEntitiesFromDeleteQuery() {
+    void shouldUseResultForVoidDeleteQuery() {
         var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
-        Mockito.when(template.prepare(Mockito.anyString(), Mockito.any())).thenReturn(preparedStatement);
+        Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
         Mockito.when(preparedStatement.isCount())
                 .thenReturn(false);
-        Mockito.when(preparedStatement.singleResult())
-                .thenReturn(Optional.of(1L));
-        people.deleteByNameReturnLong("Ada");
+        deleteCountRepository.deleteByName("Ada");
+        Mockito.verify(preparedStatement).result();
+        Mockito.verify(preparedStatement, Mockito.never()).count();
+    }
+
+    @Test
+    void shouldReturnIntNumberOfDeletedEntitiesFromDeleteQuery() {
+        var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
+        Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
+        Mockito.when(preparedStatement.isCount())
+                .thenReturn(false);
+        Mockito.when(preparedStatement.count()).thenReturn(1L);
+        Assertions.assertThat(deleteCountRepository.deleteByNameReturnInt("Ada")).isEqualTo(1);
+        Mockito.verify(preparedStatement).count();
+        Mockito.verify(preparedStatement, Mockito.never()).result();
+    }
+
+    @Test
+    void shouldReturnLongNumberOfDeletedEntitiesFromDeleteQuery() {
+        var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
+        Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
+        Mockito.when(preparedStatement.isCount())
+                .thenReturn(false);
+        Mockito.when(preparedStatement.count()).thenReturn(3L);
+        Assertions.assertThat(deleteCountRepository.deleteByNameReturnLong("Ada")).isEqualTo(3L);
+        Mockito.verify(preparedStatement).count();
+        Mockito.verify(preparedStatement, Mockito.never()).result();
     }
 
     @Test
     void shouldReturnNumberOfUpdatedEntitiesFromUpdateQuery() {
         var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
-        Mockito.when(template.prepare(Mockito.anyString(), Mockito.any())).thenReturn(preparedStatement);
+        Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
         Mockito.when(preparedStatement.isCount())
                 .thenReturn(false);
-        Mockito.when(preparedStatement.singleResult())
-                .thenReturn(Optional.of(1L));
-        people.updateReturnLong("Ada");
+        Mockito.when(preparedStatement.result())
+                .thenReturn(Stream.of(Person.builder().age(26).name("Ada").build()));
+        Assertions.assertThat(deleteCountRepository.updateReturnLong("Ada")).isEqualTo(1L);
+        Mockito.verify(preparedStatement).result();
+        Mockito.verify(preparedStatement, Mockito.never()).count();
     }
 
     @Test
@@ -695,6 +734,22 @@ class CustomRepositoryHandlerTest {
 
         @Insert
         void insert(Person[] person);
+    }
+
+    @Repository
+    public interface DeleteCountRepository {
+
+        @Query("delete from Person where name = :name")
+        void deleteByName(@jakarta.data.repository.Param("name") String name);
+
+        @Query("delete from Person where name = :name")
+        int deleteByNameReturnInt(@jakarta.data.repository.Param("name") String name);
+
+        @Query("delete from Person where name = :name")
+        long deleteByNameReturnLong(@jakarta.data.repository.Param("name") String name);
+
+        @Query("update Person where name = :name")
+        long updateReturnLong(@jakarta.data.repository.Param("name") String name);
     }
 
 }


### PR DESCRIPTION
## Description
 Adds an optional count-returning delete path for semistructured database providers and uses it for repository methods whose annotated `DELETE` query returns `int`, `Integer`, `long`, or `Long`.

The existing `void delete(DeleteQuery)` contract remains unchanged. Providers that cannot report an accurate affected-entity count continue to support ordinary deletes and receive `UnsupportedOperationException` only when a caller explicitly requests the count.

**Related Issue:** Fixes #739 

## Type of Contribution
- [X] Bug fix
- [ ] Feature request
- [ ] New database support
- [ ] Use case implementation
- [ ] Documentation update
- [ ] Other: 

## Architectural and Design Decisions
`DatabaseManager.deleteAndCount(DeleteQuery)` is a default method to preserve binary compatibility for existing providers. Its default implementation validates the query and throws `UnsupportedOperationException` without performing a delete. Providers opt in by overriding it when the delete operation itself supplies an accurate count; implementations should not pre-count matching entities because that is non-atomic.

`CommunicationPreparedStatement.count()` now accepts both `COUNT` and `DELETE`: `COUNT` continues to call `DatabaseManager.count(SelectQuery)`, while `DELETE` calls `DatabaseManager.deleteAndCount(DeleteQuery)`.

`CustomRepositoryHandler` routes numeric annotated `DELETE` methods through `PreparedStatement.count()`, including conversion for `int`/`Integer`. Void deletes and non-delete numeric query behavior remain unchanged.  No query grammar changes are required.

The API Javadocs explain provider opt-in behavior and note that proxies, decorators, and manager wrappers will likely need to delegate the new default method to expose provider support.


## Contribution Checklist
- [X] **ECA:** I have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
- [X] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
- [X] **Conventional Commits:** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
- [X] **Tests:** I have added/updated unit and integration tests.
- [ ] **Documentation:** I have updated the relevant .adoc files.
- [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results

- Communication focused tests: 49 tests, 0 failures, 0 errors.
- Mapping handler tests: 47 tests, 0 failures, 0 errors; all 10 required reactor projects succeeded.
- Combined core and Oracle provider candidate: Jakarta Data NoSQL TCK, 88 tests, 0 failures, 0 errors.

