### PR TITLE
fix: honor page total requests

### DIFF
--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
@@ -14,6 +14,7 @@
  */
 package org.eclipse.jnosql.mapping.core;
 
+import java.util.Objects;
 import java.util.function.LongSupplier;
 
 
@@ -26,7 +27,8 @@ import java.util.function.LongSupplier;
  * returned for all future invocations.</p>
  *
  * <p>This implementation is thread-safe and guarantees that the delegate
- * supplier is executed at most once.</p>
+ * supplier is executed at most once. A runtime exception or error is cached
+ * and rethrown on subsequent accesses.</p>
  *
  * <p>This utility is useful for expensive operations such as database
  * aggregation queries, count operations, or remote service calls that should
@@ -54,8 +56,10 @@ final class LazyLongSupplier implements LongSupplier {
 
     private RuntimeException failure;
 
+    private Error error;
+
     private LazyLongSupplier(LongSupplier delegate) {
-        this.delegate = delegate;
+        this.delegate = Objects.requireNonNull(delegate, "delegate is required");
     }
 
     @Override
@@ -68,6 +72,8 @@ final class LazyLongSupplier implements LongSupplier {
                         value = delegate.getAsLong();
                     } catch (RuntimeException exception) {
                         failure = exception;
+                    } catch (Error error) {
+                        this.error = error;
                     } finally {
                         loaded = true;
                     }
@@ -77,6 +83,10 @@ final class LazyLongSupplier implements LongSupplier {
 
         if (failure != null) {
             throw failure;
+        }
+
+        if (error != null) {
+            throw error;
         }
 
         return value;

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -32,6 +32,8 @@ import java.util.function.LongSupplier;
  */
 public class NoSQLPage<T> implements Page<T> {
 
+    private static final String TOTALS_UNAVAILABLE = "Total elements were not retrieved for this page";
+
     private final List<T> entities;
 
     private final PageRequest pageRequest;
@@ -46,13 +48,21 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public long totalElements() {
-        return totalSupplier.getAsLong();
+        if (!pageRequest.requestTotal()) {
+            throw new IllegalStateException(TOTALS_UNAVAILABLE);
+        }
+        try {
+            return totalSupplier.getAsLong();
+        } catch (UnsupportedOperationException exception) {
+            throw new IllegalStateException(TOTALS_UNAVAILABLE, exception);
+        }
     }
 
     @Override
     public long totalPages() {
         long totalElements = totalElements();
-        return (long) Math.ceil((double) totalElements / pageRequest.size());
+        long pageSize = pageRequest.size();
+        return totalElements / pageSize + (totalElements % pageSize == 0 ? 0 : 1);
     }
 
     @Override
@@ -93,14 +103,23 @@ public class NoSQLPage<T> implements Page<T> {
     @Override
     public PageRequest nextPageRequest() {
 
-        if (hasTotals() && !hasNext()) {
+        if (!hasNext()) {
+            if (hasTotals()) {
+                throw new NoSuchElementException(
+                        String.format(
+                                "Unable to navigate to next page. " +
+                                        "Current page: %d, page size: %d, total pages: %d",
+                                this.pageRequest.page(),
+                                this.pageRequest.size(),
+                                totalPages()
+                        )
+                );
+            }
             throw new NoSuchElementException(
                     String.format(
-                            "Unable to navigate to next page. " +
-                                    "Current page: %d, page size: %d, total pages: %d",
+                            "Unable to navigate to next page. Current page: %d, page size: %d",
                             this.pageRequest.page(),
-                            this.pageRequest.size(),
-                            totalPages()
+                            this.pageRequest.size()
                     )
             );
         }
@@ -133,6 +152,9 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public boolean hasTotals() {
+        if (!pageRequest.requestTotal()) {
+            return false;
+        }
         try {
             totalSupplier.getAsLong();
             return true;
@@ -185,6 +207,7 @@ public class NoSQLPage<T> implements Page<T> {
     public static <T> Page<T> of(List<T> entities, PageRequest pageRequest, LongSupplier totalSupplier) {
         Objects.requireNonNull(entities, "entities is required");
         Objects.requireNonNull(pageRequest, "pageRequest is required");
+        Objects.requireNonNull(totalSupplier, "totalSupplier is required");
         return new NoSQLPage<>(entities, pageRequest, LazyLongSupplier.of(totalSupplier));
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
@@ -25,9 +25,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongSupplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 class LazyLongSupplierTest {
+
+    @DisplayName("Should reject null delegate")
+    @Test
+    void shouldRejectNullDelegate() {
+
+        assertThatThrownBy(() -> LazyLongSupplier.of(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("delegate is required");
+    }
 
     @Nested
     @DisplayName("getAsLong")
@@ -211,6 +221,26 @@ class LazyLongSupplierTest {
                     .isInstanceOf(IllegalStateException.class)
                     .hasMessage("Database failure");
 
+            assertThat(counter.get()).isEqualTo(1);
+        }
+
+        @DisplayName("Should cache error")
+        @Test
+        void shouldCacheError() {
+
+            AtomicInteger counter = new AtomicInteger();
+            AssertionError failure = new AssertionError("Database failure");
+            LongSupplier delegate = () -> {
+                counter.incrementAndGet();
+                throw failure;
+            };
+            LazyLongSupplier supplier = LazyLongSupplier.of(delegate);
+
+            Throwable first = catchThrowable(supplier::getAsLong);
+            Throwable second = catchThrowable(supplier::getAsLong);
+
+            assertThat(first).isSameAs(failure);
+            assertThat(second).isSameAs(failure);
             assertThat(counter.get()).isEqualTo(1);
         }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
@@ -60,6 +60,16 @@ class NoSQLPageTest {
                     .isInstanceOf(NullPointerException.class)
                     .hasMessage("entities is required");
         }
+
+        @DisplayName("Should reject null total supplier")
+        @Test
+        void shouldRejectNullTotalSupplier() {
+
+            assertThatThrownBy(() ->
+                    NoSQLPage.of(Collections.emptyList(), PageRequest.ofPage(1), null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("totalSupplier is required");
+        }
     }
 
     @Nested
@@ -83,7 +93,9 @@ class NoSQLPageTest {
             Page<Person> page = unsupportedTotalsPage();
 
             assertThatThrownBy(page::totalElements)
-                    .isInstanceOf(UnsupportedOperationException.class);
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Total elements were not retrieved for this page")
+                    .hasCauseInstanceOf(UnsupportedOperationException.class);
         }
 
         @DisplayName("Should execute supplier only once")
@@ -100,6 +112,8 @@ class NoSQLPageTest {
                         return 100L;
                     }
             );
+
+            assertThat(counter.get()).isZero();
 
             page.totalElements();
             page.totalElements();
@@ -142,6 +156,16 @@ class NoSQLPageTest {
                     .isZero();
         }
 
+        @DisplayName("Should calculate large totals without losing precision")
+        @Test
+        void shouldCalculateLargeTotalsWithoutLosingPrecision() {
+
+            Page<Person> page = pageWithTotals(Long.MAX_VALUE, 10);
+
+            assertThat(page.totalPages())
+                    .isEqualTo(Long.MAX_VALUE / 10 + 1);
+        }
+
         @DisplayName("Should throw exception when totals are unsupported")
         @Test
         void shouldThrowExceptionWhenTotalsAreUnsupported() {
@@ -149,7 +173,9 @@ class NoSQLPageTest {
             Page<Person> page = unsupportedTotalsPage();
 
             assertThatThrownBy(page::totalPages)
-                    .isInstanceOf(UnsupportedOperationException.class);
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Total elements were not retrieved for this page")
+                    .hasCauseInstanceOf(UnsupportedOperationException.class);
         }
     }
 
@@ -173,6 +199,57 @@ class NoSQLPageTest {
             Page<Person> page = unsupportedTotalsPage();
 
             assertThat(page.hasTotals()).isFalse();
+        }
+
+        @DisplayName("Should not execute supplier when totals were not requested")
+        @Test
+        void shouldNotExecuteSupplierWhenTotalsWereNotRequested() {
+
+            AtomicInteger counter = new AtomicInteger();
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(1).withoutTotal(),
+                    () -> {
+                        counter.incrementAndGet();
+                        return 10L;
+                    }
+            );
+
+            assertThat(page.hasTotals()).isFalse();
+            assertThat(page.hasNext()).isFalse();
+            assertThatThrownBy(page::totalElements)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Total elements were not retrieved for this page");
+            assertThatThrownBy(page::totalPages)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Total elements were not retrieved for this page");
+            assertThat(counter.get()).isZero();
+        }
+
+        @DisplayName("Should cache an unsupported provider result")
+        @Test
+        void shouldCacheUnsupportedProviderResult() {
+
+            AtomicInteger counter = new AtomicInteger();
+            UnsupportedOperationException providerFailure =
+                    new UnsupportedOperationException("Count is not supported");
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(1),
+                    () -> {
+                        counter.incrementAndGet();
+                        throw providerFailure;
+                    }
+            );
+
+            assertThat(page.hasTotals()).isFalse();
+            assertThatThrownBy(page::totalElements)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasCause(providerFailure);
+            assertThatThrownBy(page::totalPages)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasCause(providerFailure);
+            assertThat(counter.get()).isEqualTo(1);
         }
     }
 
@@ -316,6 +393,27 @@ class NoSQLPageTest {
             PageRequest next = page.nextPageRequest();
 
             assertThat(next.page()).isEqualTo(2);
+        }
+
+        @DisplayName("Should reject navigation from a short page without totals")
+        @Test
+        void shouldRejectNavigationFromShortPageWithoutTotals() {
+
+            AtomicInteger counter = new AtomicInteger();
+            Page<Person> page = NoSQLPage.of(
+                    people(),
+                    PageRequest.ofPage(1).size(10).withoutTotal(),
+                    () -> {
+                        counter.incrementAndGet();
+                        return 30L;
+                    }
+            );
+
+            assertThat(page.hasNext()).isFalse();
+            assertThatThrownBy(page::nextPageRequest)
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("Current page: 1");
+            assertThat(counter.get()).isZero();
         }
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
@@ -88,7 +88,11 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
                     var prepare = (org.eclipse.jnosql.mapping.semistructured.PreparedStatement) template().prepare(textQuery, entity);
                     List<Sort<?>> sortsFromAnnotation = getSorts(method, entityMetadata());
                     if (sortsFromAnnotation.isEmpty()) {
-                        prepare.setSelectMapper(query -> updateQueryDynamically(params, query, first));
+                        prepare.setSelectMapper(query -> {
+                            var selectQuery = updateQueryDynamically(params, query, first);
+                            selectQueryAtomicReference.set(selectQuery);
+                            return selectQuery;
+                        });
                     } else {
                         prepare.setSelectMapper(query -> {
                             var selectQuery = updateQueryDynamically(params, query, first);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/RepositoryProxyPageRequestTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/RepositoryProxyPageRequestTest.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
@@ -827,6 +829,50 @@ public class RepositoryProxyPageRequestTest {
         });
     }
 
+    @DisplayName("Should provide the bound paged query to lazy totals without order by")
+    @Test
+    public void shouldProvideBoundPagedQueryToLazyTotalsWithoutOrderBy() {
+        Person ada = Person.builder().age(20).name("Ada").build();
+        var prepare = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
+        var selectMapper = new AtomicReference<UnaryOperator<SelectQuery>>();
+        var mappedQuery = new AtomicReference<SelectQuery>();
+        SelectQuery parsedQuery = SelectQuery.select().from("Person").where("name").eq("Ada").build();
+
+        Mockito.doAnswer(invocation -> {
+            selectMapper.set(invocation.getArgument(0));
+            return null;
+        }).when(prepare).setSelectMapper(any());
+        when(prepare.result()).thenAnswer(invocation -> {
+            SelectQuery query = selectMapper.get().apply(parsedQuery);
+            mappedQuery.set(query);
+            return Stream.of(ada);
+        });
+        when(template.prepare("select * from Person where name = :name", "Person")).thenReturn(prepare);
+        when(template.count(any(SelectQuery.class))).thenReturn(14L);
+
+        PageRequest pageRequest = PageRequest.ofPage(2, 5, true);
+        Page<Person> page = personRepository.pageJdql("Ada", pageRequest);
+
+        verify(template, Mockito.never()).count(any(SelectQuery.class));
+        assertThat(page.content()).containsExactly(ada);
+        assertThat(page.totalElements()).isEqualTo(14L);
+        assertThat(page.totalPages()).isEqualTo(3L);
+        assertThat(page.hasTotals()).isTrue();
+        verify(prepare).bind("name", "Ada");
+
+        ArgumentCaptor<SelectQuery> countQuery = ArgumentCaptor.forClass(SelectQuery.class);
+        verify(template).count(countQuery.capture());
+        SelectQuery query = countQuery.getValue();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(query).isSameAs(mappedQuery.get());
+            soft.assertThat(query.name()).isEqualTo("Person");
+            soft.assertThat(query.skip()).isEqualTo(5L);
+            soft.assertThat(query.limit()).isEqualTo(5L);
+            soft.assertThat(query.sorts()).isEmpty();
+            soft.assertThat(query.condition()).contains(CriteriaCondition.eq(Element.of("name", "Ada")));
+        });
+    }
+
     private PageRequest getPageRequest() {
         return PageRequest.ofPage(2).size(6);
     }
@@ -853,6 +899,9 @@ public class RepositoryProxyPageRequestTest {
 
         @Query("select * from Person where name = :name")
         CursoredPage<Person> cursorJQDL(@Param("name") String name, PageRequest pageRequest);
+
+        @Query("select * from Person where name = :name")
+        Page<Person> pageJdql(@Param("name") String name, PageRequest pageRequest);
 
         List<Person> findByName(String name, Sort<Person> sort);
 


### PR DESCRIPTION
## Description
Corrects offset `Page` total handling so it honors `PageRequest.requestTotal()`, reports unavailable totals according to the Jakarta Data contract, calculates large page counts without precision loss, and retains the mapped query needed by annotated repository methods.

**Related Issue:** Fixes #753  

## Type of Contribution
- [X] Bug fix
- [ ] Feature request
- [ ] New database support
- [ ] Use case implementation
- [ ] Documentation update
- [ ] Other: 

## Architectural and Design Decisions
  The fix remains in the JNoSQL mapping layer, where `Page` instances are created and `PageRequest` semantics are interpreted. Database providers already expose the required count operation, so no provider-specific implementation or SPI change is needed.

  Counts remain lazy and are cached, avoiding an additional database operation unless total information is actually accessed. Requests created with `requestTotal == false` never invoke the count supplier.

  The legacy repository proxy now retains the final mapped and parameter-bound `SelectQuery`, ensuring that an annotated `@Query` method counts the same query used to obtain its page content.

  There are no grammar changes, mapper-format changes, cursor-pagination changes, public API removals, or incompatible signature changes.

## Contribution Checklist
- [X] **ECA:** I have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
- [ ] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
- [X] **Conventional Commits:** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
- [X] **Tests:** I have added/updated unit and integration tests.
- [ ] **Documentation:** I have updated the relevant .adoc files.
- [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results
  - `NoSQLPageTest` and `LazyLongSupplierTest`: 44 tests passed with no failures or errors.
  - `RepositoryProxyPageRequestTest`: 30 tests passed with no failures or errors.
  - The affected mapping reactor completed successfully.
  - RAT and Checkstyle completed successfully.
  - A standalone, database-free reproducer passed all 4 tests against the fix.
  - `git diff --check` completed successfully.
