### PR TITLE
fix: report affected rows for delete queries

### DIFF
--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CommunicationPreparedStatement.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CommunicationPreparedStatement.java
@@ -160,20 +160,22 @@ public final class CommunicationPreparedStatement {
     }
 
     /**
-     * Returns the number of elements in the result.
+     * Returns the number of elements in a count result or the number of entities deleted by a delete statement.
      *
      * @return the number of elements
      * @throws QueryException if there are parameters left to bind
-     * @throws IllegalArgumentException if the operation is not a count operation
+     * @throws IllegalArgumentException if the operation is neither a count nor a delete operation
      */
     public long count(){
         if (!paramsLeft.isEmpty()) {
             throw new QueryException("Check all the parameters before execute the query, params left: " + paramsLeft);
         }
-        if (PreparedStatementType.COUNT.equals(type)) {
-            return manager.count(selectQuery);
-        }
-        throw new IllegalArgumentException("The count operation is only allowed for COUNT queries");
+        return switch (type) {
+            case COUNT -> manager.count(selectQuery);
+            case DELETE -> manager.deleteAndCount(deleteQuery);
+            default -> throw new IllegalArgumentException(
+                    "The count operation is only allowed for COUNT and DELETE queries");
+        };
 
     }
 

--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DatabaseManager.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/DatabaseManager.java
@@ -190,6 +190,30 @@ public interface DatabaseManager extends AutoCloseable {
     void delete(DeleteQuery query);
 
     /**
+     * Deletes entities from the database and returns the number of entities deleted.
+     *
+     * <p>Reporting an affected-entity count is an optional provider capability. The default implementation
+     * validates the query and then throws {@link UnsupportedOperationException} without performing the delete.
+     * This does not affect {@link #delete(DeleteQuery)}, so delete operations whose callers do not request a
+     * count continue to use the ordinary delete contract.</p>
+     *
+     * <p>A database provider should override this method only when it can obtain an accurate count from the
+     * delete operation itself. Implementations should not derive the result by counting matching entities before
+     * deletion because that is not atomic and can report an incorrect value. Proxies, decorators, and other
+     * manager wrappers will likely need to explicitly override and delegate this method to expose an underlying
+     * provider's support; otherwise callers receive the default {@link UnsupportedOperationException}.</p>
+     *
+     * @param query the query used to select entities to be deleted
+     * @return the number of entities deleted by this operation
+     * @throws NullPointerException when the query is null
+     * @throws UnsupportedOperationException if the database cannot report an accurate delete count
+     */
+    default long deleteAndCount(DeleteQuery query) {
+        Objects.requireNonNull(query, "query is required");
+        throw new UnsupportedOperationException("The database does not support reporting the number of deleted entities");
+    }
+
+    /**
      * Finds entities in the database based on the specified query.
      *
      * @param query the query used to select entities

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DatabaseManagerTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DatabaseManagerTest.java
@@ -38,6 +38,20 @@ class DatabaseManagerTest {
     @Mock(answer = Answers.CALLS_REAL_METHODS)
     private DatabaseManager databaseManager;
 
+    @Test
+    void shouldNotSupportDeleteAndCountByDefault() {
+        DeleteQuery query = DeleteQuery.delete().from("person").build();
+
+        assertThrows(UnsupportedOperationException.class, () -> databaseManager.deleteAndCount(query));
+        Mockito.verify(databaseManager, Mockito.never()).delete(Mockito.any(DeleteQuery.class));
+    }
+
+    @Test
+    void shouldValidateDeleteAndCountQueryBeforeSupportCheck() {
+        assertThrows(NullPointerException.class, () -> databaseManager.deleteAndCount(null));
+        Mockito.verify(databaseManager, Mockito.never()).delete(Mockito.any(DeleteQuery.class));
+    }
+
 
     @Test
     void shouldReturnErrorWhenThereIsNotSort() {

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DeleteQueryParserTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DeleteQueryParserTest.java
@@ -16,6 +16,7 @@ import org.eclipse.jnosql.communication.Condition;
 import org.eclipse.jnosql.communication.QueryException;
 import org.eclipse.jnosql.communication.TypeReference;
 import org.eclipse.jnosql.communication.Value;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -267,6 +268,7 @@ class DeleteQueryParserTest {
 
         var prepare = parser.prepare(query, manager, observer);
         assertThrows(QueryException.class, prepare::result);
+        assertThrows(QueryException.class, prepare::count);
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")
@@ -292,6 +294,28 @@ class DeleteQueryParserTest {
         assertEquals(Condition.EQUALS, criteriaCondition.condition());
         assertEquals("age", element.name());
         assertEquals(12, element.get());
+    }
+
+    @Test
+    void shouldDelegatePreparedDeleteCount() {
+        var query = "DELETE FROM entity WHERE age = :age";
+        Mockito.when(manager.deleteAndCount(Mockito.any(DeleteQuery.class))).thenReturn(3L);
+
+        var prepare = parser.prepare(query, manager, observer);
+        prepare.bind("age", 12);
+
+        assertEquals(3L, prepare.count());
+
+        var deleteCaptor = ArgumentCaptor.forClass(DeleteQuery.class);
+        Mockito.verify(manager).deleteAndCount(deleteCaptor.capture());
+        Mockito.verify(manager, Mockito.never()).count(Mockito.any(SelectQuery.class));
+        Mockito.verify(manager, Mockito.never()).delete(Mockito.any(DeleteQuery.class));
+        var deleteQuery = deleteCaptor.getValue();
+        assertEquals("entity", deleteQuery.name());
+        var condition = deleteQuery.condition().orElseThrow();
+        assertEquals(Condition.EQUALS, condition.condition());
+        assertEquals("age", condition.element().name());
+        assertEquals(12, condition.element().get());
     }
 
     @ParameterizedTest(name = "Should parser the query {0}")

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandler.java
@@ -149,6 +149,14 @@ public class CustomRepositoryHandler implements InvocationHandler {
                     if (prepare.isCount()) {
                         return prepare.count();
                     }
+                    if (QueryType.DELETE.equals(queryType)) {
+                        if (returnsLong(method)) {
+                            return prepare.count();
+                        }
+                        if (returnsInt(method)) {
+                            return (int) prepare.count();
+                        }
+                    }
                     Stream<?> entities = prepare.result();
                     return toResultOfQueryMethod(method, entities);
                 }
@@ -350,6 +358,5 @@ public class CustomRepositoryHandler implements InvocationHandler {
     private static boolean returnsBoolean(Method method) {
         return method.getReturnType().equals(boolean.class) || method.getReturnType().equals(Boolean.class);
     }
-
 
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryHandlerTest.java
@@ -404,6 +404,8 @@ class CustomRepositoryHandlerTest {
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         Mockito.verify(template).prepare(captor.capture());
         Mockito.verifyNoMoreInteractions(template);
+        Mockito.verify(preparedStatement).result();
+        Mockito.verify(preparedStatement, Mockito.never()).count();
         var query = captor.getValue();
 
         Assertions.assertThat(query).isEqualTo("delete from Person where name = :name");
@@ -484,14 +486,27 @@ class CustomRepositoryHandlerTest {
     }
 
     @Test
-    void shouldReturnNumberOfDeletedEntitiesFromDeleteQuery() {
+    void shouldReturnIntNumberOfDeletedEntitiesFromDeleteQuery() {
         var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
         Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
         Mockito.when(preparedStatement.isCount())
                 .thenReturn(false);
-        Mockito.when(preparedStatement.result())
-                .thenReturn(Stream.of(Person.builder().age(26).name("Ada").build()));
-        Assertions.assertThat(people.deleteByNameReturnInt("Ada")).isEqualTo(1L);
+        Mockito.when(preparedStatement.count()).thenReturn(1L);
+        Assertions.assertThat(people.deleteByNameReturnInt("Ada")).isEqualTo(1);
+        Mockito.verify(preparedStatement).count();
+        Mockito.verify(preparedStatement, Mockito.never()).result();
+    }
+
+    @Test
+    void shouldReturnLongNumberOfDeletedEntitiesFromDeleteQuery() {
+        var preparedStatement = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
+        Mockito.when(template.prepare(Mockito.anyString())).thenReturn(preparedStatement);
+        Mockito.when(preparedStatement.isCount())
+                .thenReturn(false);
+        Mockito.when(preparedStatement.count()).thenReturn(3L);
+        Assertions.assertThat(people.deleteByNameReturnLong("Ada")).isEqualTo(3L);
+        Mockito.verify(preparedStatement).count();
+        Mockito.verify(preparedStatement, Mockito.never()).result();
     }
 
     @Test
@@ -503,5 +518,7 @@ class CustomRepositoryHandlerTest {
         Mockito.when(preparedStatement.result())
                 .thenReturn(Stream.of(Person.builder().age(26).name("Ada").build()));
         Assertions.assertThat(people.updateReturnInt("Ada")).isEqualTo(1L);
+        Mockito.verify(preparedStatement).result();
+        Mockito.verify(preparedStatement, Mockito.never()).count();
     }
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/People.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/People.java
@@ -99,7 +99,10 @@ public interface People {
     }
 
     @Query("delete from Person where name = :name")
-    long deleteByNameReturnInt(@Param("name") String name);
+    int deleteByNameReturnInt(@Param("name") String name);
+
+    @Query("delete from Person where name = :name")
+    long deleteByNameReturnLong(@Param("name") String name);
 
     @Query("update Person where name = :name")
     long updateReturnInt(@Param("name") String name);


### PR DESCRIPTION
(cherry picked from commit 043c0c41e098035f14cd512fd5ba890680a921a5)

## Description
Backports the optional count-returning delete path for semistructured database providers and the repository handling needed for annotated `DELETE` methods returning `int`, `Integer`, `long`, or `Long`.

The existing `void delete(DeleteQuery)` contract remains unchanged. Providers that cannot report an accurate affected-entity count continue to support ordinary deletes and receive `UnsupportedOperationException` only when a caller explicitly requests the count.

**Related Issue:** Fixes #739 

## Type of Contribution
- [X] Bug fix
- [ ] Feature request
- [ ] New database support
- [ ] Use case implementation
- [ ] Documentation update
- [ ] Other: 

## Architectural and Design Decisions
`DatabaseManager.deleteAndCount(DeleteQuery)` remains a binary-compatible default method. Its default implementation validates the query and throws `UnsupportedOperationException` without deleting. Providers opt in only when the delete operation itself supplies an accurate affected-entity count.

Prepared `DELETE` counts route to `DatabaseManager.deleteAndCount(DeleteQuery)`, and numeric annotated `DELETE` methods route through `PreparedStatement.count()`. Void deletes and non-delete numeric query behavior remain unchanged. No query grammar changes are required.

The production changes are the main-line cherry-pick. The mapping test fixture is adapted to the 1.1.x repository interface shape while testing the same void, `int`, `long`, and non-delete behavior.

## Contribution Checklist
- [X] **ECA:** I have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
- [X] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
- [X] **Conventional Commits:** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
- [X] **Tests:** I have added/updated unit and integration tests.
- [ ] **Documentation:** I have updated the relevant .adoc files.
- [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results

- JNoSQL Communication Semistructured: 324 tests, 0 failures, 0 errors, 2 skipped.
- JNoSQL Mapping Semistructured: 425 tests, 0 failures, 0 errors.
- Combined core and Oracle provider candidate: Jakarta Data NoSQL TCK, 88 tests, 0 failures, 0 errors.
