### PR TITLE
fix: honor And precedence in method queries

### DIFF
--- a/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/AbstractMethodQueryParser.java
+++ b/jnosql-communication/jnosql-communication-query/src/main/java/org/eclipse/jnosql/communication/query/method/AbstractMethodQueryParser.java
@@ -30,7 +30,6 @@ import org.eclipse.jnosql.query.grammar.method.MethodLexer;
 import org.eclipse.jnosql.query.grammar.method.MethodParser;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -231,14 +230,6 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
     }
 
 
-    private boolean isAppendable(QueryCondition condition) {
-        return (AND.equals(condition.condition()) || OR.equals(condition.condition()));
-    }
-
-    private boolean isNotAppendable() {
-        return !isAppendable(this.condition);
-    }
-
     private QueryCondition checkNotCondition(QueryCondition condition, boolean hasNot) {
         if (hasNot) {
             ConditionQueryValue conditions = ConditionQueryValue.of(Collections.singletonList(condition));
@@ -258,40 +249,38 @@ abstract class AbstractMethodQueryParser extends MethodBaseListener {
     }
 
     private void appendCondition(Condition operator, QueryCondition newCondition) {
-
-        if (operator.equals(this.condition.condition())) {
-            ConditionQueryValue conditionValue = ConditionQueryValue.class.cast(this.condition.value());
-            List<QueryCondition> conditions = new ArrayList<>(conditionValue.get());
-            conditions.add(newCondition);
-            this.condition = new MethodCondition(SUB_ENTITY_FLAG + operator.name(), operator, ConditionQueryValue.of(conditions));
-        } else if (isNotAppendable()) {
-            List<QueryCondition> conditions = Arrays.asList(this.condition, newCondition);
-            this.condition = new MethodCondition(SUB_ENTITY_FLAG + operator.name(), operator, ConditionQueryValue.of(conditions));
-        } else {
-            List<QueryCondition> conditions = ConditionQueryValue.class.cast(this.condition.value()).get();
-            QueryCondition lastCondition = conditions.get(conditions.size() - 1);
-
-            if (isAppendable(lastCondition) && Condition.EQUALS.equals(lastCondition.condition())) {
-                List<QueryCondition> lastConditions = new ArrayList<>(ConditionQueryValue.class.cast(lastCondition.value()).get());
-                lastConditions.add(newCondition);
-
-                QueryCondition newAppendable = new MethodCondition(SUB_ENTITY_FLAG + operator.name(),
-                        operator, ConditionQueryValue.of(lastConditions));
-
-                List<QueryCondition> newConditions = new ArrayList<>(conditions.subList(0, conditions.size() - 1));
-                newConditions.add(newAppendable);
-                this.condition = new MethodCondition(this.condition.name(), this.condition.condition(),
-                        ConditionQueryValue.of(newConditions));
-            } else {
-                QueryCondition newAppendable = new MethodCondition(SUB_ENTITY_FLAG + operator.name(),
-                        operator, ConditionQueryValue.of(Collections.singletonList(newCondition)));
-
-                List<QueryCondition> newConditions = new ArrayList<>(conditions);
-                newConditions.add(newAppendable);
-                this.condition = new MethodCondition(this.condition.name(), this.condition.condition(),
-                        ConditionQueryValue.of(newConditions));
-            }
-
+        if (OR.equals(operator)) {
+            this.condition = OR.equals(this.condition.condition())
+                    ? appendToGroup(this.condition, newCondition)
+                    : createGroup(OR, List.of(this.condition, newCondition));
+            return;
         }
+
+        if (!OR.equals(this.condition.condition())) {
+            this.condition = AND.equals(this.condition.condition())
+                    ? appendToGroup(this.condition, newCondition)
+                    : createGroup(AND, List.of(this.condition, newCondition));
+            return;
+        }
+
+        List<QueryCondition> conditions = new ArrayList<>(
+                ConditionQueryValue.class.cast(this.condition.value()).get());
+        int lastIndex = conditions.size() - 1;
+        QueryCondition lastCondition = conditions.get(lastIndex);
+        QueryCondition conjunction = AND.equals(lastCondition.condition())
+                ? appendToGroup(lastCondition, newCondition)
+                : createGroup(AND, List.of(lastCondition, newCondition));
+        conditions.set(lastIndex, conjunction);
+        this.condition = createGroup(OR, conditions);
+    }
+
+    private QueryCondition appendToGroup(QueryCondition group, QueryCondition newCondition) {
+        List<QueryCondition> conditions = new ArrayList<>(ConditionQueryValue.class.cast(group.value()).get());
+        conditions.add(newCondition);
+        return createGroup(group.condition(), conditions);
+    }
+
+    private QueryCondition createGroup(Condition operator, List<QueryCondition> conditions) {
+        return new MethodCondition(SUB_ENTITY_FLAG + operator.name(), operator, ConditionQueryValue.of(conditions));
     }
 }

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/DeleteByMethodQueryProviderTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/DeleteByMethodQueryProviderTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -396,6 +398,41 @@ class DeleteByMethodQueryProviderTest {
         checkNotCondition(query, operator, variable);
     }
 
+    @ParameterizedTest(name = "Should apply AND precedence before OR for {0}")
+    @ValueSource(strings = {"deleteByAAndBOrC"})
+    void shouldApplyAndPrecedenceBeforeOr(String query) {
+        QueryCondition condition = queryProvider.apply(query, "entity").where().orElseThrow().condition();
+
+        assertConditionTree(condition, "OR(AND(EQUALS(a),EQUALS(b)),EQUALS(c))", List.of("a", "b", "c"));
+    }
+
+    @ParameterizedTest(name = "Should apply AND precedence after OR for {0}")
+    @ValueSource(strings = {"deleteByAOrBAndC"})
+    void shouldApplyAndPrecedenceAfterOr(String query) {
+        QueryCondition condition = queryProvider.apply(query, "entity").where().orElseThrow().condition();
+
+        assertConditionTree(condition, "OR(EQUALS(a),AND(EQUALS(b),EQUALS(c)))", List.of("a", "b", "c"));
+    }
+
+    @ParameterizedTest(name = "Should apply AND precedence across chained conditions for {0}")
+    @ValueSource(strings = {"deleteByAAndBOrCAndDOrE"})
+    void shouldApplyAndPrecedenceAcrossChainedConditions(String query) {
+        QueryCondition condition = queryProvider.apply(query, "entity").where().orElseThrow().condition();
+
+        assertConditionTree(condition, "OR(AND(EQUALS(a),EQUALS(b)),AND(EQUALS(c),EQUALS(d)),EQUALS(e))",
+                List.of("a", "b", "c", "d", "e"));
+    }
+
+    @ParameterizedTest(name = "Should extend the final AND group after OR for {0}")
+    @ValueSource(strings = {"deleteByAAndBOrCAndDAndEOrF"})
+    void shouldExtendFinalAndGroupAfterOr(String query) {
+        QueryCondition condition = queryProvider.apply(query, "entity").where().orElseThrow().condition();
+
+        assertConditionTree(condition,
+                "OR(AND(EQUALS(a),EQUALS(b)),AND(EQUALS(c),EQUALS(d),EQUALS(e)),EQUALS(f))",
+                List.of("a", "b", "c", "d", "e", "f"));
+    }
+
 
     private void checkAppendCondition(String query, Condition operator, Condition operator2, String variable,
                                       String variable2, Condition operatorAppender) {
@@ -422,6 +459,38 @@ class DeleteByMethodQueryProviderTest {
         QueryValue<?> param2 = condition2.value();
         assertEquals(condition2.condition(), operator2);
         assertTrue(ParamQueryValue.class.cast(param2).get().contains(variable2));
+    }
+
+    private void assertConditionTree(QueryCondition condition, String expectedTree, List<String> expectedParameters) {
+        assertEquals(expectedTree, conditionTree(condition));
+        List<String> parameters = new ArrayList<>();
+        collectParameters(condition, parameters);
+        assertEquals(expectedParameters, parameters);
+    }
+
+    private String conditionTree(QueryCondition condition) {
+        if (condition.value() instanceof ConditionQueryValue value) {
+            StringBuilder tree = new StringBuilder(condition.condition().name()).append('(');
+            List<QueryCondition> conditions = value.get();
+            for (int index = 0; index < conditions.size(); index++) {
+                if (index > 0) {
+                    tree.append(',');
+                }
+                tree.append(conditionTree(conditions.get(index)));
+            }
+            return tree.append(')').toString();
+        }
+        return condition.condition().name() + '(' + condition.name() + ')';
+    }
+
+    private void collectParameters(QueryCondition condition, List<String> parameters) {
+        if (condition.value() instanceof ConditionQueryValue value) {
+            value.get().forEach(child -> collectParameters(child, parameters));
+            return;
+        }
+        assertTrue(condition.value() instanceof ParamQueryValue);
+        String parameter = ParamQueryValue.class.cast(condition.value()).get();
+        parameters.add(parameter.substring(0, parameter.lastIndexOf('_')));
     }
 
 

--- a/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/SelectMethodQueryProviderTest.java
+++ b/jnosql-communication/jnosql-communication-query/src/test/java/org/eclipse/jnosql/communication/query/method/SelectMethodQueryProviderTest.java
@@ -14,6 +14,7 @@ package org.eclipse.jnosql.communication.query.method;
 import jakarta.data.Direction;
 import jakarta.data.Sort;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 
@@ -671,6 +672,42 @@ class SelectMethodQueryProviderTest {
         checkNotCondition(query, operator, variable);
     }
 
+    @ParameterizedTest(name = "Should apply AND precedence before OR for {0}")
+    @ValueSource(strings = {"findByAAndBOrC", "countByAAndBOrC", "existsByAAndBOrC"})
+    void shouldApplyAndPrecedenceBeforeOr(String query) {
+        QueryCondition condition = queryProvider.apply(query, "entity").where().orElseThrow().condition();
+
+        assertConditionTree(condition, "OR(AND(EQUALS(a),EQUALS(b)),EQUALS(c))", List.of("a", "b", "c"));
+    }
+
+    @ParameterizedTest(name = "Should apply AND precedence after OR for {0}")
+    @ValueSource(strings = {"findByAOrBAndC", "countByAOrBAndC", "existsByAOrBAndC"})
+    void shouldApplyAndPrecedenceAfterOr(String query) {
+        QueryCondition condition = queryProvider.apply(query, "entity").where().orElseThrow().condition();
+
+        assertConditionTree(condition, "OR(EQUALS(a),AND(EQUALS(b),EQUALS(c)))", List.of("a", "b", "c"));
+    }
+
+    @ParameterizedTest(name = "Should apply AND precedence across chained conditions for {0}")
+    @ValueSource(strings = {"findByAAndBOrCAndDOrE", "countByAAndBOrCAndDOrE", "existsByAAndBOrCAndDOrE"})
+    void shouldApplyAndPrecedenceAcrossChainedConditions(String query) {
+        QueryCondition condition = queryProvider.apply(query, "entity").where().orElseThrow().condition();
+
+        assertConditionTree(condition, "OR(AND(EQUALS(a),EQUALS(b)),AND(EQUALS(c),EQUALS(d)),EQUALS(e))",
+                List.of("a", "b", "c", "d", "e"));
+    }
+
+    @ParameterizedTest(name = "Should extend the final AND group after OR for {0}")
+    @ValueSource(strings = {"findByAAndBOrCAndDAndEOrF", "countByAAndBOrCAndDAndEOrF",
+            "existsByAAndBOrCAndDAndEOrF"})
+    void shouldExtendFinalAndGroupAfterOr(String query) {
+        QueryCondition condition = queryProvider.apply(query, "entity").where().orElseThrow().condition();
+
+        assertConditionTree(condition,
+                "OR(AND(EQUALS(a),EQUALS(b)),AND(EQUALS(c),EQUALS(d),EQUALS(e)),EQUALS(f))",
+                List.of("a", "b", "c", "d", "e", "f"));
+    }
+
     private void checkOrderBy(String query, Direction direction, Direction direction2) {
         String entity = "entity";
         SelectQuery selectQuery = queryProvider.apply(query, entity);
@@ -731,6 +768,38 @@ class SelectMethodQueryProviderTest {
         QueryValue<?> param2 = condition2.value();
         assertEquals(condition2.condition(), operator2);
         assertTrue(ParamQueryValue.class.cast(param2).get().contains(variable2));
+    }
+
+    private void assertConditionTree(QueryCondition condition, String expectedTree, List<String> expectedParameters) {
+        assertEquals(expectedTree, conditionTree(condition));
+        List<String> parameters = new ArrayList<>();
+        collectParameters(condition, parameters);
+        assertEquals(expectedParameters, parameters);
+    }
+
+    private String conditionTree(QueryCondition condition) {
+        if (condition.value() instanceof ConditionQueryValue value) {
+            StringBuilder tree = new StringBuilder(condition.condition().name()).append('(');
+            List<QueryCondition> conditions = value.get();
+            for (int index = 0; index < conditions.size(); index++) {
+                if (index > 0) {
+                    tree.append(',');
+                }
+                tree.append(conditionTree(conditions.get(index)));
+            }
+            return tree.append(')').toString();
+        }
+        return condition.condition().name() + '(' + condition.name() + ')';
+    }
+
+    private void collectParameters(QueryCondition condition, List<String> parameters) {
+        if (condition.value() instanceof ConditionQueryValue value) {
+            value.get().forEach(child -> collectParameters(child, parameters));
+            return;
+        }
+        assertTrue(condition.value() instanceof ParamQueryValue);
+        String parameter = ParamQueryValue.class.cast(condition.value()).get();
+        parameters.add(parameter.substring(0, parameter.lastIndexOf('_')));
     }
 
 


### PR DESCRIPTION
## Description
Backports the Query by Method Name precedence correction to the 1.1.x branch. When `And` and `Or` occur in the same derived method name, adjacent `And` conditions are now grouped before `Or`, while lexical parameter order remains unchanged.

The change adds exact condition-tree and parameter-order tests for leading, trailing, and chained conjunction groups across derived `find`, `count`, `exists`, and `delete` operations.

**Related Issue:** Fixes #759  

## Type of Contribution
- [X] Bug fix
- [ ] Feature request
- [ ] New database support
- [ ] Use case implementation
- [ ] Documentation update
- [ ] Other: 

## Architectural and Design Decisions
<!-- Explain WHY you chose this implementation path. Mention any impact on Mappers, Grammar, or API compatibility. -->

## Contribution Checklist
- [X] **ECA:** I have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
- [X] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
- [X] **Conventional Commits:** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
- [X] **Tests:** I have added/updated unit and integration tests.
- [ ] **Documentation:** I have updated the relevant .adoc files.
- [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results
- Full repository `mvn test` on JDK 17: 2,347 tests, 0 failures, 0 errors, 2 existing skips; all 15 reactor modules succeeded.
- Communication core/query reactor: 822 tests, 0 failures, 0 errors, 0 skips.
- Database-free reproducer: fails against 1.1.16 and passes unchanged with the corrected parser.
- Focused WebLogic regression: 1 test, 1 success, 0 failures/errors/skips; the candidate parser JAR was first on the managed-server classpath.
- Checkstyle, RAT, and `git diff --check` passed.
