### PR TITLE
Add CompletionStage repository return support

### DIFF
--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
@@ -11,6 +11,8 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *
+ *   Mohan Lal
  */
 package org.eclipse.jnosql.mapping.core.repository;
 
@@ -51,11 +53,8 @@ public enum DynamicReturnConverter {
         Class<?> typeClass = dynamic.typeClass();
         Class<?> returnType = method.getReturnType();
 
-        RepositoryReturn repositoryReturn = repositoryReturns
-                .stream()
-                .map(RepositoryReturn.class::cast)
-                .filter(r -> r.isCompatible(typeClass, returnType))
-                .findFirst().orElse(defaultReturn);
+        RepositoryReturn repositoryReturn =
+                findRepositoryReturn(typeClass, returnType);
 
         if (dynamic.hasPagination()) {
             return repositoryReturn.convertPageRequest(dynamic);
@@ -133,6 +132,17 @@ public enum DynamicReturnConverter {
         }
 
         return false;
+    }
+
+    public RepositoryReturn findRepositoryReturn(
+            Class<?> entity, Class<?> returnType) {
+
+        return repositoryReturns
+                .stream()
+                .filter(repositoryReturn ->
+                        repositoryReturn.isCompatible(entity, returnType))
+                .findFirst()
+                .orElse(defaultReturn);
     }
 
     private static boolean isIdentifierStart(final char ch) {

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturn.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturn.java
@@ -24,15 +24,20 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
- * A {@link RepositoryReturn} implementation that wraps repository results
- * in a {@link CompletionStage}.
+ * A repository return strategy that supports repository methods returning
+ * {@link CompletionStage}.
  *
- * <p>The repository method's generic return type determines the underlying
- * repository return strategy. For example, {@code CompletionStage<Person>}
- * uses the {@code Person} return strategy, while
- * {@code CompletionStage<List<Person>>} uses the {@code List} return strategy.</p>
+ * <p>The generic type declared by the {@link CompletionStage} determines
+ * the repository return strategy used to convert the underlying result.
+ * For example, {@code CompletionStage<Person>} uses the repository return
+ * strategy for {@code Person}, while {@code CompletionStage<List<Person>>}
+ * uses the repository return strategy for {@code List}.</p>
+ *
+ * <p>The converted result is wrapped in a completed
+ * {@link CompletableFuture}.</p>
  */
 public class CompletionStageRepositoryReturn implements RepositoryReturn {
+
     @Override
     public boolean isCompatible(Class<?> entity, Class<?> returnType) {
         return CompletionStage.class.equals(returnType);
@@ -45,7 +50,8 @@ public class CompletionStageRepositoryReturn implements RepositoryReturn {
 
     @Override
     public <T> Object convertPageRequest(DynamicReturn<T> dynamicReturn) {
-        return CompletableFuture.completedFuture(convertPageResult(dynamicReturn));
+        return CompletableFuture.completedFuture(
+                convertPageResult(dynamicReturn));
     }
 
     private <T> Object convertResult(DynamicReturn<T> dynamicReturn) {

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturn.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturn.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *
+ *   The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ *
+ *   Contributors:
+ *
+ *   Mohan Lal
+ *
+ */
+package org.eclipse.jnosql.mapping.core.repository.returns;
+
+import org.eclipse.jnosql.mapping.core.repository.DynamicReturn;
+import org.eclipse.jnosql.mapping.core.repository.DynamicReturnConverter;
+import org.eclipse.jnosql.mapping.core.repository.RepositoryReturn;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class CompletionStageRepositoryReturn implements RepositoryReturn {
+
+    @Override
+    public boolean isCompatible(Class<?> entity, Class<?> returnType) {
+        return CompletionStage.class.equals(returnType);
+    }
+
+    @Override
+    public <T> Object convert(DynamicReturn<T> dynamicReturn) {
+        return CompletableFuture.completedFuture(convertResult(dynamicReturn));
+    }
+
+    @Override
+    public <T> Object convertPageRequest(DynamicReturn<T> dynamicReturn) {
+        return CompletableFuture.completedFuture(convertPageResult(dynamicReturn));
+    }
+
+    private <T> Object convertResult(DynamicReturn<T> dynamicReturn) {
+        Class<?> returnType = getReturnType(dynamicReturn);
+
+        return getRepositoryReturn(dynamicReturn, returnType)
+                .convert(dynamicReturn);
+    }
+
+    private <T> Object convertPageResult(DynamicReturn<T> dynamicReturn) {
+        Class<?> returnType = getReturnType(dynamicReturn);
+
+        return getRepositoryReturn(dynamicReturn, returnType)
+                .convertPageRequest(dynamicReturn);
+    }
+
+    private <T> RepositoryReturn getRepositoryReturn(
+            DynamicReturn<T> dynamicReturn, Class<?> returnType) {
+
+        return DynamicReturnConverter.INSTANCE
+                .findRepositoryReturn(dynamicReturn.typeClass(), returnType);
+    }
+
+    private Class<?> getReturnType(DynamicReturn<?> dynamicReturn) {
+        Type genericReturnType =
+                dynamicReturn.getMethod().getGenericReturnType();
+
+        if (genericReturnType instanceof ParameterizedType parameterizedType) {
+            Type type = parameterizedType.getActualTypeArguments()[0];
+
+            if (type instanceof Class<?> typeClass) {
+                return typeClass;
+            }
+
+            if (type instanceof ParameterizedType nestedParameterizedType
+                    && nestedParameterizedType.getRawType()
+                    instanceof Class<?> rawType) {
+                return rawType;
+            }
+        }
+
+        throw new IllegalArgumentException(
+                "Cannot determine CompletionStage generic return type for method: "
+                        + dynamicReturn.getMethod());
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturn.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturn.java
@@ -23,8 +23,16 @@ import java.lang.reflect.Type;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+/**
+ * A {@link RepositoryReturn} implementation that wraps repository results
+ * in a {@link CompletionStage}.
+ *
+ * <p>The repository method's generic return type determines the underlying
+ * repository return strategy. For example, {@code CompletionStage<Person>}
+ * uses the {@code Person} return strategy, while
+ * {@code CompletionStage<List<Person>>} uses the {@code List} return strategy.</p>
+ */
 public class CompletionStageRepositoryReturn implements RepositoryReturn {
-
     @Override
     public boolean isCompatible(Class<?> entity, Class<?> returnType) {
         return CompletionStage.class.equals(returnType);

--- a/jnosql-mapping/jnosql-mapping-core/src/main/resources/META-INF/services/org.eclipse.jnosql.mapping.core.repository.RepositoryReturn
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/resources/META-INF/services/org.eclipse.jnosql.mapping.core.repository.RepositoryReturn
@@ -1,6 +1,7 @@
 org.eclipse.jnosql.mapping.core.repository.returns.InstanceRepositoryReturn
 org.eclipse.jnosql.mapping.core.repository.returns.ListRepositoryReturn
 org.eclipse.jnosql.mapping.core.repository.returns.OptionalRepositoryReturn
+org.eclipse.jnosql.mapping.core.repository.returns.CompletionStageRepositoryReturn
 org.eclipse.jnosql.mapping.core.repository.returns.PageRepositoryReturn
 org.eclipse.jnosql.mapping.core.repository.returns.QueueRepositoryReturn
 org.eclipse.jnosql.mapping.core.repository.returns.SetRepositoryReturn

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverterCompletionStageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverterCompletionStageTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Mohan Lal
+ */
+package org.eclipse.jnosql.mapping.core.repository;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DynamicReturnConverterCompletionStageTest {
+
+    interface Sample {
+        CompletionStage<Person> findByName(String name);
+
+        CompletionStage<List<Person>> findAllByName(String name);
+    }
+
+    @Test
+    void shouldWrapSingleEntityInCompletionStage() throws NoSuchMethodException, ExecutionException, InterruptedException {
+        Method method = Sample.class.getMethod("findByName", String.class);
+        Person person = new Person("Ada");
+
+        DynamicReturn.DefaultDynamicReturnBuilder<Person> builder = DynamicReturn.builder();
+        DynamicReturn<Person> dynamic = builder
+                .classSource(Person.class)
+                .methodSource(method)
+                .singleResult(() -> Optional.of(person))
+                .result(() -> Stream.of(person))
+                .build();
+
+        Object result = DynamicReturnConverter.INSTANCE.convert(dynamic);
+
+        assertThat(result).isInstanceOf(CompletionStage.class);
+        CompletionStage<?> stage = (CompletionStage<?>) result;
+        assertThat(stage.toCompletableFuture().get()).isEqualTo(person);
+    }
+
+    @Test
+    void shouldWrapListInCompletionStage() throws NoSuchMethodException, ExecutionException, InterruptedException {
+        Method method = Sample.class.getMethod("findAllByName", String.class);
+        Person ada = new Person("Ada");
+        Person alan = new Person("Alan");
+
+        DynamicReturn.DefaultDynamicReturnBuilder<Person> builder = DynamicReturn.builder();
+        DynamicReturn<Person> dynamic = builder
+                .classSource(Person.class)
+                .methodSource(method)
+                .singleResult(() -> Optional.of(ada))
+                .result(() -> Stream.of(ada, alan))
+                .build();
+
+        Object result = DynamicReturnConverter.INSTANCE.convert(dynamic);
+
+        assertThat(result).isInstanceOf(CompletionStage.class);
+        CompletionStage<?> stage = (CompletionStage<?>) result;
+
+        @SuppressWarnings("unchecked")
+        List<Person> listResult = (List<Person>) stage.toCompletableFuture().get();
+
+        assertThat(listResult).containsExactly(ada, alan);
+    }
+
+    record Person(String name) {
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverterCompletionStageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverterCompletionStageTest.java
@@ -14,16 +14,16 @@
  */
 package org.eclipse.jnosql.mapping.core.repository;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class DynamicReturnConverterCompletionStageTest {
 
@@ -35,66 +35,78 @@ class DynamicReturnConverterCompletionStageTest {
     }
 
     @Test
+    @DisplayName("Should wrap single entity in CompletionStage")
     void shouldWrapSingleEntityInCompletionStage()
-            throws NoSuchMethodException, ExecutionException,
-            InterruptedException {
+            throws NoSuchMethodException {
 
-        Method method = Sample.class.getMethod("findByName", String.class);
+        // Arrange
+        Method method = Sample.class.getMethod(
+                "findByName", String.class);
         Person person = new Person("Ada");
 
-        DynamicReturn.DefaultDynamicReturnBuilder<Person> builder =
-                DynamicReturn.builder();
-
-        DynamicReturn<Person> dynamic = builder
+        DynamicReturn<Person> dynamic = DynamicReturn.builder()
                 .classSource(Person.class)
                 .methodSource(method)
                 .singleResult(() -> Optional.of(person))
                 .result(() -> Stream.of(person))
                 .build();
 
-        Object result = DynamicReturnConverter.INSTANCE.convert(dynamic);
+        // Act
+        Object result =
+                DynamicReturnConverter.INSTANCE.convert(dynamic);
 
-        assertThat(result).isInstanceOf(CompletionStage.class);
+        // Assert
+        assertSoftly(softly -> {
+            softly.assertThat(result)
+                    .as("converted result")
+                    .isInstanceOf(CompletionStage.class);
 
-        CompletionStage<?> stage = (CompletionStage<?>) result;
+            CompletionStage<?> stage = (CompletionStage<?>) result;
 
-        assertThat(stage.toCompletableFuture().get())
-                .isEqualTo(person);
+            softly.assertThat(stage.toCompletableFuture().join())
+                    .as("completion stage value")
+                    .isEqualTo(person);
+        });
     }
 
     @Test
+    @DisplayName("Should wrap list in CompletionStage")
     void shouldWrapListInCompletionStage()
-            throws NoSuchMethodException, ExecutionException,
-            InterruptedException {
+            throws NoSuchMethodException {
 
-        Method method =
-                Sample.class.getMethod("findAllByName", String.class);
-
+        // Arrange
+        Method method = Sample.class.getMethod(
+                "findAllByName", String.class);
         Person ada = new Person("Ada");
         Person alan = new Person("Alan");
 
-        DynamicReturn.DefaultDynamicReturnBuilder<Person> builder =
-                DynamicReturn.builder();
-
-        DynamicReturn<Person> dynamic = builder
+        DynamicReturn<Person> dynamic = DynamicReturn.builder()
                 .classSource(Person.class)
                 .methodSource(method)
                 .singleResult(() -> Optional.of(ada))
                 .result(() -> Stream.of(ada, alan))
                 .build();
 
-        Object result = DynamicReturnConverter.INSTANCE.convert(dynamic);
+        // Act
+        Object result =
+                DynamicReturnConverter.INSTANCE.convert(dynamic);
 
-        assertThat(result).isInstanceOf(CompletionStage.class);
+        // Assert
+        assertSoftly(softly -> {
+            softly.assertThat(result)
+                    .as("converted result")
+                    .isInstanceOf(CompletionStage.class);
 
-        CompletionStage<?> stage = (CompletionStage<?>) result;
+            CompletionStage<?> stage = (CompletionStage<?>) result;
 
-        @SuppressWarnings("unchecked")
-        List<Person> listResult =
-                (List<Person>) stage.toCompletableFuture().get();
+            @SuppressWarnings("unchecked")
+            List<Person> listResult =
+                    (List<Person>) stage.toCompletableFuture().join();
 
-        assertThat(listResult)
-                .containsExactly(ada, alan);
+            softly.assertThat(listResult)
+                    .as("completion stage list value")
+                    .containsExactly(ada, alan);
+        });
     }
 
     record Person(String name) {

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverterCompletionStageTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverterCompletionStageTest.java
@@ -1,16 +1,16 @@
 /*
- *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
  *
- *   You may elect to redistribute this code under either of these licenses.
+ *   The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
  *
  *   Contributors:
  *
  *   Mohan Lal
+ *
  */
 package org.eclipse.jnosql.mapping.core.repository;
 
@@ -28,17 +28,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DynamicReturnConverterCompletionStageTest {
 
     interface Sample {
+
         CompletionStage<Person> findByName(String name);
 
         CompletionStage<List<Person>> findAllByName(String name);
     }
 
     @Test
-    void shouldWrapSingleEntityInCompletionStage() throws NoSuchMethodException, ExecutionException, InterruptedException {
+    void shouldWrapSingleEntityInCompletionStage()
+            throws NoSuchMethodException, ExecutionException,
+            InterruptedException {
+
         Method method = Sample.class.getMethod("findByName", String.class);
         Person person = new Person("Ada");
 
-        DynamicReturn.DefaultDynamicReturnBuilder<Person> builder = DynamicReturn.builder();
+        DynamicReturn.DefaultDynamicReturnBuilder<Person> builder =
+                DynamicReturn.builder();
+
         DynamicReturn<Person> dynamic = builder
                 .classSource(Person.class)
                 .methodSource(method)
@@ -49,17 +55,27 @@ class DynamicReturnConverterCompletionStageTest {
         Object result = DynamicReturnConverter.INSTANCE.convert(dynamic);
 
         assertThat(result).isInstanceOf(CompletionStage.class);
+
         CompletionStage<?> stage = (CompletionStage<?>) result;
-        assertThat(stage.toCompletableFuture().get()).isEqualTo(person);
+
+        assertThat(stage.toCompletableFuture().get())
+                .isEqualTo(person);
     }
 
     @Test
-    void shouldWrapListInCompletionStage() throws NoSuchMethodException, ExecutionException, InterruptedException {
-        Method method = Sample.class.getMethod("findAllByName", String.class);
+    void shouldWrapListInCompletionStage()
+            throws NoSuchMethodException, ExecutionException,
+            InterruptedException {
+
+        Method method =
+                Sample.class.getMethod("findAllByName", String.class);
+
         Person ada = new Person("Ada");
         Person alan = new Person("Alan");
 
-        DynamicReturn.DefaultDynamicReturnBuilder<Person> builder = DynamicReturn.builder();
+        DynamicReturn.DefaultDynamicReturnBuilder<Person> builder =
+                DynamicReturn.builder();
+
         DynamicReturn<Person> dynamic = builder
                 .classSource(Person.class)
                 .methodSource(method)
@@ -70,12 +86,15 @@ class DynamicReturnConverterCompletionStageTest {
         Object result = DynamicReturnConverter.INSTANCE.convert(dynamic);
 
         assertThat(result).isInstanceOf(CompletionStage.class);
+
         CompletionStage<?> stage = (CompletionStage<?>) result;
 
         @SuppressWarnings("unchecked")
-        List<Person> listResult = (List<Person>) stage.toCompletableFuture().get();
+        List<Person> listResult =
+                (List<Person>) stage.toCompletableFuture().get();
 
-        assertThat(listResult).containsExactly(ada, alan);
+        assertThat(listResult)
+                .containsExactly(ada, alan);
     }
 
     record Person(String name) {

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Mohan Lal
+ */
+package org.eclipse.jnosql.mapping.core.repository.returns;
+
+import org.eclipse.jnosql.mapping.core.repository.DynamicReturn;
+import org.eclipse.jnosql.mapping.core.repository.RepositoryReturn;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CompletionStageRepositoryReturnTest {
+
+    private final RepositoryReturn repositoryReturn =
+            new CompletionStageRepositoryReturn();
+
+    @Test
+    void shouldReturnIsCompatible() {
+        assertTrue(repositoryReturn.isCompatible(
+                Person.class, CompletionStage.class));
+    }
+
+    @Test
+    void shouldReturnCompletionStage() {
+        Person ada = new Person("Ada");
+
+        DynamicReturn<Person> dynamic = DynamicReturn.builder()
+                .singleResult(() -> Optional.of(ada))
+                .classSource(Person.class)
+                .result(() -> Stream.of(ada))
+                .methodSource(PersonRepository.class.getDeclaredMethods()[0])
+                .build();
+
+        CompletionStage<Person> result =
+                (CompletionStage<Person>) repositoryReturn.convert(dynamic);
+
+        assertEquals(ada, result.toCompletableFuture().join());
+    }
+
+    private interface PersonRepository {
+
+        CompletionStage<Person> getPerson();
+    }
+
+    private record Person(String name) {
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
@@ -18,18 +18,18 @@ import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import org.eclipse.jnosql.mapping.core.repository.DynamicReturn;
 import org.eclipse.jnosql.mapping.core.repository.RepositoryReturn;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @ExtendWith(MockitoExtension.class)
 class CompletionStageRepositoryReturnTest {
@@ -41,51 +41,81 @@ class CompletionStageRepositoryReturnTest {
     private Page<Person> page;
 
     @Test
+    @DisplayName("Should return true when return type is CompletionStage")
     void shouldReturnIsCompatible() {
-        assertTrue(repositoryReturn.isCompatible(
-                Person.class, CompletionStage.class));
-        assertFalse(repositoryReturn.isCompatible(
-                Object.class, Person.class));
-        assertFalse(repositoryReturn.isCompatible(
-                Person.class, Object.class));
+        assertSoftly(softly -> {
+            softly.assertThat(repositoryReturn.isCompatible(
+                            Person.class, CompletionStage.class))
+                    .as("CompletionStage return type is compatible")
+                    .isTrue();
+
+            softly.assertThat(repositoryReturn.isCompatible(
+                            Object.class, Person.class))
+                    .as("different entity and return types are incompatible")
+                    .isFalse();
+
+            softly.assertThat(repositoryReturn.isCompatible(
+                            Person.class, Object.class))
+                    .as("different return type is incompatible")
+                    .isFalse();
+        });
     }
 
     @Test
+    @DisplayName("Should return entity wrapped in CompletionStage")
     void shouldReturnCompletionStage() throws NoSuchMethodException {
         Person ada = new Person("Ada");
 
         DynamicReturn<Person> dynamic = DynamicReturn.builder()
-                .classSource(Person.class)
-                .methodSource(PersonRepository.class.getMethod("getPerson"))
                 .singleResult(() -> Optional.of(ada))
+                .classSource(Person.class)
                 .result(() -> Stream.of(ada))
+                .methodSource(PersonRepository.class.getMethod("getPerson"))
                 .build();
 
         CompletionStage<Person> result =
                 (CompletionStage<Person>) repositoryReturn.convert(dynamic);
 
-        assertEquals(ada, result.toCompletableFuture().join());
+        assertSoftly(softly -> {
+            softly.assertThat(result)
+                    .as("repository result")
+                    .isNotNull();
+
+            softly.assertThat(result.toCompletableFuture().join())
+                    .as("completion stage value")
+                    .isEqualTo(ada);
+        });
     }
 
     @Test
+    @DisplayName("Should return paginated entity wrapped in CompletionStage")
     void shouldReturnCompletionStagePage() throws NoSuchMethodException {
         Person ada = new Person("Ada");
 
         DynamicReturn<Person> dynamic = DynamicReturn.builder()
                 .classSource(Person.class)
-                .methodSource(PersonRepository.class.getMethod("getPerson"))
-                .singleResult(() -> Optional.of(ada))
-                .result(() -> Stream.of(ada))
+                .singleResult(Optional::empty)
+                .result(Collections::emptyList)
                 .singleResultPagination(p -> Optional.of(ada))
                 .streamPagination(p -> Stream.of(ada))
+                .methodSource(PersonRepository.class.getMethod("getPerson"))
                 .pagination(PageRequest.ofPage(2).size(2))
                 .page(p -> page)
                 .build();
 
-        CompletionStage<?> result =
-                (CompletionStage<?>) repositoryReturn.convertPageRequest(dynamic);
+        CompletionStage<Person> result =
+                (CompletionStage<Person>)
+                        repositoryReturn.convertPageRequest(dynamic);
 
-        assertEquals(ada, result.toCompletableFuture().join());
+        assertSoftly(softly -> {
+            softly.assertThat(result)
+                    .as("repository page result")
+                    .isNotNull();
+
+            softly.assertThat(result.toCompletableFuture().join())
+                    .as("completion stage page value")
+                    .isEqualTo(ada);
+        });
     }
 
     private interface PersonRepository {

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
@@ -18,18 +18,18 @@ import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import org.eclipse.jnosql.mapping.core.repository.DynamicReturn;
 import org.eclipse.jnosql.mapping.core.repository.RepositoryReturn;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class CompletionStageRepositoryReturnTest {
@@ -42,20 +42,38 @@ class CompletionStageRepositoryReturnTest {
 
     @Test
     void shouldReturnIsCompatible() {
-        Assertions.assertTrue(
-                repositoryReturn.isCompatible(Person.class, CompletionStage.class));
-        assertFalse(repositoryReturn.isCompatible(Object.class, Person.class));
-        assertFalse(repositoryReturn.isCompatible(Person.class, Object.class));
+        assertTrue(repositoryReturn.isCompatible(
+                Person.class, CompletionStage.class));
+        assertFalse(repositoryReturn.isCompatible(
+                Object.class, Person.class));
+        assertFalse(repositoryReturn.isCompatible(
+                Person.class, Object.class));
     }
 
     @Test
     void shouldReturnCompletionStage() throws NoSuchMethodException {
-        Method method = PersonRepository.class.getMethod("getPerson");
         Person ada = new Person("Ada");
 
         DynamicReturn<Person> dynamic = DynamicReturn.builder()
                 .classSource(Person.class)
-                .methodSource(method)
+                .methodSource(PersonRepository.class.getMethod("getPerson"))
+                .singleResult(() -> Optional.of(ada))
+                .result(() -> Stream.of(ada))
+                .build();
+
+        CompletionStage<Person> result =
+                (CompletionStage<Person>) repositoryReturn.convert(dynamic);
+
+        assertEquals(ada, result.toCompletableFuture().join());
+    }
+
+    @Test
+    void shouldReturnCompletionStagePage() throws NoSuchMethodException {
+        Person ada = new Person("Ada");
+
+        DynamicReturn<Person> dynamic = DynamicReturn.builder()
+                .classSource(Person.class)
+                .methodSource(PersonRepository.class.getMethod("getPerson"))
                 .singleResult(() -> Optional.of(ada))
                 .result(() -> Stream.of(ada))
                 .singleResultPagination(p -> Optional.of(ada))
@@ -64,42 +82,10 @@ class CompletionStageRepositoryReturnTest {
                 .page(p -> page)
                 .build();
 
-        Object result = repositoryReturn.convert(dynamic);
+        CompletionStage<?> result =
+                (CompletionStage<?>) repositoryReturn.convertPageRequest(dynamic);
 
-        Assertions.assertInstanceOf(CompletionStage.class, result);
-
-        CompletionStage<?> stage = (CompletionStage<?>) result;
-
-        Assertions.assertEquals(
-                ada,
-                stage.toCompletableFuture().join());
-    }
-
-    @Test
-    void shouldReturnCompletionStagePage() throws NoSuchMethodException {
-        Method method = PersonRepository.class.getMethod("getPerson");
-        Person ada = new Person("Ada");
-
-        DynamicReturn<Person> dynamic = DynamicReturn.builder()
-                .classSource(Person.class)
-                .methodSource(method)
-                .singleResult(() -> Optional.of(ada))
-                .result(Stream::empty)
-                .singleResultPagination(p -> Optional.of(ada))
-                .streamPagination(p -> Stream.of(ada))
-                .pagination(PageRequest.ofPage(2).size(2))
-                .page(p -> page)
-                .build();
-
-        Object result = repositoryReturn.convertPageRequest(dynamic);
-
-        Assertions.assertInstanceOf(CompletionStage.class, result);
-
-        CompletionStage<?> stage = (CompletionStage<?>) result;
-
-        Assertions.assertEquals(
-                ada,
-                stage.toCompletableFuture().join());
+        assertEquals(ada, result.toCompletableFuture().join());
     }
 
     private interface PersonRepository {
@@ -107,36 +93,6 @@ class CompletionStageRepositoryReturnTest {
         CompletionStage<Person> getPerson();
     }
 
-    private static class Person {
-
-        private final String name;
-
-        Person(String name) {
-            this.name = name;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            Person person = (Person) o;
-            return java.util.Objects.equals(name, person.name);
-        }
-
-        @Override
-        public int hashCode() {
-            return java.util.Objects.hash(name);
-        }
-
-        @Override
-        public String toString() {
-            return "Person{" +
-                    "name='" + name + '\'' +
-                    '}';
-        }
+    private record Person(String name) {
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
 class CompletionStageRepositoryReturnTest {
@@ -43,22 +43,17 @@ class CompletionStageRepositoryReturnTest {
     @Test
     @DisplayName("Should return true when return type is CompletionStage")
     void shouldReturnIsCompatible() {
-        assertSoftly(softly -> {
-            softly.assertThat(repositoryReturn.isCompatible(
-                            Person.class, CompletionStage.class))
-                    .as("CompletionStage return type is compatible")
-                    .isTrue();
+        assertThat(repositoryReturn.isCompatible(
+                Person.class, CompletionStage.class))
+                .isTrue();
 
-            softly.assertThat(repositoryReturn.isCompatible(
-                            Object.class, Person.class))
-                    .as("different entity and return types are incompatible")
-                    .isFalse();
+        assertThat(repositoryReturn.isCompatible(
+                Object.class, Person.class))
+                .isFalse();
 
-            softly.assertThat(repositoryReturn.isCompatible(
-                            Person.class, Object.class))
-                    .as("different return type is incompatible")
-                    .isFalse();
-        });
+        assertThat(repositoryReturn.isCompatible(
+                Person.class, Object.class))
+                .isFalse();
     }
 
     @Test
@@ -76,15 +71,11 @@ class CompletionStageRepositoryReturnTest {
         CompletionStage<Person> result =
                 (CompletionStage<Person>) repositoryReturn.convert(dynamic);
 
-        assertSoftly(softly -> {
-            softly.assertThat(result)
-                    .as("repository result")
-                    .isNotNull();
+        assertThat(result)
+                .isNotNull();
 
-            softly.assertThat(result.toCompletableFuture().join())
-                    .as("completion stage value")
-                    .isEqualTo(ada);
-        });
+        assertThat(result.toCompletableFuture().join())
+                .isEqualTo(ada);
     }
 
     @Test
@@ -107,15 +98,11 @@ class CompletionStageRepositoryReturnTest {
                 (CompletionStage<Person>)
                         repositoryReturn.convertPageRequest(dynamic);
 
-        assertSoftly(softly -> {
-            softly.assertThat(result)
-                    .as("repository page result")
-                    .isNotNull();
+        assertThat(result)
+                .isNotNull();
 
-            softly.assertThat(result.toCompletableFuture().join())
-                    .as("completion stage page value")
-                    .isEqualTo(ada);
-        });
+        assertThat(result.toCompletableFuture().join())
+                .isEqualTo(ada);
     }
 
     private interface PersonRepository {

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
@@ -1,56 +1,105 @@
 /*
- *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
- *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
  *
- *   You may elect to redistribute this code under either of these licenses.
+ *   The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
  *
  *   Contributors:
  *
  *   Mohan Lal
+ *
  */
 package org.eclipse.jnosql.mapping.core.repository.returns;
 
+import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
 import org.eclipse.jnosql.mapping.core.repository.DynamicReturn;
 import org.eclipse.jnosql.mapping.core.repository.RepositoryReturn;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+@ExtendWith(MockitoExtension.class)
 class CompletionStageRepositoryReturnTest {
 
     private final RepositoryReturn repositoryReturn =
             new CompletionStageRepositoryReturn();
 
+    @Mock
+    private Page<Person> page;
+
     @Test
     void shouldReturnIsCompatible() {
-        assertTrue(repositoryReturn.isCompatible(
-                Person.class, CompletionStage.class));
+        Assertions.assertTrue(
+                repositoryReturn.isCompatible(Person.class, CompletionStage.class));
+        assertFalse(repositoryReturn.isCompatible(Object.class, Person.class));
+        assertFalse(repositoryReturn.isCompatible(Person.class, Object.class));
     }
 
     @Test
-    void shouldReturnCompletionStage() {
+    void shouldReturnCompletionStage() throws NoSuchMethodException {
+        Method method = PersonRepository.class.getMethod("getPerson");
         Person ada = new Person("Ada");
 
         DynamicReturn<Person> dynamic = DynamicReturn.builder()
-                .singleResult(() -> Optional.of(ada))
                 .classSource(Person.class)
+                .methodSource(method)
+                .singleResult(() -> Optional.of(ada))
                 .result(() -> Stream.of(ada))
-                .methodSource(PersonRepository.class.getDeclaredMethods()[0])
+                .singleResultPagination(p -> Optional.of(ada))
+                .streamPagination(p -> Stream.of(ada))
+                .pagination(PageRequest.ofPage(2).size(2))
+                .page(p -> page)
                 .build();
 
-        CompletionStage<Person> result =
-                (CompletionStage<Person>) repositoryReturn.convert(dynamic);
+        Object result = repositoryReturn.convert(dynamic);
 
-        assertEquals(ada, result.toCompletableFuture().join());
+        Assertions.assertInstanceOf(CompletionStage.class, result);
+
+        CompletionStage<?> stage = (CompletionStage<?>) result;
+
+        Assertions.assertEquals(
+                ada,
+                stage.toCompletableFuture().join());
+    }
+
+    @Test
+    void shouldReturnCompletionStagePage() throws NoSuchMethodException {
+        Method method = PersonRepository.class.getMethod("getPerson");
+        Person ada = new Person("Ada");
+
+        DynamicReturn<Person> dynamic = DynamicReturn.builder()
+                .classSource(Person.class)
+                .methodSource(method)
+                .singleResult(() -> Optional.of(ada))
+                .result(Stream::empty)
+                .singleResultPagination(p -> Optional.of(ada))
+                .streamPagination(p -> Stream.of(ada))
+                .pagination(PageRequest.ofPage(2).size(2))
+                .page(p -> page)
+                .build();
+
+        Object result = repositoryReturn.convertPageRequest(dynamic);
+
+        Assertions.assertInstanceOf(CompletionStage.class, result);
+
+        CompletionStage<?> stage = (CompletionStage<?>) result;
+
+        Assertions.assertEquals(
+                ada,
+                stage.toCompletableFuture().join());
     }
 
     private interface PersonRepository {
@@ -58,6 +107,36 @@ class CompletionStageRepositoryReturnTest {
         CompletionStage<Person> getPerson();
     }
 
-    private record Person(String name) {
+    private static class Person {
+
+        private final String name;
+
+        Person(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Person person = (Person) o;
+            return java.util.Objects.equals(name, person.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(name);
+        }
+
+        @Override
+        public String toString() {
+            return "Person{" +
+                    "name='" + name + '\'' +
+                    '}';
+        }
     }
 }

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/repository/returns/CompletionStageRepositoryReturnTest.java
@@ -79,6 +79,31 @@ class CompletionStageRepositoryReturnTest {
     }
 
     @Test
+    @DisplayName("Should return optional entity wrapped in CompletionStage")
+    void shouldReturnOptionalCompletionStage() throws NoSuchMethodException {
+        Person ada = new Person("Ada");
+
+        DynamicReturn<Person> dynamic = DynamicReturn.builder()
+                .singleResult(() -> Optional.of(ada))
+                .classSource(Person.class)
+                .result(() -> Stream.of(ada))
+                .methodSource(
+                        PersonRepository.class.getMethod("getOptionalPerson"))
+                .build();
+
+        CompletionStage<Optional<Person>> result =
+                (CompletionStage<Optional<Person>>)
+                        repositoryReturn.convert(dynamic);
+
+        assertThat(result)
+                .isNotNull();
+
+        assertThat(result.toCompletableFuture().join())
+                .isPresent()
+                .contains(ada);
+    }
+
+    @Test
     @DisplayName("Should return paginated entity wrapped in CompletionStage")
     void shouldReturnCompletionStagePage() throws NoSuchMethodException {
         Person ada = new Person("Ada");
@@ -108,6 +133,8 @@ class CompletionStageRepositoryReturnTest {
     private interface PersonRepository {
 
         CompletionStage<Person> getPerson();
+
+        CompletionStage<Optional<Person>> getOptionalPerson();
     }
 
     private record Person(String name) {


### PR DESCRIPTION
## Summary

Adds support for repository methods that declare `CompletionStage<T>` as their return type, including nested generic shapes:

* `CompletionStage<T>` (single entity)
* `CompletionStage<List<T>>`
* `CompletionStage<Optional<T>>`
* `CompletionStage<Page<T>>`
* and other types already supported by the existing `RepositoryReturn` implementations

## Design

* `DynamicReturnConverter`'s dispatch logic is extracted into a reusable `findRepositoryReturn(Class<?>, Class<?>)` method.
* A new `CompletionStageRepositoryReturn`, registered through the existing `RepositoryReturn` SPI in `META-INF/services`, matches methods returning `CompletionStage`.
* It unwraps the declared generic type argument and delegates to the existing `RepositoryReturn` implementation responsible for that inner type.
* This reuses the existing return-type conversion logic without duplicating support for `List`, `Optional`, `Page`, `Stream`, etc.
* Execution remains synchronous; the converted result is wrapped using `CompletableFuture.completedFuture(...)`. In other words, `CompletionStage` is treated as a return-type contract here, not as a mechanism for introducing asynchronous execution.

## Relation to #631

This work was prompted by the discussion on #631 and the suggestion to investigate the repository return handling under `jnosql-mapping-core/.../repository/returns`.

However, I want to be explicit that **this PR does not fix the `NoSQLException` / `ConstructorBuilder` crash originally reported in #631**.

The reported crash occurs with a plain synchronous repository method invoked from an asynchronous context. The repository method itself was **not** declared as returning `CompletionStage`.

The `CompletionStage` support implemented here is therefore a separate capability that came out of the #631 investigation. The actual fix for the reported `ConstructorBuilder` failure uses a **TCCL-first-with-fallback** strategy in `ConstructorBuilder` and is being submitted as a separate PR.

This separation keeps the scope of this PR focused and makes it possible to review and test the two changes independently.

## Testing

* Added `DynamicReturnConverterCompletionStageTest`
* Added `CompletionStageRepositoryReturnTest`
* Full `jnosql-mapping-core` test suite: **349/349 passing**
* No regressions in existing repository return handling

## Notes

The implementation intentionally delegates to the existing `RepositoryReturn` implementations rather than introducing separate conversion logic for each supported generic type. This keeps return-type conversion centralized and means that new `RepositoryReturn` implementations can automatically be reused for `CompletionStage` return types as well.
