### PR TITLE
Feature/cdi repository interception

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 === Added
 
+- Add CDI interceptor support to semistructured and key-value repositories
 - Add support for scalar function expressions (UPPER, LOWER, LEFT, RIGHT, LENGTH, ABS) in JDQL string queries
 - Include support to Restriction interface
 - Include support to record projector

--- a/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/query/KeyValueRepositoryProducer.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/query/KeyValueRepositoryProducer.java
@@ -17,6 +17,9 @@ package org.eclipse.jnosql.mapping.keyvalue.query;
 
 import jakarta.data.repository.BasicRepository;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InterceptionFactory;
 import jakarta.inject.Inject;
 import org.eclipse.jnosql.communication.keyvalue.BucketManager;
 import org.eclipse.jnosql.mapping.core.repository.CoreRepositoryInvocationHandler;
@@ -32,29 +35,44 @@ import org.eclipse.jnosql.mapping.repository.LifecycleEventHandler;
 import java.lang.reflect.Proxy;
 import java.util.Objects;
 
-@ApplicationScoped
 /**
- * CDI producer for key-value repository proxies.
+ * CDI producer for key-value repository proxies. The resulting JNoSQL proxy is
+ * wrapped by CDI so repository interceptor bindings can be applied.
  */
+@ApplicationScoped
 public class KeyValueRepositoryProducer {
 
-    @Inject
-    private KeyValueTemplateProducer producer;
-    @Inject
-    private EntitiesMetadata entities;
-    @Inject
-    private InfrastructureOperatorProvider infrastructureOperatorProvider;
+    private final KeyValueTemplateProducer producer;
+    private final EntitiesMetadata entities;
+    private final InfrastructureOperatorProvider infrastructureOperatorProvider;
+
+    private final CoreBaseRepositoryOperationProvider repositoryOperationProvider;
+
+    private final RepositoriesMetadata repositoriesMetadata;
+
+    private final LifecycleEventHandler lifecycleEventHandler;
+
+    private final BeanManager beanManager;
 
     @Inject
-    private CoreBaseRepositoryOperationProvider repositoryOperationProvider;
-
-    @Inject
-    private RepositoriesMetadata repositoriesMetadata;
-
-    @Inject
-    private LifecycleEventHandler lifecycleEventHandler;
+    KeyValueRepositoryProducer(KeyValueTemplateProducer producer,
+                               EntitiesMetadata entities,
+                               InfrastructureOperatorProvider infrastructureOperatorProvider,
+                               CoreBaseRepositoryOperationProvider repositoryOperationProvider,
+                               RepositoriesMetadata repositoriesMetadata,
+                               LifecycleEventHandler lifecycleEventHandler,
+                               BeanManager beanManager) {
+        this.producer = producer;
+        this.entities = entities;
+        this.infrastructureOperatorProvider = infrastructureOperatorProvider;
+        this.repositoryOperationProvider = repositoryOperationProvider;
+        this.repositoriesMetadata = repositoriesMetadata;
+        this.lifecycleEventHandler = lifecycleEventHandler;
+        this.beanManager = beanManager;
+    }
 
     KeyValueRepositoryProducer() {
+        this(null, null, null, null, null, null, null);
     }
 
     /**
@@ -82,10 +100,26 @@ public class KeyValueRepositoryProducer {
      * @param <R> the repository type
      * @return the repository proxy
      */
-    @SuppressWarnings("unchecked")
     public <R extends BasicRepository<?, ?>> R get(Class<R> repositoryClass, KeyValueTemplate template) {
         Objects.requireNonNull(repositoryClass, "repository class is required");
         Objects.requireNonNull(template, "template class is required");
+        return get(repositoryClass, template, beanManager.createCreationalContext(null));
+    }
+
+    /**
+     * Creates a CDI-intercepted key-value repository backed by a template.
+     *
+     * @param repositoryClass the repository class
+     * @param template the key-value template
+     * @param creationalContext the repository bean creational context
+     * @param <R> the repository type
+     * @return the intercepted repository proxy
+     */
+    public <R extends BasicRepository<?, ?>> R get(Class<R> repositoryClass, KeyValueTemplate template,
+                                                   CreationalContext<R> creationalContext) {
+        Objects.requireNonNull(repositoryClass, "repository class is required");
+        Objects.requireNonNull(template, "template class is required");
+        Objects.requireNonNull(creationalContext, "creational context is required");
         RepositoryMetadata repositoryMetadata = repositoriesMetadata.get(repositoryClass).orElseThrow();
         var entityMetadata = entities.get(repositoryMetadata.entity().orElseThrow());
         DefaultKeyValueRepository<?, ?> executor = DefaultKeyValueRepository.of(template, entityMetadata, lifecycleEventHandler);
@@ -95,8 +129,11 @@ public class KeyValueRepositoryProducer {
                 infrastructureOperatorProvider,
                 repositoryOperationProvider,
                 template);
-        return (R) Proxy.newProxyInstance(repositoryClass.getClassLoader(),
-                new Class[]{repositoryClass},
-                repositoryHandler);
+        R repositoryProxy = repositoryClass.cast(Proxy.newProxyInstance(repositoryClass.getClassLoader(),
+                new Class<?>[]{repositoryClass},
+                repositoryHandler));
+        InterceptionFactory<R> interceptionFactory =
+                beanManager.createInterceptionFactory(creationalContext, repositoryClass);
+        return interceptionFactory.createInterceptedInstance(repositoryProxy);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/query/RepositoryKeyValueBean.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/main/java/org/eclipse/jnosql/mapping/keyvalue/query/RepositoryKeyValueBean.java
@@ -14,7 +14,6 @@
  */
 package org.eclipse.jnosql.mapping.keyvalue.query;
 
-import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.CrudRepository;
 import jakarta.enterprise.context.spi.CreationalContext;
 import org.eclipse.jnosql.mapping.DatabaseQualifier;
@@ -69,15 +68,15 @@ public class RepositoryKeyValueBean<T extends CrudRepository<?,?>> extends Abstr
     }
 
 
-    @SuppressWarnings("unchecked")
     @Override
+    @SuppressWarnings("unchecked")
     public T create(CreationalContext<T> creationalContext) {
         KeyValueTemplate template = provider.isEmpty() ? getInstance(KeyValueTemplate.class) :
                 getInstance(KeyValueTemplate.class, DatabaseQualifier.ofKeyValue(provider));
 
         var keyValueRepositoryProducer = getInstance(KeyValueRepositoryProducer.class);
-        Class<?  extends BasicRepository<?, ?>> repositoryClass = (Class<? extends BasicRepository<?, ?>>) type;
-        return (T) keyValueRepositoryProducer.get(repositoryClass, template);
+        Class<T> repositoryClass = (Class<T>) type;
+        return keyValueRepositoryProducer.get(repositoryClass, template, creationalContext);
     }
 
 

--- a/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/query/KeyValueRepositoryProducerTest.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/query/KeyValueRepositoryProducerTest.java
@@ -14,56 +14,137 @@
  */
 package org.eclipse.jnosql.mapping.keyvalue.query;
 
-import jakarta.inject.Inject;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InterceptionFactory;
 import org.eclipse.jnosql.communication.keyvalue.BucketManager;
-import org.eclipse.jnosql.mapping.core.Converters;
-import org.eclipse.jnosql.mapping.keyvalue.KeyValueEntityConverter;
+import org.eclipse.jnosql.mapping.core.repository.CoreRepositoryInvocationHandler;
+import org.eclipse.jnosql.mapping.core.repository.InfrastructureOperatorProvider;
+import org.eclipse.jnosql.mapping.core.repository.operations.CoreBaseRepositoryOperationProvider;
 import org.eclipse.jnosql.mapping.keyvalue.KeyValueTemplate;
-import org.eclipse.jnosql.mapping.keyvalue.MockProducer;
+import org.eclipse.jnosql.mapping.keyvalue.KeyValueTemplateProducer;
+import org.eclipse.jnosql.mapping.keyvalue.entities.Person;
 import org.eclipse.jnosql.mapping.keyvalue.entities.PersonRepository;
-import org.eclipse.jnosql.mapping.keyvalue.spi.KeyValueExtension;
-import org.eclipse.jnosql.mapping.reflection.Reflections;
-import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
-import org.jboss.weld.junit5.auto.AddExtensions;
-import org.jboss.weld.junit5.auto.AddPackages;
-import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoriesMetadata;
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoryMetadata;
+import org.eclipse.jnosql.mapping.repository.LifecycleEventHandler;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@EnableAutoWeld
-@AddPackages(value = {Converters.class, KeyValueEntityConverter.class})
-@AddPackages(MockProducer.class)
-@AddPackages(Reflections.class)
-@AddExtensions({ReflectionEntityMetadataExtension.class, KeyValueExtension.class})
+@DisplayName("KeyValueRepositoryProducer")
 class KeyValueRepositoryProducerTest {
 
-    @Inject
+    private final KeyValueTemplateProducer templateProducer = mock(KeyValueTemplateProducer.class);
+    private final EntitiesMetadata entities = mock(EntitiesMetadata.class);
+    private final InfrastructureOperatorProvider infrastructureOperatorProvider =
+            mock(InfrastructureOperatorProvider.class);
+    private final CoreBaseRepositoryOperationProvider operationProvider =
+            mock(CoreBaseRepositoryOperationProvider.class);
+    private final RepositoriesMetadata repositoriesMetadata = mock(RepositoriesMetadata.class);
+    private final LifecycleEventHandler lifecycleEventHandler = mock(LifecycleEventHandler.class);
+    private final BeanManager beanManager = mock(BeanManager.class);
+    private final KeyValueTemplate template = mock(KeyValueTemplate.class);
+    private final RepositoryMetadata repositoryMetadata = mock(RepositoryMetadata.class);
+    private final EntityMetadata entityMetadata = mock(EntityMetadata.class);
+    private final CreationalContext<PersonRepository> creationalContext = mock(CreationalContext.class);
+    private final InterceptionFactory<PersonRepository> interceptionFactory = mock(InterceptionFactory.class);
+
     private KeyValueRepositoryProducer producer;
 
-    @Nested
-    @DisplayName("When the producer creates repositories")
-    class WhenTheProducerCreatesRepositories {
-
-        @Test
-        @DisplayName("Should create from manager")
-        void shouldCreateFromManager() {
-            BucketManager manager = Mockito.mock(BucketManager.class);
-            PersonRepository personRepository = producer.get(PersonRepository.class, manager);
-            assertThat(personRepository).isNotNull();
-        }
-
-        @Test
-        @DisplayName("Should create from template")
-        void shouldCreateFromTemplate() {
-            KeyValueTemplate template = Mockito.mock(KeyValueTemplate.class);
-            PersonRepository personRepository = producer.get(PersonRepository.class, template);
-            assertThat(personRepository).isNotNull();
-        }
-
+    @BeforeEach
+    void setUp() {
+        producer = new KeyValueRepositoryProducer(templateProducer,
+                entities,
+                infrastructureOperatorProvider,
+                operationProvider,
+                repositoriesMetadata,
+                lifecycleEventHandler,
+                beanManager);
     }
 
+    @Nested
+    @DisplayName("When validating repository creation")
+    class WhenTheValidation {
+
+        @Test
+        @DisplayName("Should reject a null repository class")
+        void shouldRejectNullRepositoryClass() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> producer.get(null, template));
+        }
+
+        @Test
+        @DisplayName("Should reject a null template")
+        void shouldRejectNullTemplate() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> producer.get(PersonRepository.class, (KeyValueTemplate) null));
+        }
+
+        @Test
+        @DisplayName("Should reject a null manager")
+        void shouldRejectNullManager() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> producer.get(PersonRepository.class, (BucketManager) null));
+        }
+    }
+
+    @Nested
+    @DisplayName("When creating a repository")
+    class WhenTheCreation {
+
+        @BeforeEach
+        void setUpMetadata() {
+            when(repositoriesMetadata.get(PersonRepository.class)).thenReturn(Optional.of(repositoryMetadata));
+            when(repositoryMetadata.entity()).thenReturn(Optional.of(Person.class));
+            when(entities.get(Person.class)).thenReturn(entityMetadata);
+            doReturn(interceptionFactory).when(beanManager)
+                    .createInterceptionFactory(creationalContext, PersonRepository.class);
+        }
+
+        @Test
+        @DisplayName("Should return the CDI-intercepted repository")
+        void shouldReturnInterceptedRepository() {
+            PersonRepository expected = mock(PersonRepository.class);
+            when(interceptionFactory.createInterceptedInstance(any())).thenReturn(expected);
+
+            PersonRepository result = producer.get(PersonRepository.class, template, creationalContext);
+
+            ArgumentCaptor<PersonRepository> repositoryCaptor = ArgumentCaptor.forClass(PersonRepository.class);
+            verify(interceptionFactory).createInterceptedInstance(repositoryCaptor.capture());
+            assertThat(Proxy.getInvocationHandler(repositoryCaptor.getValue()))
+                    .isInstanceOf(CoreRepositoryInvocationHandler.class);
+            assertThat(result).isSameAs(expected);
+        }
+
+        @Test
+        @DisplayName("Should create the template from the manager")
+        void shouldCreateTemplateFromManager() {
+            BucketManager manager = mock(BucketManager.class);
+            PersonRepository expected = mock(PersonRepository.class);
+            when(templateProducer.apply(manager)).thenReturn(template);
+            doReturn(creationalContext).when(beanManager).createCreationalContext(null);
+            when(interceptionFactory.createInterceptedInstance(any())).thenReturn(expected);
+
+            PersonRepository result = producer.get(PersonRepository.class, manager);
+
+            verify(templateProducer).apply(manager);
+            assertThat(result).isSameAs(expected);
+        }
+    }
 }

--- a/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/query/KeyValueRepositoryProducerWeldTest.java
+++ b/jnosql-mapping/jnosql-mapping-key-value/src/test/java/org/eclipse/jnosql/mapping/keyvalue/query/KeyValueRepositoryProducerWeldTest.java
@@ -1,0 +1,224 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.keyvalue.query;
+
+import jakarta.annotation.Priority;
+import jakarta.data.repository.CrudRepository;
+import jakarta.data.repository.Repository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.keyvalue.KeyValueEntityConverter;
+import org.eclipse.jnosql.mapping.keyvalue.MockProducer;
+import org.eclipse.jnosql.mapping.keyvalue.entities.Person;
+import org.eclipse.jnosql.mapping.keyvalue.spi.KeyValueExtension;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, KeyValueEntityConverter.class})
+@AddPackages(MockProducer.class)
+@AddPackages(Reflections.class)
+@AddExtensions({ReflectionEntityMetadataExtension.class, KeyValueExtension.class})
+@AddBeanClasses({
+        KeyValueRepositoryProducerWeldTest.InvocationCounter.class,
+        KeyValueRepositoryProducerWeldTest.RepositoryInterceptor.class,
+        KeyValueRepositoryProducerWeldTest.MethodInterceptor.class
+})
+@DisplayName("KeyValueRepositoryProducer with Weld")
+public class KeyValueRepositoryProducerWeldTest {
+
+    private static final long ID = 10L;
+
+    @Inject
+    private WeldRepository repository;
+
+    @Inject
+    private InvocationCounter invocationCounter;
+
+    @BeforeEach
+    void setUp() {
+        invocationCounter.reset();
+    }
+
+    @Nested
+    @DisplayName("When invoking an injected repository")
+    class WhenTheRepositoryInvocation {
+
+        @Test
+        @DisplayName("Should apply the repository interceptor")
+        void shouldApplyRepositoryInterceptor() {
+            Optional<Person> result = repository.repositoryFindById(ID);
+
+            assertSoftly(softly -> {
+                softly.assertThat(result).as("repository result").isPresent();
+                softly.assertThat(invocationCounter.repositoryInvocations())
+                        .as("repository interceptor invocations")
+                        .isEqualTo(1);
+            });
+        }
+
+        @Test
+        @DisplayName("Should apply the method interceptor")
+        void shouldApplyMethodInterceptor() {
+            Optional<Person> result = repository.interceptedFindById(ID);
+
+            assertSoftly(softly -> {
+                softly.assertThat(result).as("repository result").isPresent();
+                softly.assertThat(invocationCounter.methodInvocations())
+                        .as("method interceptor invocations")
+                        .isEqualTo(1);
+            });
+        }
+
+        @Test
+        @DisplayName("Should apply both repository and method interceptors")
+        void shouldApplyBothInterceptors() {
+            repository.interceptedFindById(ID);
+
+            assertSoftly(softly -> {
+                softly.assertThat(invocationCounter.repositoryInvocations())
+                        .as("repository interceptor invocations")
+                        .isEqualTo(1);
+                softly.assertThat(invocationCounter.methodInvocations())
+                        .as("method interceptor invocations")
+                        .isEqualTo(1);
+            });
+        }
+
+        @Test
+        @DisplayName("Should not apply the method interceptor without its binding")
+        void shouldNotApplyMethodInterceptorWithoutBinding() {
+            repository.repositoryFindById(ID);
+
+            assertSoftly(softly -> {
+                softly.assertThat(invocationCounter.repositoryInvocations())
+                        .as("repository interceptor invocations")
+                        .isEqualTo(1);
+                softly.assertThat(invocationCounter.methodInvocations())
+                        .as("method interceptor invocations")
+                        .isZero();
+            });
+        }
+    }
+
+    @Repository
+    @RepositoryIntercepted
+    public interface WeldRepository extends CrudRepository<Person, Long> {
+
+        default Optional<Person> repositoryFindById(Long id) {
+            return findById(id);
+        }
+
+        @MethodIntercepted
+        default Optional<Person> interceptedFindById(Long id) {
+            return findById(id);
+        }
+    }
+
+    @Inherited
+    @InterceptorBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @interface RepositoryIntercepted {
+    }
+
+    @InterceptorBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @interface MethodIntercepted {
+    }
+
+    @RepositoryIntercepted
+    @Interceptor
+    @Priority(Interceptor.Priority.APPLICATION)
+    static class RepositoryInterceptor {
+
+        @Inject
+        private InvocationCounter counter;
+
+        @AroundInvoke
+        Object intercept(InvocationContext context) throws Exception {
+            counter.incrementRepository();
+            return context.proceed();
+        }
+    }
+
+    @MethodIntercepted
+    @Interceptor
+    @Priority(Interceptor.Priority.APPLICATION + 1)
+    static class MethodInterceptor {
+
+        @Inject
+        private InvocationCounter counter;
+
+        @AroundInvoke
+        Object intercept(InvocationContext context) throws Exception {
+            counter.incrementMethod();
+            return context.proceed();
+        }
+    }
+
+    @ApplicationScoped
+    static class InvocationCounter {
+
+        private final AtomicInteger repositoryCounter = new AtomicInteger();
+        private final AtomicInteger methodCounter = new AtomicInteger();
+
+        void incrementRepository() {
+            repositoryCounter.incrementAndGet();
+        }
+
+        void incrementMethod() {
+            methodCounter.incrementAndGet();
+        }
+
+        int repositoryInvocations() {
+            return repositoryCounter.get();
+        }
+
+        int methodInvocations() {
+            return methodCounter.get();
+        }
+
+        void reset() {
+            repositoryCounter.set(0);
+            methodCounter.set(0);
+        }
+    }
+
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseRepositoryBean.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseRepositoryBean.java
@@ -94,7 +94,7 @@ abstract class BaseRepositoryBean<T> extends AbstractBean<T> {
                 ? getInstance(getTemplateClass())
                 : getInstance(getTemplateClass(), getDatabaseQualifier(provider));
 
-        return producer.get(type, template);
+        return producer.get(type, template, context);
     }
 
     @Override
@@ -112,4 +112,3 @@ abstract class BaseRepositoryBean<T> extends AbstractBean<T> {
         return type.getName() + '@' + databaseType + "-" + provider;
     }
 }
-

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducer.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducer.java
@@ -66,7 +66,7 @@ public class SemistructuredRepositoryProducer {
         this.beanManager = beanManager;
     }
 
-    public SemistructuredRepositoryProducer() {
+    SemistructuredRepositoryProducer() {
         this(null, null, null, null, null, null);
     }
 

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducer.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducer.java
@@ -16,6 +16,9 @@ package org.eclipse.jnosql.mapping.semistructured.repository;
 
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InterceptionFactory;
 import jakarta.inject.Inject;
 import org.eclipse.jnosql.mapping.core.repository.CoreRepositoryInvocationHandler;
 import org.eclipse.jnosql.mapping.core.repository.InfrastructureOperatorProvider;
@@ -29,25 +32,43 @@ import java.lang.reflect.Proxy;
 import java.util.Objects;
 
 /**
- * CDI producer responsible for creating runtime implementations of semistructured Jakarta Data repositories.
+ * CDI producer responsible for resolving repository metadata and creating runtime
+ * implementations of semistructured Jakarta Data repositories. The resulting JNoSQL
+ * repository proxy is wrapped by CDI so that repository interceptor bindings are applied.
  */
 @ApplicationScoped
 public class SemistructuredRepositoryProducer {
 
-    @Inject
-    private EntitiesMetadata entities;
+    private final EntitiesMetadata entities;
+
+    private final InfrastructureOperatorProvider infrastructureOperatorProvider;
+
+    private final SemistructuredRepositoryOperationProvider semistructuredRepositoryOperationProvider;
+
+    private final RepositoriesMetadata repositoriesMetadata;
+
+    private final LifecycleEventHandler lifecycleEventHandler;
+
+    private final BeanManager beanManager;
 
     @Inject
-    private InfrastructureOperatorProvider infrastructureOperatorProvider;
+    SemistructuredRepositoryProducer(EntitiesMetadata entities,
+                                     InfrastructureOperatorProvider infrastructureOperatorProvider,
+                                     SemistructuredRepositoryOperationProvider semistructuredRepositoryOperationProvider,
+                                     RepositoriesMetadata repositoriesMetadata,
+                                     LifecycleEventHandler lifecycleEventHandler,
+                                     BeanManager beanManager) {
+        this.entities = entities;
+        this.infrastructureOperatorProvider = infrastructureOperatorProvider;
+        this.semistructuredRepositoryOperationProvider = semistructuredRepositoryOperationProvider;
+        this.repositoriesMetadata = repositoriesMetadata;
+        this.lifecycleEventHandler = lifecycleEventHandler;
+        this.beanManager = beanManager;
+    }
 
-    @Inject
-    private SemistructuredRepositoryOperationProvider semistructuredRepositoryOperationProvider;
-
-    @Inject
-    private RepositoriesMetadata repositoriesMetadata;
-
-    @Inject
-    private LifecycleEventHandler lifecycleEventHandler;
+    public SemistructuredRepositoryProducer() {
+        this(null, null, null, null, null, null);
+    }
 
     /**
      * Returns a fully functional repository implementation for the given
@@ -61,10 +82,30 @@ public class SemistructuredRepositoryProducer {
      * @throws java.util.NoSuchElementException if required repository or entity
      *         metadata cannot be resolved
      */
-    @SuppressWarnings("unchecked")
-    public <R> R get(Class<?> repositoryClass, SemiStructuredTemplate template) {
+    public <R> R get(Class<R> repositoryClass, SemiStructuredTemplate template) {
         Objects.requireNonNull(repositoryClass, "repository class is required");
         Objects.requireNonNull(template, "template class is required");
+        return get(repositoryClass, template, beanManager.createCreationalContext(null));
+    }
+
+    /**
+     * Returns a fully functional CDI-intercepted repository implementation using
+     * the repository bean's creational context.
+     *
+     * @param repositoryClass the repository interface to implement
+     * @param template the semistructured template used by the repository
+     * @param creationalContext the repository bean creational context
+     * @param <R> the repository type
+     * @return an intercepted instance implementing the repository interface
+     * @throws NullPointerException if any argument is {@code null}
+     * @throws java.util.NoSuchElementException if required repository or entity
+     *         metadata cannot be resolved
+     */
+    public <R> R get(Class<R> repositoryClass, SemiStructuredTemplate template,
+                     CreationalContext<R> creationalContext) {
+        Objects.requireNonNull(repositoryClass, "repository class is required");
+        Objects.requireNonNull(template, "template class is required");
+        Objects.requireNonNull(creationalContext, "creational context is required");
         RepositoryMetadata repositoryMetadata = repositoriesMetadata.get(repositoryClass).orElseThrow();
         var entityMetadata = entities.get(repositoryMetadata.entity().orElseThrow());
 
@@ -77,9 +118,12 @@ public class SemistructuredRepositoryProducer {
                 semistructuredRepositoryOperationProvider,
                 template);
 
-        return (R) Proxy.newProxyInstance(repositoryClass.getClassLoader(),
-                new Class[]{repositoryClass},
-                repositoryHandler);
+        R repositoryProxy = repositoryClass.cast(Proxy.newProxyInstance(repositoryClass.getClassLoader(),
+                new Class<?>[]{repositoryClass},
+                repositoryHandler));
+        InterceptionFactory<R> interceptionFactory =
+                beanManager.createInterceptionFactory(creationalContext, repositoryClass);
+        return interceptionFactory.createInterceptedInstance(repositoryProxy);
     }
 
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/BaseRepositoryBeanTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/BaseRepositoryBeanTest.java
@@ -61,7 +61,8 @@ class BaseRepositoryBeanTest {
         CreationalContext<MockRepository> context = mock(CreationalContext.class);
         BaseRepositoryBean<MockRepository> spyBean = spy(repositoryBean);
         SemistructuredRepositoryProducer producer = mock(SemistructuredRepositoryProducer.class);
-        Mockito.when(producer.get(eq(MockRepository.class), Mockito.any())).thenReturn(Mockito.mock(MockRepository.class));
+        Mockito.when(producer.get(eq(MockRepository.class), Mockito.any(), eq(context)))
+                .thenReturn(Mockito.mock(MockRepository.class));
 
         doReturn(mock(SemiStructuredTemplate.class)).when(spyBean).getInstance(eq(SemiStructuredTemplate.class), any());
         doReturn(mock(EntitiesMetadata.class)).when(spyBean).getInstance(EntitiesMetadata.class);

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryBeanTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/query/CustomRepositoryBeanTest.java
@@ -101,8 +101,8 @@ class CustomRepositoryBeanTest {
 
         SemiStructuredTemplate mockTemplate = mock(SemiStructuredTemplate.class);
         SemistructuredRepositoryProducer producer = mock(SemistructuredRepositoryProducer.class);
-        Mockito.when(producer.get(eq(BaseRepositoryBeanTest.MockRepository.class), Mockito.any()))
-                .thenReturn(Mockito.mock(BaseRepositoryBeanTest.MockRepository.class));
+        Mockito.when(producer.get(eq(MockRepository.class), Mockito.any(), eq(context)))
+                .thenReturn(Mockito.mock(MockRepository.class));
 
         doReturn(producer).when(repositoryBean).getInstance(eq(SemistructuredRepositoryProducer.class), any());
         doReturn(producer).when(repositoryBean).getInstance(eq(SemistructuredRepositoryProducer.class));

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerTest.java
@@ -14,91 +14,121 @@
  */
 package org.eclipse.jnosql.mapping.semistructured.repository;
 
-import jakarta.inject.Inject;
-import org.assertj.core.api.Assertions;
-import org.eclipse.jnosql.mapping.core.Converters;
-import org.eclipse.jnosql.mapping.reflection.Reflections;
-import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
-import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
-import org.eclipse.jnosql.mapping.semistructured.MockProducer;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.InterceptionFactory;
+import org.eclipse.jnosql.mapping.core.repository.CoreRepositoryInvocationHandler;
+import org.eclipse.jnosql.mapping.core.repository.InfrastructureOperatorProvider;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.metadata.EntityMetadata;
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoriesMetadata;
+import org.eclipse.jnosql.mapping.metadata.repository.RepositoryMetadata;
+import org.eclipse.jnosql.mapping.repository.LifecycleEventHandler;
 import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
 import org.eclipse.jnosql.mapping.semistructured.query.Tasks;
-import org.eclipse.jnosql.mapping.semistructured.repository.entities.ComicBookRepository;
-import org.jboss.weld.junit5.auto.AddExtensions;
-import org.jboss.weld.junit5.auto.AddPackages;
-import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Proxy;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@EnableAutoWeld
-@AddPackages(value = {Converters.class, EntityConverter.class})
-@AddPackages(MockProducer.class)
-@AddPackages(Reflections.class)
-@AddExtensions({ReflectionEntityMetadataExtension.class})
+@DisplayName("SemistructuredRepositoryProducer")
 class SemistructuredRepositoryProducerTest {
 
-    @Inject
+    private final EntitiesMetadata entities = mock(EntitiesMetadata.class);
+    private final InfrastructureOperatorProvider infrastructureOperatorProvider =
+            mock(InfrastructureOperatorProvider.class);
+    private final SemistructuredRepositoryOperationProvider operationProvider =
+            mock(SemistructuredRepositoryOperationProvider.class);
+    private final RepositoriesMetadata repositoriesMetadata = mock(RepositoriesMetadata.class);
+    private final LifecycleEventHandler lifecycleEventHandler = mock(LifecycleEventHandler.class);
+    private final BeanManager beanManager = mock(BeanManager.class);
+    private final CreationalContext<Tasks> creationalContext = mock(CreationalContext.class);
+    private final InterceptionFactory<Tasks> interceptionFactory = mock(InterceptionFactory.class);
+    private final SemiStructuredTemplate template = mock(SemiStructuredTemplate.class);
+    private final RepositoryMetadata repositoryMetadata = mock(RepositoryMetadata.class);
+    private final EntityMetadata entityMetadata = mock(EntityMetadata.class);
+
     private SemistructuredRepositoryProducer producer;
 
-    private SemiStructuredTemplate semiStructuredTemplate;
-
     @BeforeEach
-    void setUP() {
-        this.semiStructuredTemplate = Mockito.mock(SemiStructuredTemplate.class);
+    void setUp() {
+        producer = new SemistructuredRepositoryProducer(entities,
+                infrastructureOperatorProvider,
+                operationProvider,
+                repositoriesMetadata,
+                lifecycleEventHandler,
+                beanManager);
     }
-
-    @DisplayName("Should return instance")
-    @Test
-    void shouldReturnInstance() {
-        Assertions.assertThat(producer).isNotNull();
-    }
-
-
-    @DisplayName("Should return error when template is null")
-    @Test
-    void shouldReturnErrorWhenTemplateIsNull() {
-        Assertions.assertThatThrownBy(() -> producer.get(Tasks.class, null))
-                .isInstanceOf(NullPointerException.class);
-    }
-
-    @DisplayName("Should return error when repository class is null")
-    @Test
-    void shouldReturnErrorWhenRepositoryClassIsNull() {
-        Assertions.assertThatThrownBy(() -> producer.get(null, semiStructuredTemplate))
-                .isInstanceOf(NullPointerException.class);
-    }
-
-    @DisplayName("Should instance default constructor")
-    @Test
-    void shouldInstanceDefaultConstructor() {
-        SemistructuredRepositoryProducer producer = new SemistructuredRepositoryProducer();
-        Assertions.assertThat(producer).isNotNull();
-    }
-
-
-    @DisplayName("Should return custom repository instance")
-    @Test
-    void shouldReturnCustomRepositoryInstance() {
-        var repository = producer.get(Tasks.class, semiStructuredTemplate);
-        Assertions.assertThat(repository).isNotNull();
-    }
-
-    @DisplayName("Should return repository instance")
-    @Test
-    void shouldReturnRepositoryInstance() {
-        var repository = producer.get(ComicBookRepository.class, semiStructuredTemplate);
-        Assertions.assertThat(repository).isNotNull();
-    }
-
 
     @Nested
-    @DisplayName("When the semistructured repository producer is tested")
-    class WhenTheSemistructuredRepositoryProducerIsTested {
+    @DisplayName("when validating repository creation arguments")
+    class Validation {
+
+        @Test
+        @DisplayName("throws NullPointerException when the repository class is null")
+        void shouldRejectNullRepositoryClass() {
+            assertThatThrownBy(() -> producer.get(null, template))
+                    .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("throws NullPointerException when the template is null")
+        void shouldRejectNullTemplate() {
+            assertThatThrownBy(() -> producer.get(Tasks.class, null))
+                    .isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("when repository metadata is resolved")
+    class ProxyCreation {
+
+        @BeforeEach
+        void setUpMetadata() {
+            when(repositoriesMetadata.get(Tasks.class)).thenReturn(Optional.of(repositoryMetadata));
+            when(repositoryMetadata.entity()).thenReturn(Optional.of(Object.class));
+            when(entities.get(Object.class)).thenReturn(entityMetadata);
+        }
+
+        @Test
+        @DisplayName("returns the repository instance created by CDI interception")
+        void shouldCreateCdiInterceptedRepository() {
+            Tasks expected = mock(Tasks.class);
+            doReturn(creationalContext).when(beanManager).createCreationalContext(null);
+            doReturn(interceptionFactory).when(beanManager)
+                    .createInterceptionFactory(creationalContext, Tasks.class);
+            when(interceptionFactory.createInterceptedInstance(any())).thenReturn(expected);
+
+            Tasks result = producer.get(Tasks.class, template);
+
+            ArgumentCaptor<Tasks> repositoryCaptor = ArgumentCaptor.forClass(Tasks.class);
+            verify(interceptionFactory).createInterceptedInstance(repositoryCaptor.capture());
+            assertThat(Proxy.getInvocationHandler(repositoryCaptor.getValue()))
+                    .isInstanceOf(CoreRepositoryInvocationHandler.class);
+            assertThat(result).isSameAs(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("when instantiated for CDI proxying")
+    class Construction {
+
+        @Test
+        @DisplayName("provides a no-argument constructor")
+        void shouldProvideDefaultConstructor() {
+            assertThat(new SemistructuredRepositoryProducer()).isNotNull();
+        }
     }
 }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerTest.java
@@ -126,7 +126,7 @@ class SemistructuredRepositoryProducerTest {
     class Construction {
 
         @Test
-        @DisplayName("provides a no-argument constructor")
+        @DisplayName("provides a package-private no-argument constructor for CDI")
         void shouldProvideDefaultConstructor() {
             assertThat(new SemistructuredRepositoryProducer()).isNotNull();
         }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerWeldTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerWeldTest.java
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ *   and the Apache License v2.0 is available at http://www.opensource.org/licenses/apache2.0.php.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.semistructured.repository;
+
+import jakarta.annotation.Priority;
+import jakarta.data.repository.Repository;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InterceptorBinding;
+import jakarta.interceptor.InvocationContext;
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+import org.eclipse.jnosql.mapping.NoSQLRepository;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, EntityConverter.class})
+@AddPackages(Reflections.class)
+@AddExtensions(ReflectionEntityMetadataExtension.class)
+@AddBeanClasses({
+        SemistructuredRepositoryProducerWeldTest.RepositoryBeans.class,
+        SemistructuredRepositoryProducerWeldTest.InvocationCounter.class,
+        SemistructuredRepositoryProducerWeldTest.RepositoryInterceptor.class
+})
+@DisplayName("SemistructuredRepositoryProducer with Weld")
+class SemistructuredRepositoryProducerWeldTest {
+
+    @Inject
+    private WeldRepository repository;
+
+    @Inject
+    private SemiStructuredTemplate template;
+
+    @Inject
+    private InvocationCounter invocationCounter;
+
+    @BeforeEach
+    void setUp() {
+        invocationCounter.reset();
+    }
+
+    @Nested
+    @DisplayName("when CDI injects a repository")
+    class RepositoryInjection {
+
+        @Test
+        @DisplayName("executes repository operations through the CDI interceptor")
+        void shouldExecuteRepositoryThroughInterceptor() {
+            when(template.count(WeldEntity.class)).thenReturn(1L);
+
+            long result = repository.countAll();
+
+            assertThat(result).isEqualTo(1L);
+            assertThat(invocationCounter.value()).isEqualTo(1);
+            verify(template).count(WeldEntity.class);
+        }
+    }
+
+    @Repository
+    @RepositoryIntercepted
+    interface WeldRepository extends NoSQLRepository<WeldEntity, String> {
+
+        long countAll();
+    }
+
+    @Entity
+    record WeldEntity(@Id String id, @Column String name) {
+    }
+
+    @Inherited
+    @InterceptorBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @interface RepositoryIntercepted {
+    }
+
+    @RepositoryIntercepted
+    @Interceptor
+    @Priority(Interceptor.Priority.APPLICATION)
+    static class RepositoryInterceptor {
+
+        @Inject
+        private InvocationCounter counter;
+
+        @AroundInvoke
+        Object intercept(InvocationContext context) throws Exception {
+            counter.increment();
+            return context.proceed();
+        }
+    }
+
+    @ApplicationScoped
+    static class InvocationCounter {
+
+        private final AtomicInteger counter = new AtomicInteger();
+
+        void increment() {
+            counter.incrementAndGet();
+        }
+
+        int value() {
+            return counter.get();
+        }
+
+        void reset() {
+            counter.set(0);
+        }
+    }
+
+    @ApplicationScoped
+    static class RepositoryBeans {
+
+        private final SemiStructuredTemplate template = mock(SemiStructuredTemplate.class);
+
+        @Inject
+        private SemistructuredRepositoryProducer producer;
+
+        @Produces
+        SemiStructuredTemplate template() {
+            return template;
+        }
+
+        @Produces
+        WeldRepository repository() {
+            return producer.get(WeldRepository.class, template);
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerWeldTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredRepositoryProducerWeldTest.java
@@ -26,6 +26,7 @@ import jakarta.interceptor.InvocationContext;
 import jakarta.nosql.Column;
 import jakarta.nosql.Entity;
 import jakarta.nosql.Id;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
 import org.eclipse.jnosql.mapping.NoSQLRepository;
 import org.eclipse.jnosql.mapping.core.Converters;
 import org.eclipse.jnosql.mapping.reflection.Reflections;
@@ -48,8 +49,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -60,7 +63,8 @@ import static org.mockito.Mockito.when;
 @AddBeanClasses({
         SemistructuredRepositoryProducerWeldTest.RepositoryBeans.class,
         SemistructuredRepositoryProducerWeldTest.InvocationCounter.class,
-        SemistructuredRepositoryProducerWeldTest.RepositoryInterceptor.class
+        SemistructuredRepositoryProducerWeldTest.RepositoryInterceptor.class,
+        SemistructuredRepositoryProducerWeldTest.MethodInterceptor.class
 })
 @DisplayName("SemistructuredRepositoryProducer with Weld")
 class SemistructuredRepositoryProducerWeldTest {
@@ -77,22 +81,77 @@ class SemistructuredRepositoryProducerWeldTest {
     @BeforeEach
     void setUp() {
         invocationCounter.reset();
+        reset(template);
     }
 
     @Nested
-    @DisplayName("when CDI injects a repository")
-    class RepositoryInjection {
+    @DisplayName("When invoking an injected repository")
+    class WhenTheRepositoryInvocation {
 
         @Test
-        @DisplayName("executes repository operations through the CDI interceptor")
-        void shouldExecuteRepositoryThroughInterceptor() {
+        @DisplayName("Should apply the repository interceptor")
+        void shouldApplyRepositoryInterceptor() {
             when(template.count(WeldEntity.class)).thenReturn(1L);
 
             long result = repository.countAll();
 
-            assertThat(result).isEqualTo(1L);
-            assertThat(invocationCounter.value()).isEqualTo(1);
+            assertSoftly(softly -> {
+                softly.assertThat(result).as("repository result").isEqualTo(1L);
+                softly.assertThat(invocationCounter.repositoryInvocations())
+                        .as("repository interceptor invocations")
+                        .isEqualTo(1);
+            });
             verify(template).count(WeldEntity.class);
+        }
+
+        @Test
+        @DisplayName("Should apply the method interceptor")
+        void shouldApplyMethodInterceptor() {
+            when(template.count(any(SelectQuery.class))).thenReturn(2L);
+
+            long result = repository.countByName("Ada");
+
+            assertSoftly(softly -> {
+                softly.assertThat(result).as("repository result").isEqualTo(2L);
+                softly.assertThat(invocationCounter.methodInvocations())
+                        .as("method interceptor invocations")
+                        .isEqualTo(1);
+            });
+            verify(template).count(any(SelectQuery.class));
+        }
+
+        @Test
+        @DisplayName("Should apply both repository and method interceptors")
+        void shouldApplyBothInterceptors() {
+            when(template.count(any(SelectQuery.class))).thenReturn(2L);
+
+            repository.countByName("Ada");
+
+            assertSoftly(softly -> {
+                softly.assertThat(invocationCounter.repositoryInvocations())
+                        .as("repository interceptor invocations")
+                        .isEqualTo(1);
+                softly.assertThat(invocationCounter.methodInvocations())
+                        .as("method interceptor invocations")
+                        .isEqualTo(1);
+            });
+        }
+
+        @Test
+        @DisplayName("Should not apply the method interceptor without its binding")
+        void shouldNotApplyMethodInterceptorWithoutBinding() {
+            when(template.count(WeldEntity.class)).thenReturn(1L);
+
+            repository.countAll();
+
+            assertSoftly(softly -> {
+                softly.assertThat(invocationCounter.repositoryInvocations())
+                        .as("repository interceptor invocations")
+                        .isEqualTo(1);
+                softly.assertThat(invocationCounter.methodInvocations())
+                        .as("method interceptor invocations")
+                        .isZero();
+            });
         }
     }
 
@@ -101,6 +160,9 @@ class SemistructuredRepositoryProducerWeldTest {
     interface WeldRepository extends NoSQLRepository<WeldEntity, String> {
 
         long countAll();
+
+        @MethodIntercepted
+        long countByName(String name);
     }
 
     @Entity
@@ -114,6 +176,12 @@ class SemistructuredRepositoryProducerWeldTest {
     @interface RepositoryIntercepted {
     }
 
+    @InterceptorBinding
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @interface MethodIntercepted {
+    }
+
     @RepositoryIntercepted
     @Interceptor
     @Priority(Interceptor.Priority.APPLICATION)
@@ -124,7 +192,22 @@ class SemistructuredRepositoryProducerWeldTest {
 
         @AroundInvoke
         Object intercept(InvocationContext context) throws Exception {
-            counter.increment();
+            counter.incrementRepository();
+            return context.proceed();
+        }
+    }
+
+    @MethodIntercepted
+    @Interceptor
+    @Priority(Interceptor.Priority.APPLICATION + 1)
+    static class MethodInterceptor {
+
+        @Inject
+        private InvocationCounter counter;
+
+        @AroundInvoke
+        Object intercept(InvocationContext context) throws Exception {
+            counter.incrementMethod();
             return context.proceed();
         }
     }
@@ -132,18 +215,28 @@ class SemistructuredRepositoryProducerWeldTest {
     @ApplicationScoped
     static class InvocationCounter {
 
-        private final AtomicInteger counter = new AtomicInteger();
+        private final AtomicInteger repositoryCounter = new AtomicInteger();
+        private final AtomicInteger methodCounter = new AtomicInteger();
 
-        void increment() {
-            counter.incrementAndGet();
+        void incrementRepository() {
+            repositoryCounter.incrementAndGet();
         }
 
-        int value() {
-            return counter.get();
+        void incrementMethod() {
+            methodCounter.incrementAndGet();
+        }
+
+        int repositoryInvocations() {
+            return repositoryCounter.get();
+        }
+
+        int methodInvocations() {
+            return methodCounter.get();
         }
 
         void reset() {
-            counter.set(0);
+            repositoryCounter.set(0);
+            methodCounter.set(0);
         }
     }
 


### PR DESCRIPTION
This pull request introduces support for CDI (Contexts and Dependency Injection) interceptors in both semistructured and key-value repository implementations. This enables the use of custom interceptor bindings on repositories and repository methods, allowing for cross-cutting concerns (like logging, security, etc.) to be handled via CDI. The changes also include refactoring to support this new capability, updates to repository bean creation, and comprehensive tests to validate interceptor behavior.

Key changes include:

**CDI Interceptor Support for Repositories**
* Added CDI interceptor support to both key-value and semistructured repositories, allowing repository interfaces and methods to be annotated with interceptor bindings and have those interceptors applied at runtime. [[1]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93R28) [[2]](diffhunk://#diff-0d115489022b594e39efd9f74d11fd836c9abc0d5448de0988a82dd2f12273e8R20-R22) [[3]](diffhunk://#diff-0d115489022b594e39efd9f74d11fd836c9abc0d5448de0988a82dd2f12273e8L35-R75) [[4]](diffhunk://#diff-0d115489022b594e39efd9f74d11fd836c9abc0d5448de0988a82dd2f12273e8L85-R122) [[5]](diffhunk://#diff-0d115489022b594e39efd9f74d11fd836c9abc0d5448de0988a82dd2f12273e8L98-R137) [[6]](diffhunk://#diff-8ee75df5a02fabe72d87244185e11fe263c057eb7998773f5a37080d8d6321dbL97-R97)

**Refactoring and API Changes**
* Refactored `KeyValueRepositoryProducer` and semistructured equivalents to accept and pass CDI `CreationalContext` and `BeanManager` for proper proxy/interceptor creation. The repository instantiation now uses CDI's `InterceptionFactory` to wrap proxies with interceptors. [[1]](diffhunk://#diff-0d115489022b594e39efd9f74d11fd836c9abc0d5448de0988a82dd2f12273e8L35-R75) [[2]](diffhunk://#diff-0d115489022b594e39efd9f74d11fd836c9abc0d5448de0988a82dd2f12273e8L85-R122) [[3]](diffhunk://#diff-0d115489022b594e39efd9f74d11fd836c9abc0d5448de0988a82dd2f12273e8L98-R137) [[4]](diffhunk://#diff-8ee75df5a02fabe72d87244185e11fe263c057eb7998773f5a37080d8d6321dbL97-R97)
* Updated `RepositoryKeyValueBean` and semistructured bean classes to pass the `CreationalContext` when creating repositories, ensuring interceptors are properly applied. [[1]](diffhunk://#diff-5ab8eb05f3a01f96e4ab1fb5d8916ce24e8951538b674b3056ce5f6f0a1931e9L72-R79) [[2]](diffhunk://#diff-8ee75df5a02fabe72d87244185e11fe263c057eb7998773f5a37080d8d6321dbL97-R97)

**Testing Enhancements**
* Added a new integration test `KeyValueRepositoryProducerWeldTest` that verifies CDI interceptor support on repositories and methods using Weld. The test covers scenarios with repository-level and method-level interceptor bindings.
* Refactored and expanded unit tests in `KeyValueRepositoryProducerTest` to validate correct interceptor application, input validation, and proxy creation logic.

These changes collectively make it possible to leverage CDI interceptors in JNoSQL repositories, improving extensibility and integration with enterprise Java applications.