### PR TITLE
fix: correct backward cursor navigation

### DIFF
--- a/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CursorExecutor.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/main/java/org/eclipse/jnosql/communication/semistructured/CursorExecutor.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -53,83 +53,46 @@ enum CursorExecutor {
         public CursoredPage<CommunicationEntity> cursor(SelectQuery query, PageRequest pageRequest, DatabaseManager template) {
 
             var cursor = pageRequest.cursor().orElseThrow();
-            var condition = condition(query, cursor);
+            var condition = condition(query, cursor, true);
 
-            var select = updateQuery(pageRequest.size(), query, condition);
+            var select = updateQuery(pageRequest.size(), query, condition, query.sorts());
 
             var entities = template.select(select).toList();
-            var last = entities.isEmpty() ? null : entities.get(entities.size() - 1);
-            if (last == null) {
+            if (entities.isEmpty()) {
                 return new CursoredPageRecord<>(entities, Collections.emptyList(), -1, pageRequest,
                         null, null);
             } else {
-                var nextCursor = getCursor(query.sorts(), last);
+                var firstCursor = getCursor(query.sorts(), entities.get(0));
+                var nextCursor = getCursor(query.sorts(), entities.get(entities.size() - 1));
                 var afterCursor = PageRequest.ofSize(pageRequest.size()).afterCursor(nextCursor);
+                var beforeCursor = PageRequest.ofSize(pageRequest.size()).beforeCursor(firstCursor);
                 return new CursoredPageRecord<>(entities, List.of(cursor, nextCursor), -1,
-                        pageRequest, afterCursor, null);
+                        pageRequest, afterCursor, beforeCursor);
             }
         }
-
-        private static CriteriaCondition condition(SelectQuery query, PageRequest.Cursor cursor) {
-            CriteriaCondition condition = null;
-            CriteriaCondition previousCondition = null;
-            List<Sort<?>> sorts = query.sorts();
-            checkCursorKeySizes(cursor, sorts);
-            for (int index = 0; index < sorts.size(); index++) {
-                Sort<?> sort = sorts.get(index);
-                Object key = cursor.get(index);
-                if(condition == null) {
-                    condition = CriteriaCondition.gt(sort.property(), key);
-                    previousCondition = CriteriaCondition.eq(sort.property(), key);
-                } else {
-                    condition = condition.or(previousCondition.and(CriteriaCondition.gt(sort.property(), key)));
-                    previousCondition = previousCondition.and(CriteriaCondition.eq(sort.property(), key));
-                }
-
-            }
-            return condition;
-        }
-
 
     }, CURSOR_PREVIOUS {
         @Override
         public CursoredPage<CommunicationEntity> cursor(SelectQuery query, PageRequest pageRequest, DatabaseManager template) {
             var cursor = pageRequest.cursor().orElseThrow();
-            var condition = condition(query, cursor);
+            var condition = condition(query, cursor, false);
 
-            var select = updateQuery(pageRequest.size(), query, condition);
+            var select = updateQuery(pageRequest.size(), query, condition, invert(query.sorts()));
 
-            var entities = template.select(select).toList();
-            var last = entities.isEmpty() ? null : entities.get(entities.size() - 1);
-            if (last == null) {
+            var entities = new ArrayList<>(template.select(select).toList());
+            Collections.reverse(entities);
+            if (entities.isEmpty()) {
                 return new CursoredPageRecord<>(entities, Collections.emptyList(), -1, pageRequest,
                         null, null);
             } else {
-                var beforeCursor = getCursor(query.sorts(), last);
+                var beforeCursor = getCursor(query.sorts(), entities.get(0));
+                var nextCursor = getCursor(query.sorts(), entities.get(entities.size() - 1));
                 var beforeRequest = PageRequest.<CommunicationEntity>ofSize(pageRequest.size()).beforeCursor(beforeCursor);
+                var nextRequest = PageRequest.ofSize(pageRequest.size()).afterCursor(nextCursor);
 
-                return new CursoredPageRecord<>(entities, List.of(beforeCursor, cursor), -1, pageRequest, null, beforeRequest);
+                return new CursoredPageRecord<>(entities, List.of(beforeCursor, cursor), -1, pageRequest,
+                        nextRequest, beforeRequest);
             }
-        }
-
-        private static CriteriaCondition condition(SelectQuery query, PageRequest.Cursor cursor) {
-            CriteriaCondition condition = null;
-            CriteriaCondition previousCondition = null;
-            List<Sort<?>> sorts = query.sorts();
-            checkCursorKeySizes(cursor, sorts);
-            for (int index = 0; index < sorts.size(); index++) {
-                Sort<?> sort = sorts.get(index);
-                Object key = cursor.get(index);
-                if(condition == null) {
-                    condition = CriteriaCondition.lt(sort.property(), key);
-                    previousCondition = CriteriaCondition.eq(sort.property(), key);
-                } else {
-                    condition = condition.or(previousCondition.and(CriteriaCondition.lt(sort.property(), key)));
-                    previousCondition = previousCondition.and(CriteriaCondition.eq(sort.property(), key));
-                }
-
-            }
-            return condition;
         }
     };
 
@@ -175,14 +138,48 @@ enum CursorExecutor {
         }
     }
 
-    private static DefaultSelectQuery updateQuery(int limit, SelectQuery query, CriteriaCondition condition) {
-        return new DefaultSelectQuery(limit, 0, query.name(), query.columns(), query.sorts(),
+    private static CriteriaCondition condition(SelectQuery query, PageRequest.Cursor cursor, boolean after) {
+        CriteriaCondition condition = null;
+        CriteriaCondition equalities = null;
+        List<Sort<?>> sorts = query.sorts();
+        checkCursorKeySizes(cursor, sorts);
+        for (int index = 0; index < sorts.size(); index++) {
+            Sort<?> sort = sorts.get(index);
+            Object key = cursor.get(index);
+            CriteriaCondition comparison = comparison(sort, key, after);
+            CriteriaCondition current = equalities == null ? comparison : equalities.and(comparison);
+            condition = condition == null ? current : condition.or(current);
+            CriteriaCondition equality = CriteriaCondition.eq(sort.property(), key);
+            equalities = equalities == null ? equality : equalities.and(equality);
+        }
+        return condition;
+    }
+
+    private static CriteriaCondition comparison(Sort<?> sort, Object key, boolean after) {
+        boolean greaterThan = sort.isAscending() == after;
+        return greaterThan ? CriteriaCondition.gt(sort.property(), key) : CriteriaCondition.lt(sort.property(), key);
+    }
+
+    private static List<Sort<?>> invert(List<Sort<?>> sorts) {
+        return sorts.stream().map(CursorExecutor::invert).toList();
+    }
+
+    private static Sort<?> invert(Sort<?> sort) {
+        if (sort.isAscending()) {
+            return sort.ignoreCase() ? Sort.descIgnoreCase(sort.property()) : Sort.desc(sort.property());
+        }
+        return sort.ignoreCase() ? Sort.ascIgnoreCase(sort.property()) : Sort.asc(sort.property());
+    }
+
+    private static DefaultSelectQuery updateQuery(int limit, SelectQuery query, CriteriaCondition condition,
+                                                   List<Sort<?>> sorts) {
+        return new DefaultSelectQuery(limit, 0, query.name(), query.columns(), sorts,
                 query.condition().map(c -> CriteriaCondition.and(c, condition))
-                        .orElse(condition),false);
+                        .orElse(condition), false);
     }
 
     private static void checkCursorKeySizes(PageRequest.Cursor cursor, List<Sort<?>> sorts) {
-        if(sorts.size() != cursor.size()) {
+        if (sorts.size() != cursor.size()) {
             throw new IllegalArgumentException("The cursor size is different from the sort size. Cursor: "
                     + cursor.size() + " Sort: " + sorts.size());
         }

--- a/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DatabaseManagerTest.java
+++ b/jnosql-communication/jnosql-communication-semistructured/src/test/java/org/eclipse/jnosql/communication/semistructured/DatabaseManagerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  * and Apache License v2.0 which accompanies this distribution.
@@ -12,6 +12,7 @@
 package org.eclipse.jnosql.communication.semistructured;
 
 import jakarta.data.exceptions.NonUniqueResultException;
+import jakarta.data.Sort;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.PageRequest;
 import org.assertj.core.api.Assertions;
@@ -26,7 +27,10 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -472,6 +476,172 @@ class DatabaseManagerTest {
 
     }
 
+
+    @Test
+    void shouldNavigateForwardAndBackwardInDeclaredOrder() {
+        List<SelectQuery> delegatedQueries = new ArrayList<>();
+        useData(List.of(entity(1), entity(2), entity(3)), delegatedQueries);
+        SelectQuery query = SelectQuery.select().from("person").orderBy("id").asc().build();
+
+        CursoredPage<CommunicationEntity> firstPage = databaseManager.selectCursor(query, PageRequest.ofSize(2));
+        CursoredPage<CommunicationEntity> secondPage = databaseManager.selectCursor(query,
+                firstPage.nextPageRequest());
+        CursoredPage<CommunicationEntity> returnedFirstPage = databaseManager.selectCursor(query,
+                secondPage.previousPageRequest());
+        CursoredPage<CommunicationEntity> returnedSecondPage = databaseManager.selectCursor(query,
+                returnedFirstPage.nextPageRequest());
+        CursoredPage<CommunicationEntity> beforeFirstPage = databaseManager.selectCursor(query,
+                returnedFirstPage.previousPageRequest());
+
+        assertSoftly(soft -> {
+            soft.assertThat(ids(firstPage)).containsExactly(1, 2);
+            soft.assertThat(firstPage.hasPrevious()).isFalse();
+            soft.assertThat(firstPage.nextPageRequest().cursor().orElseThrow().get(0)).isEqualTo(2);
+
+            soft.assertThat(ids(secondPage)).containsExactly(3);
+            soft.assertThat(secondPage.hasPrevious()).isTrue();
+            soft.assertThat(secondPage.previousPageRequest().cursor().orElseThrow().get(0)).isEqualTo(3);
+
+            soft.assertThat(ids(returnedFirstPage)).containsExactly(1, 2);
+            soft.assertThat(returnedFirstPage.hasPrevious()).isTrue();
+            soft.assertThat(returnedFirstPage.hasNext()).isTrue();
+            soft.assertThat(returnedFirstPage.previousPageRequest().cursor().orElseThrow().get(0)).isEqualTo(1);
+            soft.assertThat(returnedFirstPage.nextPageRequest().cursor().orElseThrow().get(0)).isEqualTo(2);
+
+            soft.assertThat(ids(returnedSecondPage)).containsExactly(3);
+            soft.assertThat(beforeFirstPage).isEmpty();
+            soft.assertThat(beforeFirstPage.hasPrevious()).isFalse();
+            soft.assertThat(beforeFirstPage.hasNext()).isFalse();
+            soft.assertThat(delegatedQueries).allSatisfy(
+                    delegated -> soft.assertThat(delegated.limit()).isEqualTo(2));
+            soft.assertThat(delegatedQueries.get(2).sorts()).containsExactly(Sort.desc("id"));
+        });
+    }
+
+    @Test
+    void shouldReturnTheImmediatePreviousPageDuringDeepTraversal() {
+        List<SelectQuery> delegatedQueries = new ArrayList<>();
+        useData(List.of(entity(1), entity(2), entity(3), entity(4), entity(5), entity(6)), delegatedQueries);
+        SelectQuery query = SelectQuery.select().from("person").orderBy("id").asc().build();
+
+        CursoredPage<CommunicationEntity> firstPage = databaseManager.selectCursor(query, PageRequest.ofSize(2));
+        CursoredPage<CommunicationEntity> secondPage = databaseManager.selectCursor(query,
+                firstPage.nextPageRequest());
+        CursoredPage<CommunicationEntity> thirdPage = databaseManager.selectCursor(query,
+                secondPage.nextPageRequest());
+        CursoredPage<CommunicationEntity> returnedSecondPage = databaseManager.selectCursor(query,
+                thirdPage.previousPageRequest());
+        CursoredPage<CommunicationEntity> returnedFirstPage = databaseManager.selectCursor(query,
+                returnedSecondPage.previousPageRequest());
+        CursoredPage<CommunicationEntity> reciprocalThirdPage = databaseManager.selectCursor(query,
+                returnedSecondPage.nextPageRequest());
+
+        assertSoftly(soft -> {
+            soft.assertThat(ids(firstPage)).containsExactly(1, 2);
+            soft.assertThat(ids(secondPage)).containsExactly(3, 4);
+            soft.assertThat(ids(thirdPage)).containsExactly(5, 6);
+            soft.assertThat(thirdPage.previousPageRequest().cursor().orElseThrow().get(0)).isEqualTo(5);
+
+            soft.assertThat(ids(returnedSecondPage)).containsExactly(3, 4);
+            soft.assertThat(returnedSecondPage.previousPageRequest().cursor().orElseThrow().get(0)).isEqualTo(3);
+            soft.assertThat(returnedSecondPage.nextPageRequest().cursor().orElseThrow().get(0)).isEqualTo(4);
+
+            soft.assertThat(ids(returnedFirstPage)).containsExactly(1, 2);
+            soft.assertThat(ids(reciprocalThirdPage)).containsExactly(5, 6);
+            soft.assertThat(delegatedQueries.get(3).sorts()).containsExactly(Sort.desc("id"));
+            soft.assertThat(delegatedQueries.get(4).sorts()).containsExactly(Sort.desc("id"));
+            soft.assertThat(delegatedQueries).allSatisfy(
+                    delegated -> soft.assertThat(delegated.limit()).isEqualTo(2));
+        });
+    }
+
+    @Test
+    void shouldNavigateDescendingCursorPages() {
+        List<SelectQuery> delegatedQueries = new ArrayList<>();
+        useData(List.of(entity(1), entity(2), entity(3), entity(4), entity(5)), delegatedQueries);
+        SelectQuery query = SelectQuery.select().from("person").orderBy("id").desc().build();
+
+        CursoredPage<CommunicationEntity> firstPage = databaseManager.selectCursor(query, PageRequest.ofSize(2));
+        CursoredPage<CommunicationEntity> secondPage = databaseManager.selectCursor(query,
+                firstPage.nextPageRequest());
+        CursoredPage<CommunicationEntity> returnedFirstPage = databaseManager.selectCursor(query,
+                secondPage.previousPageRequest());
+
+        assertSoftly(soft -> {
+            soft.assertThat(ids(firstPage)).containsExactly(5, 4);
+            soft.assertThat(ids(secondPage)).containsExactly(3, 2);
+            soft.assertThat(ids(returnedFirstPage)).containsExactly(5, 4);
+            soft.assertThat(delegatedQueries.get(1).condition()).contains(CriteriaCondition.lt("id", 4));
+            soft.assertThat(delegatedQueries.get(1).sorts()).containsExactly(Sort.desc("id"));
+            soft.assertThat(delegatedQueries.get(2).condition()).contains(CriteriaCondition.gt("id", 3));
+            soft.assertThat(delegatedQueries.get(2).sorts()).containsExactly(Sort.asc("id"));
+            soft.assertThat(delegatedQueries).allSatisfy(
+                    delegated -> soft.assertThat(delegated.limit()).isEqualTo(2));
+        });
+    }
+
+    @Test
+    void shouldNavigateMixedDirectionsAndPreserveOriginalFilter() {
+        List<CommunicationEntity> data = List.of(
+                mixedEntity(1, "Ada", 40, "active"),
+                mixedEntity(2, "Ada", 30, "active"),
+                mixedEntity(3, "Ada", 30, "active"),
+                mixedEntity(99, "Bob", 55, "inactive"),
+                mixedEntity(4, "Bob", 50, "active"),
+                mixedEntity(5, "Bob", 20, "active"),
+                mixedEntity(6, "Cara", 60, "active"));
+        CriteriaCondition originalCondition = CriteriaCondition.eq("status", "active");
+        List<Sort<?>> sorts = List.of(Sort.ascIgnoreCase("group"), Sort.desc("rank"), Sort.asc("id"));
+        SelectQuery query = new DefaultSelectQuery(99, 0, "person", List.of("group", "rank", "id"),
+                sorts, originalCondition, false);
+        List<SelectQuery> delegatedQueries = new ArrayList<>();
+        useData(data, delegatedQueries);
+
+        CursoredPage<CommunicationEntity> firstPage = databaseManager.selectCursor(query, PageRequest.ofSize(2));
+        CursoredPage<CommunicationEntity> secondPage = databaseManager.selectCursor(query,
+                firstPage.nextPageRequest());
+        CursoredPage<CommunicationEntity> thirdPage = databaseManager.selectCursor(query,
+                secondPage.nextPageRequest());
+        CursoredPage<CommunicationEntity> returnedSecondPage = databaseManager.selectCursor(query,
+                thirdPage.previousPageRequest());
+
+        CriteriaCondition forwardCursor = CriteriaCondition.gt("group", "Ada")
+                .or(CriteriaCondition.eq("group", "Ada").and(CriteriaCondition.lt("rank", 30)))
+                .or(CriteriaCondition.eq("group", "Ada").and(CriteriaCondition.eq("rank", 30))
+                        .and(CriteriaCondition.gt("id", 2)));
+        CriteriaCondition backwardCursor = CriteriaCondition.lt("group", "Bob")
+                .or(CriteriaCondition.eq("group", "Bob").and(CriteriaCondition.gt("rank", 20)))
+                .or(CriteriaCondition.eq("group", "Bob").and(CriteriaCondition.eq("rank", 20))
+                        .and(CriteriaCondition.lt("id", 5)));
+
+        assertSoftly(soft -> {
+            soft.assertThat(ids(firstPage)).containsExactly(1, 2);
+            soft.assertThat(ids(secondPage)).containsExactly(3, 4);
+            soft.assertThat(ids(thirdPage)).containsExactly(5, 6);
+            soft.assertThat(ids(returnedSecondPage)).containsExactly(3, 4);
+
+            SelectQuery forwardQuery = delegatedQueries.get(1);
+            soft.assertThat(forwardQuery.condition()).contains(
+                    CriteriaCondition.and(originalCondition, forwardCursor));
+            soft.assertThat(forwardQuery.sorts()).containsExactlyElementsOf(sorts);
+
+            SelectQuery previousQuery = delegatedQueries.get(3);
+            soft.assertThat(previousQuery.condition()).contains(
+                    CriteriaCondition.and(originalCondition, backwardCursor));
+            soft.assertThat(previousQuery.sorts()).containsExactly(
+                    Sort.descIgnoreCase("group"), Sort.asc("rank"), Sort.desc("id"));
+            soft.assertThat(previousQuery.sorts().get(0).ignoreCase()).isTrue();
+
+            soft.assertThat(delegatedQueries).allSatisfy(delegated -> {
+                soft.assertThat(delegated.limit()).isEqualTo(2);
+                soft.assertThat(delegated.skip()).isZero();
+                soft.assertThat(delegated.name()).isEqualTo("person");
+                soft.assertThat(delegated.columns()).containsExactly("group", "rank", "id");
+                soft.assertThat(delegated.isCount()).isFalse();
+            });
+        });
+    }
+
     @Test
     void shouldCount(){
         SelectQuery query = SelectQuery.select().from("person").build();
@@ -575,6 +745,89 @@ class DatabaseManagerTest {
 
     }
 
+
+
+    private void useData(List<CommunicationEntity> data, List<SelectQuery> delegatedQueries) {
+        Mockito.when(databaseManager.select(Mockito.any(SelectQuery.class))).thenAnswer(invocation -> {
+            SelectQuery query = invocation.getArgument(0);
+            delegatedQueries.add(query);
+            Stream<CommunicationEntity> stream = data.stream();
+            if (query.condition().isPresent()) {
+                CriteriaCondition condition = query.condition().orElseThrow();
+                stream = stream.filter(entity -> matches(condition, entity));
+            }
+            if (!query.sorts().isEmpty()) {
+                stream = stream.sorted(comparator(query.sorts()));
+            }
+            return stream.limit(query.limit());
+        });
+    }
+
+    private boolean matches(CriteriaCondition condition, CommunicationEntity entity) {
+        if (condition.condition() == Condition.AND || condition.condition() == Condition.OR) {
+            List<CriteriaCondition> conditions = condition.element().get(new TypeReference<>() {
+            });
+            if (condition.condition() == Condition.AND) {
+                return conditions.stream().allMatch(current -> matches(current, entity));
+            }
+            return conditions.stream().anyMatch(current -> matches(current, entity));
+        }
+
+        Object entityValue = entity.find(condition.element().name()).orElseThrow().get();
+        Object conditionValue = condition.element().get();
+        return switch (condition.condition()) {
+            case EQUALS -> Objects.equals(entityValue, conditionValue);
+            case GREATER_THAN -> compare(entityValue, conditionValue, false) > 0;
+            case LESSER_THAN -> compare(entityValue, conditionValue, false) < 0;
+            default -> throw new IllegalArgumentException("Unsupported test condition: " + condition.condition());
+        };
+    }
+
+    private Comparator<CommunicationEntity> comparator(List<Sort<?>> sorts) {
+        Comparator<CommunicationEntity> comparator = (left, right) -> 0;
+        for (Sort<?> sort : sorts) {
+            Comparator<CommunicationEntity> current = (left, right) -> compare(
+                    left.find(sort.property()).orElseThrow().get(),
+                    right.find(sort.property()).orElseThrow().get(), sort.ignoreCase());
+            if (sort.isDescending()) {
+                current = current.reversed();
+            }
+            comparator = comparator.thenComparing(current);
+        }
+        return comparator;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private int compare(Object left, Object right, boolean ignoreCase) {
+        if (ignoreCase && left instanceof String leftString && right instanceof String rightString) {
+            return leftString.compareToIgnoreCase(rightString);
+        }
+        return ((Comparable) left).compareTo(right);
+    }
+
+    private CommunicationEntity entity(int id) {
+        CommunicationEntity entity = CommunicationEntity.of("person");
+        entity.add("id", id);
+        entity.add("name", "name-" + id);
+        entity.add("age", id);
+        entity.add("status", "active");
+        return entity;
+    }
+
+    private CommunicationEntity mixedEntity(int id, String group, int rank, String status) {
+        CommunicationEntity entity = CommunicationEntity.of("person");
+        entity.add("id", id);
+        entity.add("group", group);
+        entity.add("rank", rank);
+        entity.add("status", status);
+        return entity;
+    }
+
+    private List<Integer> ids(CursoredPage<CommunicationEntity> page) {
+        return page.content().stream()
+                .map(entity -> entity.find("id", Integer.class).orElseThrow())
+                .toList();
+    }
 
     private Stream<CommunicationEntity> stream() {
         var entity = CommunicationEntity.of("name");


### PR DESCRIPTION
## Description
  Backports the shared semistructured cursor-navigation correction from main PR #757 to the 1.1.x maintenance branch.

  A page reached with a next-page request now exposes a usable previous-page request, and backward traversal returns the immediately preceding results in the caller's declared order.

  The change:

  - Builds direction-aware lexicographic cursor predicates, including equality prefixes for mixed-direction sort tuples.
  - Inverts every declared sort direction for previous-page provider queries.
  - Normalizes previous-query results back into the declared order before returning the page.
  - Derives reciprocal requests from the current page boundaries: previous from the first result and next from the last result.

  This PR intentionally excludes lookahead and exact-boundary detection, general cursor-list or cursor-cardinality cleanup, derived-request metadata and totals changes, OFFSET behavior, and mapping changes. No public API, query grammar, or provider-specific implementation is
  changed.

**Related Issue:** Fixes #756 

## Type of Contribution
- [X] Bug fix
- [ ] Feature request
- [ ] New database support
- [ ] Use case implementation
- [ ] Documentation update
- [ ] Other: 

## Architectural and Design Decisions
 The correction belongs in the shared package-private cursor executor because the default DatabaseManager.selectCursor implementation delegates cursor navigation there. This keeps the behavior provider-independent without adding a public API or provider override.

  Strict cursor comparisons follow both navigation direction and each declared sort direction. Previous-page queries use inverse provider ordering to select the closest preceding rows, after which the results are reversed into declared order. Requests are then built from the normalized page's first and last results, as required by the Jakarta Data 1.0 CursoredPage boundary semantics.

  The caller's complete sort tuple must remain a unique key, as required for cursor pagination. Java 17 compatibility is preserved.


## Contribution Checklist
- [X] **ECA:** I have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
- [ ] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
- [X] **Conventional Commits:** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
- [X] **Tests:** I have added/updated unit and integration tests.
- [ ] **Documentation:** I have updated the relevant .adoc files.
- [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results
  - JDK 17 focused DatabaseManagerTest: 29 tests run, 0 failures, 0 errors, 0 skipped.
  - JDK 17 semistructured communication module: 328 tests run, 0 failures, 0 errors, 2 skipped.
  - Unchanged standalone database-free reproducer:
      - 1 expected failure against 1.1.16 GA.
      - 1 passing test against the maintenance candidate.

  - Focused WebLogic Server cursor integration test on JDK 21: 1 test run, 0 failures, 0 errors, 0 skipped.
  - Jakarta Data 1.0.1 TCK on JDK 21:
      - JPA: 99 tests run, 0 failures, 0 errors, 0 skipped.
      - NoSQL: 88 tests run, 0 failures, 0 errors, 0 skipped.

  - Jakarta NoSQL 1.0.0 TCK on JDK 21: 111 tests run, 0 failures, 0 errors, 0 skipped.
  - Checkstyle: 0 violations.
  - git diff --check: passed.
