### PR TITLE
Fix ConstructorBuilder ServiceLoader lookup to try TCCL first, fall back to defining class loader

### DIFF
--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilder.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *  Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   and Apache License v2.0 which accompanies this distribution.
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  */
 package org.eclipse.jnosql.mapping.metadata;
 
@@ -18,6 +19,7 @@ package org.eclipse.jnosql.mapping.metadata;
 import jakarta.nosql.NoSQLException;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.ServiceLoader;
 
 /**
@@ -30,10 +32,38 @@ import java.util.ServiceLoader;
  */
 public interface ConstructorBuilder {
 
-    ConstructorBuilderSupplier CONSTRUCTOR_BUILDER_SUPPLIER = ServiceLoader.load(ConstructorBuilderSupplier.class)
-            .findFirst()
-            .orElseThrow(() ->
-                    new NoSQLException("There is not implementation for the ConstructorBuilderSupplier"));
+    ConstructorBuilderSupplier CONSTRUCTOR_BUILDER_SUPPLIER = loadConstructorBuilderSupplier();
+
+    /**
+     * Loads the {@link ConstructorBuilderSupplier} service provider.
+     * <p>
+     * The thread context class loader (TCCL) is tried first, preserving the normal
+     * behavior expected by application servers, OSGi, and similar environments that
+     * manage the TCCL explicitly. If the TCCL cannot see the provider — for example,
+     * when this class is first initialized from a thread whose TCCL does not have
+     * visibility into the application's {@code META-INF/services} entries, such as a
+     * Vert.x event-loop thread in a reactive Quarkus application — the class loader
+     * that loaded {@link ConstructorBuilder} itself is used as a fallback.
+     *
+     * @return the resolved {@link ConstructorBuilderSupplier}
+     * @throws NoSQLException when no provider can be found via either class loader
+     */
+    private static ConstructorBuilderSupplier loadConstructorBuilderSupplier() {
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+
+        if (tccl != null) {
+            Optional<ConstructorBuilderSupplier> viaTccl =
+                    ServiceLoader.load(ConstructorBuilderSupplier.class, tccl).findFirst();
+            if (viaTccl.isPresent()) {
+                return viaTccl.get();
+            }
+        }
+
+        return ServiceLoader.load(ConstructorBuilderSupplier.class, ConstructorBuilder.class.getClassLoader())
+                .findFirst()
+                .orElseThrow(() ->
+                        new NoSQLException("There is not implementation for the ConstructorBuilderSupplier"));
+    }
 
     /**
      * Returns the constructor parameters.

--- a/jnosql-mapping/jnosql-mapping-api-core/src/test/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilderTcclFallbackTest.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/test/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilderTcclFallbackTest.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Mohan Lal
+ */
+package org.eclipse.jnosql.mapping.metadata;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Regression test for the TCCL-first-with-fallback ServiceLoader lookup in
+ * {@link ConstructorBuilder}.
+ * <p>
+ * IMPORTANT: {@code CONSTRUCTOR_BUILDER_SUPPLIER} is a field on an interface, and is
+ * therefore initialized exactly once per JVM, the first time {@link ConstructorBuilder}
+ * is loaded. Because of this, this test class MUST be run in isolation — as the only
+ * test in its Surefire fork — so that the TCCL swap below happens before any other
+ * code has triggered class initialization. Running it alongside other tests that touch
+ * {@link ConstructorBuilder} first will make this test pass regardless of whether the
+ * fallback logic actually works, since the static field will already be populated.
+ *
+ * <pre>
+ * mvn -pl jnosql-mapping/jnosql-mapping-api-core \
+ *     -Dtest=ConstructorBuilderTcclFallbackTest test
+ * </pre>
+ */
+class ConstructorBuilderTcclFallbackTest {
+
+    @Test
+    void shouldFallBackToDefiningClassLoaderWhenTcclCannotSeeProvider() {
+        ClassLoader original = Thread.currentThread().getContextClassLoader();
+
+        try {
+            ClassLoader isolated = new ClassLoader(null) {
+            };
+            Thread.currentThread().setContextClassLoader(isolated);
+
+            ConstructorMetadata metadata = mock(ConstructorMetadata.class);
+
+            // First-ever touch of ConstructorBuilder in this JVM fork.
+            // The TCCL cannot see the provider, so this must fall back
+            // to ConstructorBuilder.class.getClassLoader() to succeed.
+            ConstructorBuilder builder = ConstructorBuilder.of(metadata);
+
+            assertThat(builder).isNotNull();
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-api-core/src/test/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilderTcclFallbackTest.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/test/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilderTcclFallbackTest.java
@@ -14,9 +14,9 @@
  */
 package org.eclipse.jnosql.mapping.metadata;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -40,25 +40,33 @@ import static org.mockito.Mockito.mock;
  */
 class ConstructorBuilderTcclFallbackTest {
 
-    @Test
-    void shouldFallBackToDefiningClassLoaderWhenTcclCannotSeeProvider() {
-        ClassLoader original = Thread.currentThread().getContextClassLoader();
+    @Nested
+    @DisplayName("When loading the ConstructorBuilder supplier")
+    class WhenTheConstructorBuilderSupplierIsLoaded {
 
-        try {
+        @Test
+        @DisplayName("Should fall back to the defining class loader when the TCCL cannot find the provider")
+        void shouldFallBackToDefiningClassLoaderWhenTcclCannotFindProvider() {
+            // Given
+            ClassLoader original = Thread.currentThread().getContextClassLoader();
             ClassLoader isolated = new ClassLoader(null) {
             };
-            Thread.currentThread().setContextClassLoader(isolated);
-
             ConstructorMetadata metadata = mock(ConstructorMetadata.class);
 
-            // First-ever touch of ConstructorBuilder in this JVM fork.
-            // The TCCL cannot see the provider, so this must fall back
-            // to ConstructorBuilder.class.getClassLoader() to succeed.
-            ConstructorBuilder builder = ConstructorBuilder.of(metadata);
+            try {
+                Thread.currentThread().setContextClassLoader(isolated);
 
-            assertThat(builder).isNotNull();
-        } finally {
-            Thread.currentThread().setContextClassLoader(original);
+                // When
+                // First-ever touch of ConstructorBuilder in this JVM fork.
+                // The TCCL cannot see the provider, so this must fall back
+                // to ConstructorBuilder.class.getClassLoader() to succeed.
+                ConstructorBuilder builder = ConstructorBuilder.of(metadata);
+
+                // Then
+                assertThat(builder).isNotNull();
+            } finally {
+                Thread.currentThread().setContextClassLoader(original);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes #631.

## Summary

`ConstructorBuilder` previously resolved its `ConstructorBuilderSupplier` provider using `ServiceLoader.load(ConstructorBuilderSupplier.class)`, which uses the thread context class loader (TCCL) for provider discovery.

Because this resolution happens once, when the static `CONSTRUCTOR_BUILDER_SUPPLIER` field is initialized, whichever thread first triggers `ConstructorBuilder` initialization determines the result for the lifetime of that JVM.

If that first thread happens to be a Vert.x event-loop thread whose TCCL cannot see the provider — as can occur in reactive Quarkus applications — the lookup fails and `ConstructorBuilder` becomes permanently unusable for that JVM, producing:

```text
jakarta.nosql.NoSQLException: There is not implementation for the ConstructorBuilderSupplier
```

This explains the intermittent nature of the original report: the failure depends on which thread happens to initialize `ConstructorBuilder` first, rather than on any particular repository call.

## Design

Incorporating feedback from **@OndroMih** on the earlier #747 attempt, a hardcoded switch to `ConstructorBuilder.class.getClassLoader()` would bypass the normal TCCL behavior expected by application servers, OSGi, Quarkus, and similar environments.

The implementation therefore uses a **TCCL-first with fallback** strategy:

* The TCCL is tried first, preserving the normal behavior expected in environments that manage the TCCL explicitly.
* Only when the TCCL cannot discover the provider does the lookup fall back to `ConstructorBuilder.class.getClassLoader()`.

This preserves existing behavior for normal class-loader configurations while addressing the specific class-loader failure reported in #631.

## Testing

The fix was validated at multiple levels.

Isolated JVM forks are used for the class-loader tests because `CONSTRUCTOR_BUILDER_SUPPLIER` is cached on first use. Without process isolation, an earlier test can initialize the static field successfully and cause a later test to incorrectly appear to pass.

* Isolated TCCL + unfixed code → throws `NoSQLException`, confirming the original failure mechanism.
* Isolated TCCL + fixed code → succeeds through the defining-class-loader fallback.
* Normal TCCL + fixed code → existing `ConstructorBuilderTest` passes unmodified, confirming that normal TCCL behavior is unchanged.
* Full `jnosql-mapping-api-core` suite: **62/62 passing**.
* A separate, independent Quarkus reproducer project consuming this fix as a real installed artifact passes both:

  * a direct `ServiceLoader` isolation test, and
  * a genuine Vert.x event-loop test reproducing the original failure environment.

## Relation to #746 / #747

This PR replaces the earlier #747 attempt, which was closed.

The earlier closure was based on a flawed reproducer that inadvertently tested an already-initialized static field rather than a fresh first initialization. As a result, the previous conclusion that the change did not reproduce the original #631 failure did not hold up under a properly isolated test.

The fresh-JVM tests in this PR reproduce the failure with the unfixed implementation and demonstrate that the TCCL-first-with-fallback implementation resolves it.

See the discussion on #631 for the full investigation history.

## Relation to #764

This PR is independent of **#764 — Add CompletionStage repository return support**.

The `CompletionStage` support in #764 was identified during the investigation of #631 and adds support for repository methods returning `CompletionStage<T>`. It does **not** resolve the `ConstructorBuilderSupplier` lookup failure described here, because the original reported repository method was synchronous and the failure occurs during `ConstructorBuilder` initialization.

Keeping the two changes separate allows each change to be reviewed and tested independently.
