### PR TITLE
fix: support opt-in mapping settings providers

### DIFF
--- a/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/configuration/ColumnManagerSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/main/java/org/eclipse/jnosql/mapping/column/configuration/ColumnManagerSupplier.java
@@ -20,7 +20,7 @@ import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
 import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
 import org.eclipse.jnosql.mapping.Database;
 import org.eclipse.jnosql.mapping.DatabaseType;
-import org.eclipse.jnosql.mapping.core.config.MicroProfileSettings;
+import org.eclipse.jnosql.mapping.core.config.MappingSettingsProvider;
 import org.eclipse.jnosql.mapping.reflection.Reflections;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -45,7 +45,7 @@ class ColumnManagerSupplier implements Supplier<DatabaseManager> {
     @Database(DatabaseType.COLUMN)
     @ApplicationScoped
     public DatabaseManager get() {
-        Settings settings = MicroProfileSettings.INSTANCE;
+        Settings settings = MappingSettingsProvider.resolve();
 
         DatabaseConfiguration configuration = settings.get(COLUMN_PROVIDER, Class.class)
                 .filter(DatabaseConfiguration.class::isAssignableFrom)

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/config/MappingSettingsProvider.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/config/MappingSettingsProvider.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ */
+package org.eclipse.jnosql.mapping.core.config;
+
+import org.eclipse.jnosql.communication.Settings;
+
+import java.util.Objects;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+/**
+ * An optional provider for the {@link Settings} used by mapping internals.
+ *
+ * <p>Providers are discovered with the class loader that defined this
+ * interface; the thread context class loader is not consulted. When multiple
+ * providers are visible, the first provider in
+ * {@link ServiceLoader} iteration order supplies the settings; installing a
+ * single provider is recommended. When no provider is visible, mapping lazily
+ * retains its existing {@link MicroProfileSettings#INSTANCE} behavior.</p>
+ *
+ * <p>A provider must return non-null settings. Service configuration and
+ * provider-construction failures, including {@link ServiceConfigurationError},
+ * and provider-invocation failures propagate without falling back.</p>
+ *
+ * @since 1.1.17
+ */
+public interface MappingSettingsProvider {
+
+    /**
+     * Returns the settings to use for the current mapping context.
+     *
+     * @return the non-null settings
+     */
+    Settings getSettings();
+
+    /**
+     * Resolves settings from the first provider visible to the class loader
+     * that defined this interface, or lazily falls back to
+     * {@link MicroProfileSettings#INSTANCE} when no provider is available.
+     *
+     * @return the resolved settings
+     * @throws NullPointerException when a provider returns {@code null}
+     * @throws ServiceConfigurationError when provider configuration is invalid
+     *         or a provider cannot be constructed
+     */
+    static Settings resolve() {
+        return MappingSettingsResolver.resolve(MappingSettingsProvider.class.getClassLoader());
+    }
+}
+
+final class MappingSettingsResolver {
+
+    private MappingSettingsResolver() {
+    }
+
+    static Settings resolve(ClassLoader classLoader) {
+        for (MappingSettingsProvider provider : ServiceLoader.load(MappingSettingsProvider.class, classLoader)) {
+            return Objects.requireNonNull(provider.getSettings(),
+                    "MappingSettingsProvider.getSettings() must not return null");
+        }
+        return MicroProfileSettings.INSTANCE;
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/config/MappingSettingsProviderTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/config/MappingSettingsProviderTest.java
@@ -1,0 +1,274 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ */
+package org.eclipse.jnosql.mapping.core.config;
+
+import org.eclipse.jnosql.communication.Settings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.ServiceConfigurationError;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MappingSettingsProviderTest {
+
+    private static final Settings FIRST_SETTINGS = Settings.of(Map.of("provider", "first"));
+
+    private static final Settings SECOND_SETTINGS = Settings.of(Map.of("provider", "second"));
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void shouldReturnMicroProfileSettingsWhenProviderIsNotAvailable() throws Exception {
+        try (URLClassLoader classLoader = serviceClassLoader("fallback", null)) {
+            assertSame(MicroProfileSettings.INSTANCE, resolve(classLoader));
+        }
+    }
+
+    @Test
+    void shouldResolveProviderBeforeLoadingMicroProfileSettings() throws Exception {
+        Path root = serviceRoot("lazy", LazyProvider.class.getName());
+        URL mainClasses = MappingSettingsProvider.class.getProtectionDomain().getCodeSource().getLocation();
+        URL testClasses = MappingSettingsProviderTest.class.getProtectionDomain().getCodeSource().getLocation();
+
+        try (URLClassLoader classLoader = new MicroProfileBlockingClassLoader(
+                new URL[]{root.toUri().toURL(), mainClasses, testClasses}, getClass().getClassLoader())) {
+            Class<?> providerType = Class.forName(MappingSettingsProvider.class.getName(), true, classLoader);
+            Method resolve = providerType.getMethod("resolve");
+
+            assertSame(Settings.settings(), resolve.invoke(null));
+        }
+    }
+
+    @Test
+    void shouldIgnoreHostileContextClassLoaderProvider() throws Exception {
+        try (URLClassLoader hostile = serviceClassLoader("hostile", FirstProvider.class.getName())) {
+            ClassLoader previous = Thread.currentThread().getContextClassLoader();
+            try {
+                Thread.currentThread().setContextClassLoader(hostile);
+
+                assertSame(MicroProfileSettings.INSTANCE, MappingSettingsProvider.resolve());
+            } finally {
+                Thread.currentThread().setContextClassLoader(previous);
+            }
+        }
+    }
+
+    @Test
+    void shouldFollowSequentialExplicitClassLoaderChanges() throws Exception {
+        try (URLClassLoader first = serviceClassLoader("first", FirstProvider.class.getName());
+             URLClassLoader second = serviceClassLoader("second", SecondProvider.class.getName())) {
+            assertSame(FIRST_SETTINGS, resolve(first));
+            assertSame(SECOND_SETTINGS, resolve(second));
+            assertSame(FIRST_SETTINGS, resolve(first));
+        }
+    }
+
+    @Test
+    void shouldSelectFirstProvider() throws Exception {
+        String providers = FirstProvider.class.getName() + '\n' + SecondProvider.class.getName();
+        try (URLClassLoader classLoader = serviceClassLoader("ordered", providers)) {
+            assertSame(FIRST_SETTINGS, resolve(classLoader));
+        }
+    }
+
+    @Test
+    void shouldKeepConcurrentExplicitClassLoadersIsolated() throws Exception {
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try (URLClassLoader first = serviceClassLoader("concurrent-first", FirstProvider.class.getName());
+             URLClassLoader second = serviceClassLoader("concurrent-second", SecondProvider.class.getName())) {
+            Future<Settings> firstResult = executor.submit(() -> resolveRepeatedly(first, FIRST_SETTINGS, ready, start));
+            Future<Settings> secondResult = executor.submit(() ->
+                    resolveRepeatedly(second, SECOND_SETTINGS, ready, start));
+
+            assertTrue(ready.await(10, TimeUnit.SECONDS));
+            start.countDown();
+            assertSame(FIRST_SETTINGS, firstResult.get(10, TimeUnit.SECONDS));
+            assertSame(SECOND_SETTINGS, secondResult.get(10, TimeUnit.SECONDS));
+        } finally {
+            start.countDown();
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    void shouldRejectNullProviderSettings() throws Exception {
+        try (URLClassLoader classLoader = serviceClassLoader("null", NullProvider.class.getName())) {
+            NullPointerException exception = assertThrows(NullPointerException.class, () -> resolve(classLoader));
+
+            assertEquals("MappingSettingsProvider.getSettings() must not return null", exception.getMessage());
+        }
+    }
+
+    @Test
+    void shouldPropagateProviderFailure() throws Exception {
+        try (URLClassLoader classLoader = serviceClassLoader("failure", FailingProvider.class.getName())) {
+            IllegalStateException exception = assertThrows(IllegalStateException.class, () -> resolve(classLoader));
+
+            assertEquals("provider failure", exception.getMessage());
+        }
+    }
+
+    @Test
+    void shouldPropagateProviderConstructionFailure() throws Exception {
+        try (URLClassLoader classLoader = serviceClassLoader("construction-failure",
+                ConstructionFailingProvider.class.getName())) {
+            assertThrows(ServiceConfigurationError.class, () -> resolve(classLoader));
+        }
+    }
+
+    @Test
+    void shouldPropagateMalformedServiceEntry() throws Exception {
+        try (URLClassLoader classLoader = serviceClassLoader("malformed", "not.a.MappingSettingsProvider")) {
+            assertThrows(ServiceConfigurationError.class, () -> resolve(classLoader));
+        }
+    }
+
+    private Settings resolve(ClassLoader classLoader) {
+        return MappingSettingsResolver.resolve(classLoader);
+    }
+
+    private Settings resolveRepeatedly(ClassLoader classLoader, Settings expected,
+                                       CountDownLatch ready, CountDownLatch start) throws Exception {
+        ready.countDown();
+        assertTrue(start.await(10, TimeUnit.SECONDS));
+        Settings resolved = null;
+        for (int index = 0; index < 100; index++) {
+            resolved = MappingSettingsResolver.resolve(classLoader);
+            assertSame(expected, resolved);
+        }
+        return resolved;
+    }
+
+    private URLClassLoader serviceClassLoader(String name, String providerName) throws Exception {
+        Path root = serviceRoot(name, providerName);
+        return new URLClassLoader(new URL[]{root.toUri().toURL()}, getClass().getClassLoader());
+    }
+
+    private Path serviceRoot(String name, String providerName) throws Exception {
+        Path root = temporaryDirectory.resolve(name);
+        if (providerName != null) {
+            Path services = root.resolve("META-INF/services");
+            Files.createDirectories(services);
+            Files.writeString(services.resolve(MappingSettingsProvider.class.getName()), providerName + '\n',
+                    StandardCharsets.UTF_8);
+        }
+        return root;
+    }
+
+    public static final class FirstProvider implements MappingSettingsProvider {
+
+        @Override
+        public Settings getSettings() {
+            return FIRST_SETTINGS;
+        }
+    }
+
+    public static final class SecondProvider implements MappingSettingsProvider {
+
+        @Override
+        public Settings getSettings() {
+            return SECOND_SETTINGS;
+        }
+    }
+
+    public static final class NullProvider implements MappingSettingsProvider {
+
+        @Override
+        public Settings getSettings() {
+            return null;
+        }
+    }
+
+    public static final class FailingProvider implements MappingSettingsProvider {
+
+        @Override
+        public Settings getSettings() {
+            throw new IllegalStateException("provider failure");
+        }
+    }
+
+    public static final class ConstructionFailingProvider implements MappingSettingsProvider {
+
+        public ConstructionFailingProvider() {
+            throw new IllegalStateException("provider construction failure");
+        }
+
+        @Override
+        public Settings getSettings() {
+            return Settings.settings();
+        }
+    }
+
+    public static final class LazyProvider implements MappingSettingsProvider {
+
+        @Override
+        public Settings getSettings() {
+            return Settings.settings();
+        }
+    }
+
+    private static final class MicroProfileBlockingClassLoader extends URLClassLoader {
+
+        private MicroProfileBlockingClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> type = findLoadedClass(name);
+                if (type == null && MicroProfileSettings.class.getName().equals(name)) {
+                    throw new ClassNotFoundException(name);
+                }
+                if (type == null && isIsolated(name)) {
+                    type = findClass(name);
+                }
+                if (type == null) {
+                    type = super.loadClass(name, false);
+                }
+                if (resolve) {
+                    resolveClass(type);
+                }
+                return type;
+            }
+        }
+
+        private boolean isIsolated(String name) {
+            return MappingSettingsProvider.class.getName().equals(name)
+                    || MappingSettingsResolver.class.getName().equals(name)
+                    || LazyProvider.class.getName().equals(name);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/configuration/DocumentManagerSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/main/java/org/eclipse/jnosql/mapping/document/configuration/DocumentManagerSupplier.java
@@ -20,7 +20,7 @@ import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
 import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
 import org.eclipse.jnosql.mapping.Database;
 import org.eclipse.jnosql.mapping.DatabaseType;
-import org.eclipse.jnosql.mapping.core.config.MicroProfileSettings;
+import org.eclipse.jnosql.mapping.core.config.MappingSettingsProvider;
 import org.eclipse.jnosql.mapping.reflection.Reflections;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -45,7 +45,7 @@ class DocumentManagerSupplier implements Supplier<DatabaseManager> {
     @ApplicationScoped
     @Database(DatabaseType.DOCUMENT)
     public DatabaseManager get() {
-        Settings settings = MicroProfileSettings.INSTANCE;
+        Settings settings = MappingSettingsProvider.resolve();
 
         DatabaseConfiguration configuration = settings.get(DOCUMENT_PROVIDER, Class.class)
                 .filter(DatabaseConfiguration.class::isAssignableFrom)

--- a/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/configuration/GraphManagerSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/main/java/org/eclipse/jnosql/mapping/graph/configuration/GraphManagerSupplier.java
@@ -21,7 +21,7 @@ import org.eclipse.jnosql.communication.CommunicationException;
 import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.graph.GraphDatabaseManager;
 import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
-import org.eclipse.jnosql.mapping.core.config.MicroProfileSettings;
+import org.eclipse.jnosql.mapping.core.config.MappingSettingsProvider;
 import org.eclipse.jnosql.mapping.reflection.Reflections;
 
 import java.util.Optional;
@@ -43,7 +43,7 @@ class GraphManagerSupplier implements Supplier<GraphDatabaseManager> {
     @Produces
     @ApplicationScoped
     public GraphDatabaseManager get() {
-        Settings settings = MicroProfileSettings.INSTANCE;
+        Settings settings = MappingSettingsProvider.resolve();
 
         DatabaseConfiguration configuration = settings.get(GRAPH_PROVIDER, Class.class)
                 .filter(DatabaseConfiguration.class::isAssignableFrom)

--- a/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/configuration/BucketManagerFactorySupplier.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/configuration/BucketManagerFactorySupplier.java
@@ -21,7 +21,7 @@ import jakarta.enterprise.inject.spi.CDI;
 import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
 import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
-import org.eclipse.jnosql.mapping.core.config.MicroProfileSettings;
+import org.eclipse.jnosql.mapping.core.config.MappingSettingsProvider;
 import org.eclipse.jnosql.mapping.reflection.Reflections;
 
 import java.util.function.Supplier;
@@ -40,7 +40,7 @@ class BucketManagerFactorySupplier implements Supplier<BucketManagerFactory> {
     @ApplicationScoped
     public BucketManagerFactory get() {
 
-        Settings settings = MicroProfileSettings.INSTANCE;
+        Settings settings = MappingSettingsProvider.resolve();
 
         KeyValueConfiguration configuration = settings.get(KEY_VALUE_PROVIDER, Class.class)
                 .filter(KeyValueConfiguration.class::isAssignableFrom)

--- a/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/configuration/BucketManagerSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/configuration/BucketManagerSupplier.java
@@ -19,7 +19,7 @@ import org.eclipse.jnosql.communication.Settings;
 import org.eclipse.jnosql.communication.keyvalue.BucketManager;
 import org.eclipse.jnosql.communication.keyvalue.BucketManagerFactory;
 import org.eclipse.jnosql.communication.keyvalue.KeyValueConfiguration;
-import org.eclipse.jnosql.mapping.core.config.MicroProfileSettings;
+import org.eclipse.jnosql.mapping.core.config.MappingSettingsProvider;
 import org.eclipse.jnosql.mapping.reflection.Reflections;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -44,7 +44,7 @@ class BucketManagerSupplier implements Supplier<BucketManager> {
     @ApplicationScoped
     public BucketManager get() {
 
-        Settings settings = MicroProfileSettings.INSTANCE;
+        Settings settings = MappingSettingsProvider.resolve();
 
         KeyValueConfiguration configuration = settings.get(KEY_VALUE_PROVIDER, Class.class)
                 .filter(KeyValueConfiguration.class::isAssignableFrom)

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
@@ -30,7 +30,7 @@ import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.IdNotFoundException;
 import org.eclipse.jnosql.mapping.core.NoSQLPage;
-import org.eclipse.jnosql.mapping.core.config.MicroProfileSettings;
+import org.eclipse.jnosql.mapping.core.config.MappingSettingsProvider;
 import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
 import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
 import org.eclipse.jnosql.mapping.metadata.FieldMetadata;
@@ -330,7 +330,8 @@ public abstract class AbstractSemiStructuredTemplate implements SemiStructuredTe
         requireNonNull(query, "query is required");
         requireNonNull(pageRequest, "pageRequest is required");
         LOGGER.finest(() -> "Executing query: " + query);
-        var enableMultipleSorting = MicroProfileSettings.INSTANCE.get(CURSOR_PAGINATION_MULTIPLE_SORTING, Boolean.class)
+        var enableMultipleSorting = MappingSettingsProvider.resolve()
+                .get(CURSOR_PAGINATION_MULTIPLE_SORTING, Boolean.class)
                 .orElse(false);
         LOGGER.finest(() -> "Cursor pagination with multiple sorting is enabled: " + enableMultipleSorting);
 


### PR DESCRIPTION
## Description
Adds an opt-in `MappingSettingsProvider` SPI for integrations that need to supply JNoSQL Mapping settings without replacing the process-wide MicroProfile Config resolver.

The six internal mapping configuration consumers now resolve settings through the SPI. When no provider is installed, resolution lazily returns the exact existing `MicroProfileSettings.INSTANCE`, so current applications retain their existing discovery, conversion, caching, and error behavior.

**Related Issue:** Fixes #762 

## Type of Contribution
- [X] Bug fix
- [ ] Feature request
- [ ] New database support
- [ ] Use case implementation
- [ ] Documentation update
- [ ] Other: 

## Architectural and Design Decisions
This is an additive integration SPI with no API removal and no default behavior change. Provider discovery uses the SPI's defining class loader, which lets a container control the authoritative provider without allowing an unrelated thread context class loader to override it. Resolution is performed without caching provider, settings, or class-loader state.

The first visible provider supplies a non-null `Settings` instance. Service metadata, provider construction, null results, and provider invocation failures are propagated. If no provider is visible, the existing `MicroProfileSettings` singleton is returned unchanged.

**This change is intentionally limited to the 1.1.x maintenance branch. There is no matching `main` PR because Jakarta EE 12 is considering a Jakarta Config effort, and the configuration architecture on `main` is likely to require broader alignment with that direction.**  This PR does not claim that `main` is fixed or prescribe its future design.

No mapper grammar, datastore-provider contract, or existing MicroProfile Config behavior changes.

## Contribution Checklist
- [X] **ECA:** I have signed the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php).
- [X] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
- [X] **Conventional Commits:** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
- [X] **Tests:** I have added/updated unit and integration tests.
- [ ] **Documentation:** I have updated the relevant .adoc files.
- [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results
- Focused mapping-core tests: 35 tests, 0 failures, 0 errors, 0 skips.
- Full 1.1.x reactor: all 15 modules succeeded; 2,341 tests, 0 failures, 0 errors, 2 existing skips.
- RAT, Checkstyle, PMD, Javadocs, packaging, and the Maven verification lifecycle completed successfully.
- Downstream WebLogic Server validation against the same candidate: 7 focused integration tests, 321 full integration-module tests, and 14 server-based mapping tests passed with no failures or errors. Class-loading evidence confirmed that the candidate SPI and affected mapping code were exercised, and the server teardown completed cleanly.