### PR TITLE
fix: honor page total requests

### DIFF
--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/LazyLongSupplier.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.core;
+
+import java.util.Objects;
+import java.util.function.LongSupplier;
+
+/**
+ * A thread-safe {@link LongSupplier} that evaluates its delegate at most once.
+ * Both a successfully computed value and a runtime exception or error are cached.
+ */
+final class LazyLongSupplier implements LongSupplier {
+
+    private final LongSupplier delegate;
+
+    private volatile boolean loaded;
+
+    private long value;
+
+    private RuntimeException failure;
+
+    private Error error;
+
+    private LazyLongSupplier(LongSupplier delegate) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate is required");
+    }
+
+    @Override
+    public long getAsLong() {
+        if (!loaded) {
+            synchronized (this) {
+                if (!loaded) {
+                    try {
+                        value = delegate.getAsLong();
+                    } catch (RuntimeException exception) {
+                        failure = exception;
+                    } catch (Error error) {
+                        this.error = error;
+                    } finally {
+                        loaded = true;
+                    }
+                }
+            }
+        }
+
+        if (failure != null) {
+            throw failure;
+        }
+        if (error != null) {
+            throw error;
+        }
+        return value;
+    }
+
+    static LazyLongSupplier of(LongSupplier delegate) {
+        return new LazyLongSupplier(delegate);
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/NoSQLPage.java
@@ -21,7 +21,9 @@ import jakarta.data.page.PageRequest;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.function.LongSupplier;
 
 /**
  * A JNoSQL implementation of {@link  Page}
@@ -30,23 +32,41 @@ import java.util.Objects;
  */
 public class NoSQLPage<T> implements Page<T> {
 
+    private static final String TOTALS_UNAVAILABLE = "Total elements were not retrieved for this page";
+
+    private static final LongSupplier UNSUPPORTED_TOTAL = () -> {
+        throw new UnsupportedOperationException("The database provider does not support page totals");
+    };
+
     private final List<T> entities;
 
     private final PageRequest pageRequest;
 
-    private NoSQLPage(List<T> entities, PageRequest pageRequest) {
+    private final LongSupplier totalSupplier;
+
+    private NoSQLPage(List<T> entities, PageRequest pageRequest, LongSupplier totalSupplier) {
         this.entities = entities;
         this.pageRequest = pageRequest;
+        this.totalSupplier = totalSupplier;
     }
 
     @Override
     public long totalElements() {
-        throw new UnsupportedOperationException("JNoSQL has no support for this feature yet");
+        if (!pageRequest.requestTotal()) {
+            throw new IllegalStateException(TOTALS_UNAVAILABLE);
+        }
+        try {
+            return totalSupplier.getAsLong();
+        } catch (UnsupportedOperationException exception) {
+            throw new IllegalStateException(TOTALS_UNAVAILABLE, exception);
+        }
     }
 
     @Override
     public long totalPages() {
-        throw new UnsupportedOperationException("JNoSQL has no support for this feature yet");
+        long totalElements = totalElements();
+        long pageSize = pageRequest.size();
+        return totalElements / pageSize + (totalElements % pageSize == 0 ? 0 : 1);
     }
 
     @Override
@@ -66,12 +86,15 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public boolean hasNext() {
-      return hasContent() && this.entities.size() == this.pageRequest.size();
+        if (hasTotals()) {
+            return this.pageRequest.page() < totalPages();
+        }
+        return hasContent() && this.entities.size() == this.pageRequest.size();
     }
 
     @Override
     public boolean hasPrevious() {
-        return hasContent();
+        return this.pageRequest.page() > 1;
     }
 
     @Override
@@ -82,19 +105,41 @@ public class NoSQLPage<T> implements Page<T> {
 
     @Override
     public PageRequest nextPageRequest() {
+        if (!hasNext()) {
+            if (hasTotals()) {
+                throw new NoSuchElementException("Unable to navigate to next page. Current page: "
+                        + this.pageRequest.page() + ", page size: " + this.pageRequest.size()
+                        + ", total pages: " + totalPages());
+            }
+            throw new NoSuchElementException("Unable to navigate to next page. Current page: "
+                    + this.pageRequest.page() + ", page size: " + this.pageRequest.size());
+        }
         return PageRequest.ofPage(this.pageRequest.page() + 1, this.pageRequest.size(), this.pageRequest.requestTotal());
     }
 
 
     @Override
     public PageRequest previousPageRequest() {
+        if (!hasPrevious()) {
+            throw new NoSuchElementException("Unable to navigate to previous page. Current page: "
+                    + this.pageRequest.page() + ", page size: " + this.pageRequest.size()
+                    + ". Page numbers start at 1.");
+        }
         return PageRequest.ofPage(this.pageRequest.page() - 1, this.pageRequest.size(), this.pageRequest.requestTotal());
     }
 
 
     @Override
     public boolean hasTotals() {
-        throw new UnsupportedOperationException("Eclipse JNoSQL has no support for this feature hasTotals");
+        if (!pageRequest.requestTotal()) {
+            return false;
+        }
+        try {
+            totalSupplier.getAsLong();
+            return true;
+        } catch (UnsupportedOperationException exception) {
+            return false;
+        }
     }
 
     @Override
@@ -135,9 +180,24 @@ public class NoSQLPage<T> implements Page<T> {
      * @param <T> the entity type
      */
     public static <T> Page<T> of(List<T> entities, PageRequest pageRequest) {
+        return of(entities, pageRequest, UNSUPPORTED_TOTAL);
+    }
+
+    /**
+     * Creates a {@link Page} implementation whose total element count is evaluated lazily.
+     *
+     * @param entities the entities in the requested page
+     * @param pageRequest the page request
+     * @param totalSupplier supplier for the total number of matching entities
+     * @param <T> the entity type
+     * @return a {@link Page} instance
+     * @throws NullPointerException when any parameter is null
+     */
+    public static <T> Page<T> of(List<T> entities, PageRequest pageRequest, LongSupplier totalSupplier) {
         Objects.requireNonNull(entities, "entities is required");
         Objects.requireNonNull(pageRequest, "pageRequest is required");
-        return new NoSQLPage<>(entities, pageRequest);
+        Objects.requireNonNull(totalSupplier, "totalSupplier is required");
+        return new NoSQLPage<>(entities, pageRequest, LazyLongSupplier.of(totalSupplier));
     }
 
     /**

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturn.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturn.java
@@ -21,11 +21,16 @@ import org.eclipse.jnosql.mapping.PreparedStatement;
 import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 
 /**
  * This instance has the information to run the JNoSQL native query at {@link jakarta.data.repository.CrudRepository}
  */
 public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutable {
+
+    private static final LongSupplier UNSUPPORTED_TOTAL = () -> {
+        throw new UnsupportedOperationException("The database provider does not support page totals");
+    };
 
 
     private final Method method;
@@ -33,15 +38,17 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
     private final Class<?> typeClass;
     private final Function<String, PreparedStatement> prepareConverter;
     private final PageRequest pageRequest;
+    private final LongSupplier totalSupplier;
 
     private DynamicQueryMethodReturn(Method method, Object[] args, Class<?> typeClass,
                                      Function<String, PreparedStatement> prepareConverter,
-                                     PageRequest pageRequest) {
+                                     PageRequest pageRequest, LongSupplier totalSupplier) {
         this.method = method;
         this.args = args;
         this.typeClass = typeClass;
         this.prepareConverter = prepareConverter;
         this.pageRequest = pageRequest;
+        this.totalSupplier = totalSupplier;
     }
 
     Method method() {
@@ -64,6 +71,10 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
         return pageRequest;
     }
 
+    LongSupplier totalSupplier() {
+        return totalSupplier;
+    }
+
     boolean hasPagination() {
         return pageRequest != null;
     }
@@ -84,6 +95,7 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
         private Class<?> typeClass;
         private Function<String, PreparedStatement> prepareConverter;
         private PageRequest pageRequest;
+        private LongSupplier totalSupplier = UNSUPPORTED_TOTAL;
 
         private DynamicQueryMethodReturnBuilder() {
         }
@@ -115,11 +127,17 @@ public final class DynamicQueryMethodReturn<T> implements MethodDynamicExecutabl
             return this;
         }
 
+        public DynamicQueryMethodReturnBuilder<T> totalSupplier(LongSupplier totalSupplier) {
+            this.totalSupplier = totalSupplier;
+            return this;
+        }
+
         public DynamicQueryMethodReturn<T> build() {
             Objects.requireNonNull(method, "method is required");
             Objects.requireNonNull(typeClass, "typeClass is required");
             Objects.requireNonNull(prepareConverter, "prepareConverter is required");
-            return new DynamicQueryMethodReturn<>(method, args, typeClass, prepareConverter, pageRequest);
+            Objects.requireNonNull(totalSupplier, "totalSupplier is required");
+            return new DynamicQueryMethodReturn<>(method, args, typeClass, prepareConverter, pageRequest, totalSupplier);
         }
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
@@ -103,7 +103,7 @@ public enum DynamicReturnConverter {
                 .singleResultPagination(p -> prepare.singleResult())
                 .page(p -> {
                     Stream<?> entities = prepare.result();
-                    return NoSQLPage.of(entities.toList(), (PageRequest) p);
+                    return NoSQLPage.of(entities.toList(), (PageRequest) p, dynamicQueryMethod.totalSupplier());
                 }).build();
 
         return convert(dynamicReturn);

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/LazyLongSupplierTest.java
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+
+class LazyLongSupplierTest {
+
+    @Test
+    void shouldRejectNullDelegate() {
+        assertThatThrownBy(() -> LazyLongSupplier.of(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("delegate is required");
+    }
+
+    @Test
+    void shouldLoadAndCacheValueLazily() {
+        AtomicInteger invocations = new AtomicInteger();
+        LazyLongSupplier supplier = LazyLongSupplier.of(() -> {
+            invocations.incrementAndGet();
+            return 42L;
+        });
+
+        assertThat(invocations.get()).isZero();
+        assertThat(supplier.getAsLong()).isEqualTo(42L);
+        assertThat(supplier.getAsLong()).isEqualTo(42L);
+        assertThat(invocations.get()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCacheRuntimeException() {
+        AtomicInteger invocations = new AtomicInteger();
+        IllegalStateException failure = new IllegalStateException("Database failure");
+        LazyLongSupplier supplier = LazyLongSupplier.of(() -> {
+            invocations.incrementAndGet();
+            throw failure;
+        });
+
+        Throwable first = catchThrowable(supplier::getAsLong);
+        Throwable second = catchThrowable(supplier::getAsLong);
+
+        assertThat(first).isSameAs(failure);
+        assertThat(second).isSameAs(failure);
+        assertThat(invocations.get()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldCacheError() {
+        AtomicInteger invocations = new AtomicInteger();
+        AssertionError failure = new AssertionError("Database failure");
+        LongSupplier delegate = () -> {
+            invocations.incrementAndGet();
+            throw failure;
+        };
+        LazyLongSupplier supplier = LazyLongSupplier.of(delegate);
+
+        Throwable first = catchThrowable(supplier::getAsLong);
+        Throwable second = catchThrowable(supplier::getAsLong);
+
+        assertThat(first).isSameAs(failure);
+        assertThat(second).isSameAs(failure);
+        assertThat(invocations.get()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldExecuteDelegateOnlyOnceUnderConcurrentAccess() throws Exception {
+        int callerCount = 8;
+        AtomicInteger invocations = new AtomicInteger();
+        CountDownLatch ready = new CountDownLatch(callerCount);
+        CountDownLatch start = new CountDownLatch(1);
+        LazyLongSupplier supplier = LazyLongSupplier.of(() -> {
+            invocations.incrementAndGet();
+            return 99L;
+        });
+        ExecutorService executor = Executors.newFixedThreadPool(callerCount);
+        List<Future<Long>> results = new ArrayList<>(callerCount);
+
+        try {
+            for (int index = 0; index < callerCount; index++) {
+                results.add(executor.submit(() -> {
+                    ready.countDown();
+                    start.await();
+                    return supplier.getAsLong();
+                }));
+            }
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            for (Future<Long> result : results) {
+                assertThat(result.get(5, TimeUnit.SECONDS)).isEqualTo(99L);
+            }
+            assertThat(invocations.get()).isEqualTo(1);
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/NoSQLPageTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,13 +41,110 @@ class NoSQLPageTest {
     }
 
     @Test
-    void shouldReturnUnsupportedOperation() {
+    void shouldRejectNullTotalSupplier() {
+        NullPointerException exception = assertThrows(NullPointerException.class,
+                () -> NoSQLPage.of(Collections.emptyList(), PageRequest.ofPage(1), null));
+
+        assertEquals("totalSupplier is required", exception.getMessage());
+    }
+
+    @Test
+    void shouldReportUnavailableTotalsForCompatibilityFactory() {
         Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
                 PageRequest.ofPage(2));
 
-        assertThrows(UnsupportedOperationException.class, page::totalPages);
-        assertThrows(UnsupportedOperationException.class, page::totalElements);
-        assertThrows(UnsupportedOperationException.class, page::hasTotals);
+        Assertions.assertFalse(page.hasTotals());
+        assertThrows(IllegalStateException.class, page::totalPages);
+        assertThrows(IllegalStateException.class, page::totalElements);
+    }
+
+    @Test
+    void shouldLoadAndCacheRequestedTotals() {
+        AtomicInteger invocations = new AtomicInteger();
+        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
+                PageRequest.ofPage(2, 10, true), () -> {
+                    invocations.incrementAndGet();
+                    return 21L;
+                });
+
+        assertEquals(0, invocations.get());
+        assertEquals(21L, page.totalElements());
+        assertEquals(3L, page.totalPages());
+        Assertions.assertTrue(page.hasTotals());
+        Assertions.assertTrue(page.hasNext());
+        assertEquals(1, invocations.get());
+    }
+
+    @Test
+    void shouldCalculateLargeTotalPagesWithoutLosingPrecision() {
+        Page<Person> page = NoSQLPage.of(Collections.emptyList(),
+                PageRequest.ofPage(1, 10, true), () -> Long.MAX_VALUE);
+
+        assertEquals(Long.MAX_VALUE / 10 + 1, page.totalPages());
+    }
+
+    @Test
+    void shouldNotLoadTotalsWhenRequestDisablesThem() {
+        AtomicInteger invocations = new AtomicInteger();
+        PageRequest request = PageRequest.ofPage(2).size(1).withoutTotal();
+        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
+                request, () -> {
+                    invocations.incrementAndGet();
+                    return 20L;
+                });
+
+        Assertions.assertFalse(page.hasTotals());
+        Assertions.assertTrue(page.hasNext());
+        assertThrows(IllegalStateException.class, page::totalElements);
+        assertThrows(IllegalStateException.class, page::totalPages);
+        Assertions.assertFalse(page.nextPageRequest().requestTotal());
+        assertEquals(0, invocations.get());
+    }
+
+    @Test
+    void shouldHandleAndCacheUnsupportedProviderCount() {
+        AtomicInteger invocations = new AtomicInteger();
+        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
+                PageRequest.ofPage(2, 1, true), () -> {
+                    invocations.incrementAndGet();
+                    throw new UnsupportedOperationException("count is not supported");
+                });
+
+        Assertions.assertFalse(page.hasTotals());
+        assertThrows(IllegalStateException.class, page::totalElements);
+        assertThrows(IllegalStateException.class, page::totalPages);
+        Assertions.assertTrue(page.hasNext());
+        assertThat(page.content()).hasSize(1);
+        assertEquals(1, invocations.get());
+    }
+
+    @Test
+    void shouldUseKnownTotalsForNavigation() {
+        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
+                PageRequest.ofPage(2, 10, true), () -> 11L);
+
+        Assertions.assertFalse(page.hasNext());
+        Assertions.assertTrue(page.hasPrevious());
+        assertThrows(NoSuchElementException.class, page::nextPageRequest);
+
+        Page<Person> firstPage = NoSQLPage.of(Collections.emptyList(),
+                PageRequest.ofPage(1, 10, true), () -> 0L);
+        Assertions.assertFalse(firstPage.hasPrevious());
+        assertThrows(NoSuchElementException.class, firstPage::previousPageRequest);
+    }
+
+    @Test
+    void shouldRejectNextPageRequestFromShortPageWithoutTotals() {
+        AtomicInteger invocations = new AtomicInteger();
+        Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
+                PageRequest.ofPage(1).size(10).withoutTotal(), () -> {
+                    invocations.incrementAndGet();
+                    return 30L;
+                });
+
+        Assertions.assertFalse(page.hasNext());
+        assertThrows(NoSuchElementException.class, page::nextPageRequest);
+        assertEquals(0, invocations.get());
     }
 
     @Test
@@ -117,9 +216,9 @@ class NoSQLPageTest {
     @Test
     void shouldNextPageRequest() {
         Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
+                PageRequest.ofPage(2).size(1));
         PageRequest pageRequest = page.nextPageRequest();
-        assertEquals(PageRequest.ofPage(3), pageRequest);
+        assertEquals(PageRequest.ofPage(3).size(1), pageRequest);
     }
 
     @Test
@@ -163,12 +262,12 @@ class NoSQLPageTest {
     @Test
     void shouldNext(){
         Page<Person> page = NoSQLPage.of(Collections.singletonList(Person.builder().withName("Otavio").build()),
-                PageRequest.ofPage(2));
+                PageRequest.ofPage(2).size(1));
         PageRequest pageRequest = page.nextPageRequest();
 
         SoftAssertions.assertSoftly(soft ->{
             soft.assertThat(pageRequest.page()).isEqualTo(3);
-            soft.assertThat(pageRequest.size()).isEqualTo(10);
+            soft.assertThat(pageRequest.size()).isEqualTo(1);
         });
     }
 

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicQueryMethodReturnTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 class DynamicQueryMethodReturnTest {
@@ -267,6 +268,7 @@ class DynamicQueryMethodReturnTest {
     @Test
     void shouldReturnPage() throws NoSuchMethodException {
         PreparedStatement preparedStatement = Mockito.mock(PreparedStatement.class);
+        AtomicInteger totalInvocations = new AtomicInteger();
         Mockito.when(preparedStatement.<Person>result())
                 .thenReturn(Stream.of(new Person("Ada")));
 
@@ -279,6 +281,10 @@ class DynamicQueryMethodReturnTest {
                 .args(new Object[]{"Ada", PageRequest.ofPage(10)})
                 .prepareConverter(s -> preparedStatement)
                 .pageRequest(PageRequest.ofPage(10))
+                .totalSupplier(() -> {
+                    totalInvocations.incrementAndGet();
+                    return 23L;
+                })
                 .build();
         Object execute = dynamicReturn.execute();
         SoftAssertions.assertSoftly(soft -> {
@@ -286,6 +292,11 @@ class DynamicQueryMethodReturnTest {
             Page<Person> page = (Page<Person>) execute;
             soft.assertThat(page.content()).containsExactly(new Person("Ada"));
             soft.assertThat(page.pageRequest()).isEqualTo(PageRequest.ofPage(10));
+            soft.assertThat(totalInvocations).hasValue(0);
+            soft.assertThat(page.totalElements()).isEqualTo(23L);
+            soft.assertThat(page.totalPages()).isEqualTo(3L);
+            soft.assertThat(page.hasTotals()).isTrue();
+            soft.assertThat(totalInvocations).hasValue(1);
         });
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
@@ -353,7 +353,7 @@ public abstract class AbstractSemiStructuredTemplate implements SemiStructuredTe
         var queryPage = new MappingQuery(query.sorts(), pageRequest.size(), NoSQLPage.skip(pageRequest),
                 query.condition().orElse(null), query.name(), query.columns());
         Stream<T> result = select(queryPage);
-        return NoSQLPage.of(result.toList(), pageRequest);
+        return NoSQLPage.of(result.toList(), pageRequest, () -> count(query));
     }
 
     protected <T> T persist(T entity, UnaryOperator<CommunicationEntity> persistAction) {

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepository.java
@@ -60,7 +60,7 @@ public abstract class AbstractSemiStructuredRepository<T, K> extends AbstractRep
                 , null ,metadata.name(), List.of());
 
         List<T> entities = template().<T>select(query).toList();
-        return NoSQLPage.of(entities, pageRequest);
+        return NoSQLPage.of(entities, pageRequest, () -> template().count(query));
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
@@ -31,6 +31,7 @@ import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
@@ -61,15 +62,21 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
         var returnType = method.getReturnType();
         LOGGER.finest("Query: " + queryValue + " with type: " + queryType + " and return type: " + returnType);
         queryType.checkValidReturn(returnType, queryValue);
+        var selectQueryReference = new AtomicReference<SelectQuery>();
 
         var methodReturn = DynamicQueryMethodReturn.builder()
                 .args(params)
                 .method(method)
                 .typeClass(type)
                 .pageRequest(pageRequest)
+                .totalSupplier(() -> template().count(selectQueryReference.get()))
                 .prepareConverter(textQuery -> {
                     var prepare = (org.eclipse.jnosql.mapping.semistructured.PreparedStatement) template().prepare(textQuery, entity);
-                    prepare.setSelectMapper(query -> updateQueryDynamically(params, query));
+                    prepare.setSelectMapper(query -> {
+                        var updatedQuery = updateQueryDynamically(params, query);
+                        selectQueryReference.set(updatedQuery);
+                        return updatedQuery;
+                    });
                     return prepare;
                 }).build();
         return methodReturn.execute();

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseSemiStructuredRepository.java
@@ -181,7 +181,7 @@ public abstract class BaseSemiStructuredRepository<T, K> extends AbstractReposit
     protected Function<PageRequest, Page<T>> getPage(org.eclipse.jnosql.communication.semistructured.SelectQuery query) {
         return p -> {
             Stream<T> entities = template().select(query);
-            return NoSQLPage.of(entities.toList(), p);
+            return NoSQLPage.of(entities.toList(), p, () -> template().count(query));
         };
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/DefaultSemiStructuredTemplateTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/DefaultSemiStructuredTemplateTest.java
@@ -568,14 +568,19 @@ class DefaultSemiStructuredTemplateTest {
         SelectQuery query = select().from("Person").orderBy("name").asc().build();
 
         Mockito.when(managerMock.select(Mockito.any())).thenReturn(Stream.empty());
+        Mockito.when(managerMock.count(query)).thenReturn(15L);
 
         Page<Person> result = template.selectOffSet(query, request);
         var captor = ArgumentCaptor.forClass(SelectQuery.class);
         Mockito.verify(managerMock).select(captor.capture());
+        Mockito.verify(managerMock, never()).count(any(SelectQuery.class));
         SelectQuery value = captor.getValue();
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(result).isNotNull();
             soft.assertThat(result.content()).isEmpty();
+            soft.assertThat(result.totalElements()).isEqualTo(15L);
+            soft.assertThat(result.totalPages()).isEqualTo(2L);
+            soft.assertThat(result.hasTotals()).isTrue();
             soft.assertThat(result.hasNext()).isFalse();
             soft.assertThat(value.columns()).isEmpty();
             soft.assertThat(value.name()).isEqualTo("Person");
@@ -584,6 +589,22 @@ class DefaultSemiStructuredTemplateTest {
             soft.assertThat(value.limit()).isEqualTo(10);
 
         });
+        Mockito.verify(managerMock).count(query);
+    }
+
+    @Test
+    void shouldNotCountSelectOffSetWhenTotalsAreDisabled() {
+        PageRequest request = PageRequest.ofPage(1, 10, false);
+        SelectQuery query = select().from("Person").orderBy("name").asc().build();
+        Mockito.when(managerMock.select(Mockito.any())).thenReturn(Stream.empty());
+
+        Page<Person> result = template.selectOffSet(query, request);
+
+        assertFalse(result.hasTotals());
+        assertThrows(IllegalStateException.class, result::totalElements);
+        assertThrows(IllegalStateException.class, result::totalPages);
+        assertFalse(result.hasNext());
+        Mockito.verify(managerMock, never()).count(any(SelectQuery.class));
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/RepositoryProxyPageRequestTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/RepositoryProxyPageRequestTest.java
@@ -61,6 +61,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -788,6 +790,105 @@ public class RepositoryProxyPageRequestTest {
         });
     }
 
+    @Test
+    public void shouldReturnLazyTotalsForFindPage() {
+        Person ada = Person.builder().age(20).name("Ada").build();
+        when(template.select(any(SelectQuery.class))).thenReturn(Stream.of(ada));
+        when(template.count(any(SelectQuery.class))).thenReturn(13L);
+
+        PageRequest pageRequest = PageRequest.ofPage(2, 6, true);
+        Page<Person> page = personRepository.findPageByName("Ada", pageRequest);
+
+        verify(template, Mockito.never()).count(any(SelectQuery.class));
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(page.content()).containsExactly(ada);
+            soft.assertThat(page.totalElements()).isEqualTo(13L);
+            soft.assertThat(page.totalPages()).isEqualTo(3L);
+            soft.assertThat(page.hasTotals()).isTrue();
+        });
+
+        ArgumentCaptor<SelectQuery> countQuery = ArgumentCaptor.forClass(SelectQuery.class);
+        verify(template).count(countQuery.capture());
+        SelectQuery query = countQuery.getValue();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(query.name()).isEqualTo("Person");
+            soft.assertThat(query.skip()).isEqualTo(6L);
+            soft.assertThat(query.limit()).isEqualTo(6L);
+            soft.assertThat(query.condition()).contains(CriteriaCondition.eq(Element.of("name", "Ada")));
+        });
+    }
+
+    @Test
+    public void shouldNotCountFindPageWhenTotalsAreDisabled() {
+        Person ada = Person.builder().age(20).name("Ada").build();
+        when(template.select(any(SelectQuery.class))).thenReturn(Stream.of(ada));
+
+        Page<Person> page = personRepository.findPageByName("Ada", PageRequest.ofPage(1, 1, false));
+
+        assertFalse(page.hasTotals());
+        assertThrows(IllegalStateException.class, page::totalElements);
+        assertThrows(IllegalStateException.class, page::totalPages);
+        assertTrue(page.hasNext());
+        assertThat(page.content()).containsExactly(ada);
+        verify(template, Mockito.never()).count(any(SelectQuery.class));
+    }
+
+    @Test
+    public void shouldReturnLazyTotalsForQueryPageWithoutOrderBy() {
+        Person ada = Person.builder().age(20).name("Ada").build();
+        var prepare = Mockito.mock(org.eclipse.jnosql.mapping.semistructured.PreparedStatement.class);
+        var selectMapper = new AtomicReference<UnaryOperator<SelectQuery>>();
+        SelectQuery parsedQuery = SelectQuery.select().from("Person").where("name").eq("Ada").build();
+
+        Mockito.doAnswer(invocation -> {
+            selectMapper.set(invocation.getArgument(0));
+            return null;
+        }).when(prepare).setSelectMapper(any());
+        when(prepare.result()).thenAnswer(invocation -> {
+            selectMapper.get().apply(parsedQuery);
+            return Stream.of(ada);
+        });
+        when(template.prepare("select * from Person where name = :name", "Person")).thenReturn(prepare);
+        when(template.count(any(SelectQuery.class))).thenReturn(14L);
+
+        PageRequest pageRequest = PageRequest.ofPage(2, 5, true);
+        Page<Person> page = personRepository.pageJdql("Ada", pageRequest);
+
+        verify(template, Mockito.never()).count(any(SelectQuery.class));
+        assertThat(page.content()).containsExactly(ada);
+        assertEquals(14L, page.totalElements());
+        assertEquals(3L, page.totalPages());
+        assertTrue(page.hasTotals());
+
+        ArgumentCaptor<SelectQuery> countQuery = ArgumentCaptor.forClass(SelectQuery.class);
+        verify(template).count(countQuery.capture());
+        SelectQuery query = countQuery.getValue();
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(query.name()).isEqualTo("Person");
+            soft.assertThat(query.skip()).isEqualTo(5L);
+            soft.assertThat(query.limit()).isEqualTo(5L);
+            soft.assertThat(query.condition()).contains(CriteriaCondition.eq(Element.of("name", "Ada")));
+        });
+    }
+
+    @Test
+    public void shouldReturnLazyTotalsForDirectRepositoryFindAll() {
+        Person ada = Person.builder().age(20).name("Ada").build();
+        when(template.select(any(SelectQuery.class))).thenReturn(Stream.of(ada));
+        when(template.count(any(SelectQuery.class))).thenReturn(8L);
+        var repository = SemiStructuredRepositoryProxy.SemiStructuredRepository
+                .<Person, Long>of(template, entities.get(Person.class));
+
+        Page<Person> page = repository.findAll(PageRequest.ofPage(2, 3, true), Order.by(Sort.asc("name")));
+
+        verify(template, Mockito.never()).count(any(SelectQuery.class));
+        assertThat(page.content()).containsExactly(ada);
+        assertEquals(8L, page.totalElements());
+        assertEquals(3L, page.totalPages());
+        assertTrue(page.hasTotals());
+        verify(template).count(any(SelectQuery.class));
+    }
+
     private PageRequest getPageRequest() {
         return PageRequest.ofPage(2).size(6);
     }
@@ -807,6 +908,12 @@ public class RepositoryProxyPageRequestTest {
 
         @Find
         Page<Person> pageAll(PageRequest pageRequest, Sort<Person> order);
+
+        @Find
+        Page<Person> findPageByName(@By("name") String name, PageRequest pageRequest);
+
+        @Query("select * from Person where name = :name")
+        Page<Person> pageJdql(@Param("name") String name, PageRequest pageRequest);
         CursoredPage<Person> findByNameOrderByName(String name, PageRequest pageRequest);
 
         @Find


### PR DESCRIPTION
## Description
Backports offset `Page` total support and the associated Jakarta Data contract corrections to `1.1.x`.

The change supplies total-count operations to every offset-page construction path while preserving the existing two-argument `NoSQLPage.of` factory for compatibility.

**Related Issue:** Fixes #753  

**Backport of:** #754 

## Type of Contribution
- [X] Bug fix
- [ ] Feature request
- [ ] New database support
- [ ] Use case implementation
- [ ] Documentation update
- [ ] Other: 

## Architectural and Design Decisions
  The backport adds a lazy, cached total supplier and threads it through:

  - Direct template offset selection.
  - Repository `findAll`.
  - Derived and `@Find` repository methods.
  - Annotated `@Query` repository methods.

  Counts are retrieved only when requested and are cached after the first attempt. Existing APIs remain compatible, and no database-provider or cursor-pagination changes are required.

## Contribution Checklist
- [X] **ECA:** I have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
- [ ] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
- [X] **Conventional Commits:** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
- [X] **Tests:** I have added/updated unit and integration tests.
- [ ] **Documentation:** I have updated the relevant .adoc files.
- [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results
  - Exact 1.1.16 affected mapping reactor: BUILD SUCCESS
  - Mapping core: 327 passed
  - Mapping semistructured: 431 passed
  - Focused downstream regression: passed
  - Jakarta Data TCK: 99 persistence and 88 NoSQL tests passed
  - Jakarta NoSQL TCK: 111 passed
  - Standalone database-free reproducer: 4 passed
  - RAT, Checkstyle, and `git diff --check`: passed
