### PR TITLE
Fix ConstructorBuilder service loading with custom class loader

### DIFF
--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilder.java
@@ -30,7 +30,10 @@ import java.util.ServiceLoader;
  */
 public interface ConstructorBuilder {
 
-    ConstructorBuilderSupplier CONSTRUCTOR_BUILDER_SUPPLIER = ServiceLoader.load(ConstructorBuilderSupplier.class)
+    ConstructorBuilderSupplier CONSTRUCTOR_BUILDER_SUPPLIER = ServiceLoader.load(
+                    ConstructorBuilderSupplier.class,
+                    ConstructorBuilder.class.getClassLoader()
+            )
             .findFirst()
             .orElseThrow(() ->
                     new NoSQLException("There is not implementation for the ConstructorBuilderSupplier"));

--- a/jnosql-mapping/jnosql-mapping-api-core/src/test/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilderTest.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/test/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilderTest.java
@@ -28,4 +28,23 @@ class ConstructorBuilderTest {
         SoftAssertions.assertSoftly(soft -> soft.assertThat(builder).isNotNull());
     }
 
+    @Test
+    void shouldReturnValidConstructorBuilderWhenTcclCannotSeeProvider() {
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+
+        try {
+            ClassLoader isolatedClassLoader = new ClassLoader(null) {
+            };
+            Thread.currentThread().setContextClassLoader(isolatedClassLoader);
+
+            ConstructorMetadata constructorMetadata = mock(ConstructorMetadata.class);
+
+            ConstructorBuilder builder = ConstructorBuilder.of(constructorMetadata);
+
+            SoftAssertions.assertSoftly(soft ->
+                    soft.assertThat(builder).isNotNull());
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
 }


### PR DESCRIPTION
**Related to #631** — improves `ConstructorBuilder`'s ServiceLoader robustness against thread context class loaders that cannot see the provider.

## Issue

`ConstructorBuilder` previously used:

```java
ServiceLoader.load(ConstructorBuilderSupplier.class)
```

This relies solely on the thread context class loader (TCCL). In Quarkus/Vert.x async contexts, the TCCL may not see the provider even though it is available via the API classloader. This caused intermittent:

```
jakarta.nosql.NoSQLException: There is not implementation for the ConstructorBuilderSupplier
```

## Solution

- Changed the service lookup to explicitly use `ConstructorBuilder.class.getClassLoader()` instead of relying on the implicit thread context class loader.
- This makes SPI discovery robust against TCCL mismatches.
- Added a regression test that simulates a TCCL that cannot see the provider and verifies the lookup still succeeds.
- Retained the original unit test (`shouldReturnValidConstructorBuilder`) alongside the new regression test.

## Scope

- This PR targets the `1.1.x` branch.
- The same fragility likely exists on `main`/`1.2.x`. Maintainers: please confirm whether fixes are backported forward automatically, or if I should open a parallel PR against `main`. Happy to do either — just want to avoid duplicating work.

## Impact

- Fixes the intermittent `NoSQLException` in Quarkus/Vert.x async contexts.
- No behavior change for normal applications.
- Minimal, reversible change contained within `ConstructorBuilder`.

## Note on the broader issue

Per maintainer feedback, #631's root cause also involves missing `CompletionStage` support in the repository invocation engine. That enhancement is being tracked and implemented separately. This PR stands on its own as a ServiceLoader/TCCL robustness fix, independent of that work.

## Verification

- `ConstructorBuilderTest`: 2 tests passed.
- `jnosql-mapping-api-core`: 62 tests passed.
- Checkstyle: 0 violations.
- `git diff --check`: passed.
- Regression test added for the TCCL blind case.