### PR TITLE
fix: update NOTICE EPL reference to 2.0

### DIFF
--- a/NOTICE.adoc
+++ b/NOTICE.adoc
@@ -5,7 +5,7 @@ Committers project.
 
 == Declared Project Licenses
 
-This program and the accompanying materials are made available under the terms of the Eclipse Public License 1.0 which is
+This program and the accompanying materials are made available under the terms of the Eclipse Public License 2.0 which is
  available at https://www.eclipse.org/legal/epl-2.0, or the Apache Software License 2.0 which is available 
  at https://www.apache.org/licenses/LICENSE-2.0.
 


### PR DESCRIPTION
## Related Issue

Closes #772

## What does this PR do?

Updates the remaining Eclipse Public License reference in `NOTICE.adoc` from EPL 1.0 to EPL 2.0.

The existing Apache License 2.0 option and license URLs are preserved.

## Changes

- Update `Eclipse Public License 1.0` to `Eclipse Public License 2.0` in `NOTICE.adoc`
- Preserve the existing EPL 2.0 URL
- Preserve the Apache License 2.0 alternative

## Validation

- `git diff --check` passes
- Working tree is clean