### PR TITLE
fix: honor And precedence in method queries

### DIFF
--- a/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/AbstractMethodQueryParser.java
+++ b/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/AbstractMethodQueryParser.java
@@ -30,7 +30,6 @@ import org.eclipse.jnosql.query.grammar.method.MethodLexer;
 import org.eclipse.jnosql.query.grammar.method.MethodParser;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -238,14 +237,6 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
     }
 
 
-    private boolean isAppendable(QueryCondition condition) {
-        return (AND.equals(condition.condition()) || OR.equals(condition.condition()));
-    }
-
-    private boolean isNotAppendable() {
-        return !isAppendable(this.condition);
-    }
-
     private QueryCondition checkNotCondition(QueryCondition condition, boolean hasNot) {
         if (hasNot) {
             ConditionQueryValue conditions = ConditionQueryValue.of(Collections.singletonList(condition));
@@ -256,40 +247,30 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
     }
 
     private void appendCondition(Condition operator, QueryCondition newCondition) {
-
         if (operator.equals(this.condition.condition())) {
-            ConditionQueryValue conditionValue = ConditionQueryValue.class.cast(this.condition.value());
-            List<QueryCondition> conditions = new ArrayList<>(conditionValue.get());
-            conditions.add(newCondition);
-            this.condition = new MethodCondition(SUB_ENTITY_FLAG + operator.name(), operator, ConditionQueryValue.of(conditions));
-        } else if (isNotAppendable()) {
-            List<QueryCondition> conditions = Arrays.asList(this.condition, newCondition);
-            this.condition = new MethodCondition(SUB_ENTITY_FLAG + operator.name(), operator, ConditionQueryValue.of(conditions));
+            this.condition = appendTo(this.condition, newCondition);
+        } else if (OR.equals(operator)) {
+            this.condition = group(OR, List.of(this.condition, newCondition));
+        } else if (!OR.equals(this.condition.condition())) {
+            this.condition = group(AND, List.of(this.condition, newCondition));
         } else {
-            List<QueryCondition> conditions = ConditionQueryValue.class.cast(this.condition.value()).get();
+            List<QueryCondition> conditions = new ArrayList<>(ConditionQueryValue.class.cast(this.condition.value()).get());
             QueryCondition lastCondition = conditions.getLast();
-
-            if (isAppendable(lastCondition) && Condition.EQUALS.equals(lastCondition.condition())) {
-                List<QueryCondition> lastConditions = new ArrayList<>(ConditionQueryValue.class.cast(lastCondition.value()).get());
-                lastConditions.add(newCondition);
-
-                QueryCondition newAppendable = new MethodCondition(SUB_ENTITY_FLAG + operator.name(),
-                        operator, ConditionQueryValue.of(lastConditions));
-
-                List<QueryCondition> newConditions = new ArrayList<>(conditions.subList(0, conditions.size() - 1));
-                newConditions.add(newAppendable);
-                this.condition = new MethodCondition(this.condition.name(), this.condition.condition(),
-                        ConditionQueryValue.of(newConditions));
-            } else {
-                QueryCondition newAppendable = new MethodCondition(SUB_ENTITY_FLAG + operator.name(),
-                        operator, ConditionQueryValue.of(Collections.singletonList(newCondition)));
-
-                List<QueryCondition> newConditions = new ArrayList<>(conditions);
-                newConditions.add(newAppendable);
-                this.condition = new MethodCondition(this.condition.name(), this.condition.condition(),
-                        ConditionQueryValue.of(newConditions));
-            }
-
+            QueryCondition lastGroup = AND.equals(lastCondition.condition())
+                    ? appendTo(lastCondition, newCondition)
+                    : group(AND, List.of(lastCondition, newCondition));
+            conditions.set(conditions.size() - 1, lastGroup);
+            this.condition = group(OR, conditions);
         }
+    }
+
+    private QueryCondition appendTo(QueryCondition currentCondition, QueryCondition newCondition) {
+        List<QueryCondition> conditions = new ArrayList<>(ConditionQueryValue.class.cast(currentCondition.value()).get());
+        conditions.add(newCondition);
+        return group(currentCondition.condition(), conditions);
+    }
+
+    private QueryCondition group(Condition operator, List<QueryCondition> conditions) {
+        return new MethodCondition(SUB_ENTITY_FLAG + operator.name(), operator, ConditionQueryValue.of(conditions));
     }
 }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/DeleteByMethodQueryProviderTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/DeleteByMethodQueryProviderTest.java
@@ -21,6 +21,7 @@ import org.eclipse.jnosql.communication.query.QueryValue;
 import org.eclipse.jnosql.communication.query.Where;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -32,6 +33,7 @@ import java.util.Optional;
 
 import static org.eclipse.jnosql.communication.query.method.SelectMethodQueryProviderTest.checkPrependedCondition;
 import static org.eclipse.jnosql.communication.query.method.SelectMethodQueryProviderTest.checkTerminalCondition;
+import static org.eclipse.jnosql.communication.query.method.SelectMethodQueryProviderTest.assertConditionTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -479,6 +481,46 @@ class DeleteByMethodQueryProviderTest {
             checkConditions(query, expectedProperty, conditions);
         }
 
+    }
+
+    @Nested
+    @DisplayName("When deleting with mixed logical predicates")
+    class WhenTheMixedLogicalPredicatesAreParsed {
+
+        @Test
+        @DisplayName("Should apply AND before OR when the conjunction comes first")
+        void shouldApplyAndBeforeOrWhenTheConjunctionComesFirst() {
+            // When
+            QueryCondition condition = queryProvider.apply("deleteByNameAndAgeOrCity", "entity")
+                    .where().orElseThrow().condition();
+
+            // Then
+            assertConditionTree(condition, "OR(AND(name,age),city)", "name", "age", "city");
+        }
+
+        @Test
+        @DisplayName("Should apply AND before OR when the conjunction comes last")
+        void shouldApplyAndBeforeOrWhenTheConjunctionComesLast() {
+            // When
+            QueryCondition condition = queryProvider.apply("deleteByNameOrAgeAndCity", "entity")
+                    .where().orElseThrow().condition();
+
+            // Then
+            assertConditionTree(condition, "OR(name,AND(age,city))", "name", "age", "city");
+        }
+
+        @Test
+        @DisplayName("Should keep chained OR branches and their AND groups in lexical order")
+        void shouldKeepChainedBranchesInLexicalOrder() {
+            // When
+            QueryCondition condition = queryProvider.apply(
+                            "deleteByNameAndAgeOrCityAndActiveAndEnabledOrEmail", "entity")
+                    .where().orElseThrow().condition();
+
+            // Then
+            assertConditionTree(condition, "OR(AND(name,age),AND(city,active,enabled),email)",
+                    "name", "age", "city", "active", "enabled", "email");
+        }
     }
 
     private void checkConditions(String query, String variable, Condition... operators) {

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/SelectMethodQueryProviderTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/SelectMethodQueryProviderTest.java
@@ -687,6 +687,57 @@ class SelectMethodQueryProviderTest {
 
     }
 
+    @Nested
+    @DisplayName("When parsing mixed logical predicates")
+    class WhenTheMixedLogicalPredicatesAreParsed {
+
+        @ParameterizedTest(name = "{0}ByNameAndAgeOrCity")
+        @ValueSource(strings = {"find", "count", "exists"})
+        @DisplayName("Should apply AND before OR when the conjunction comes first")
+        void shouldApplyAndBeforeOrWhenTheConjunctionComesFirst(String operation) {
+            // Given
+            String query = operation + "ByNameAndAgeOrCity";
+
+            // When
+            QueryCondition condition = queryProvider.apply(query, "entity")
+                    .where().orElseThrow().condition();
+
+            // Then
+            assertConditionTree(condition, "OR(AND(name,age),city)", "name", "age", "city");
+        }
+
+        @ParameterizedTest(name = "{0}ByNameOrAgeAndCity")
+        @ValueSource(strings = {"find", "count", "exists"})
+        @DisplayName("Should apply AND before OR when the conjunction comes last")
+        void shouldApplyAndBeforeOrWhenTheConjunctionComesLast(String operation) {
+            // Given
+            String query = operation + "ByNameOrAgeAndCity";
+
+            // When
+            QueryCondition condition = queryProvider.apply(query, "entity")
+                    .where().orElseThrow().condition();
+
+            // Then
+            assertConditionTree(condition, "OR(name,AND(age,city))", "name", "age", "city");
+        }
+
+        @ParameterizedTest(name = "{0}ByNameAndAgeOrCityAndActiveAndEnabledOrEmail")
+        @ValueSource(strings = {"find", "count", "exists"})
+        @DisplayName("Should keep chained OR branches and their AND groups in lexical order")
+        void shouldKeepChainedBranchesInLexicalOrder(String operation) {
+            // Given
+            String query = operation + "ByNameAndAgeOrCityAndActiveAndEnabledOrEmail";
+
+            // When
+            QueryCondition condition = queryProvider.apply(query, "entity")
+                    .where().orElseThrow().condition();
+
+            // Then
+            assertConditionTree(condition, "OR(AND(name,age),AND(city,active,enabled),email)",
+                    "name", "age", "city", "active", "enabled", "email");
+        }
+    }
+
     /*
      Converts from comma-separated values (space around commas is ignored) to an array of Condition instances,
      using Condition.valueOf
@@ -902,6 +953,48 @@ class SelectMethodQueryProviderTest {
                 assertThat(ParamQueryValue.class.cast(value).get().contains(variable)).isTrue();
             }
         }
+    }
+
+    static void assertConditionTree(QueryCondition condition, String expectedTree, String... expectedLeaves) {
+        List<QueryCondition> leaves = leafConditions(condition);
+
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(conditionTree(condition))
+                    .as("logical condition tree")
+                    .isEqualTo(expectedTree);
+            softly.assertThat(leaves)
+                    .as("logical leaves in lexical order")
+                    .extracting(QueryCondition::name)
+                    .containsExactly(expectedLeaves);
+
+            for (int index = 0; index < expectedLeaves.length; index++) {
+                String expectedLeaf = expectedLeaves[index];
+                softly.assertThat(leaves.get(index).value())
+                        .as("value for leaf %s", expectedLeaf)
+                        .isInstanceOf(ParamQueryValue.class);
+                softly.assertThat(ParamQueryValue.class.cast(leaves.get(index).value()).get())
+                        .as("parameter for leaf %s at index %s", expectedLeaf, index)
+                        .startsWith(expectedLeaf + "_");
+            }
+        });
+    }
+
+    private static String conditionTree(QueryCondition condition) {
+        if (Condition.AND.equals(condition.condition()) || Condition.OR.equals(condition.condition())) {
+            return condition.condition().name() + ConditionQueryValue.class.cast(condition.value()).get().stream()
+                    .map(SelectMethodQueryProviderTest::conditionTree)
+                    .collect(java.util.stream.Collectors.joining(",", "(", ")"));
+        }
+        return condition.name();
+    }
+
+    private static List<QueryCondition> leafConditions(QueryCondition condition) {
+        if (Condition.AND.equals(condition.condition()) || Condition.OR.equals(condition.condition())) {
+            return ConditionQueryValue.class.cast(condition.value()).get().stream()
+                    .flatMap(child -> leafConditions(child).stream())
+                    .toList();
+        }
+        return List.of(condition);
     }
 
 


### PR DESCRIPTION
## Description
Fixes Query by Method Name parsing when `And` and `Or` occur in the same derived method name. The parser now groups adjacent `And` conditions before applying `Or`, while preserving lexical parameter order for downstream binding.

The change also adds exact condition-tree and parameter-order tests for leading, trailing, and chained conjunction groups across derived `find`, `count`, `exists`, and `delete` operations.

**Related Issue:** Fixes #759 

## Type of Contribution
- [X] Bug fix
- [ ] Feature request
- [ ] New database support
- [ ] Use case implementation
- [ ] Documentation update
- [ ] Other: 

## Architectural and Design Decisions
The correction is implemented in the shared communication-query method-name parser because that is where the incorrect condition tree is created. Mixed expressions are represented as `Or` branches containing atomic predicates or flattened `And` groups. A following `And` extends only the final `Or` branch.

## Contribution Checklist
- [X] **ECA:** I have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
- [X] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
- [X] **Conventional Commits:** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
- [X] **Tests:** I have added/updated unit and integration tests.
- [ ] **Documentation:** I have updated the relevant .adoc files.
- [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results
- Full repository `mvn test` on JDK 21: 3,499 tests, 0 failures, 0 errors, 2 existing skips; all 15 reactor modules succeeded.
- Communication core/query reactor: 964 tests, 0 failures, 0 errors, 0 skips.
- Database-free reproducer: fails against 1.1.16 and passes unchanged with the corrected parser.
- Checkstyle, RAT, and `git diff --check` passed.
