### PR TITLE
Fix update jakarta data

### DIFF
--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/AbstractSemiStructuredTemplate.java
@@ -338,7 +338,7 @@ public abstract class AbstractSemiStructuredTemplate implements SemiStructuredTe
         }
         CursoredPage<CommunicationEntity> cursoredPage = this.manager().selectCursor(query, pageRequest);
         List<T> entities = cursoredPage.stream().<T>map(c -> converter().toEntity(c)).toList();
-        return new MappedCursoredPage<>(entities, cursoredPage);
+        return MappedCursoredPage.of(entities, cursoredPage);
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MappedCursoredPage.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/MappedCursoredPage.java
@@ -34,17 +34,24 @@ public final class MappedCursoredPage<T> implements CursoredPage<T> {
 
     private final CursoredPage<?> delegate;
 
+    private MappedCursoredPage(List<T> content, CursoredPage<?> delegate) {
+        this.content = List.copyOf(requireNonNull(content, "content is required"));
+        this.delegate = requireNonNull(delegate, "delegate is required");
+    }
+
     /**
-     * Creates a mapped cursor page.
+     * Creates a cursor page with mapped content and pagination behavior
+     * delegated to the original page.
      *
      * @param content the mapped page content
      * @param delegate the cursor page that provides pagination behavior
+     * @param <T> the mapped content type
+     * @return the mapped cursor page
      * @throws NullPointerException if content or delegate is {@code null}, or
      *                              if content contains a {@code null} element
      */
-    public MappedCursoredPage(List<T> content, CursoredPage<?> delegate) {
-        this.content = List.copyOf(requireNonNull(content, "content is required"));
-        this.delegate = requireNonNull(delegate, "delegate is required");
+    public static <T> CursoredPage<T> of(List<T> content, CursoredPage<?> delegate) {
+        return new MappedCursoredPage<>(content, delegate);
     }
 
     @Override

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/AbstractSemiStructuredRepositoryProxy.java
@@ -143,7 +143,7 @@ public abstract class AbstractSemiStructuredRepositoryProxy<T, K> extends BaseSe
             var cursoredPage = this.template().selectCursor(updateQuery, pageRequest);
             if (method.getAnnotation(Select.class) != null) {
                 var mappedResult = cursoredPage.content().stream().map(mapper(method)).toList();
-                return new MappedCursoredPage<>(mappedResult, cursoredPage);
+                return MappedCursoredPage.of(mappedResult, cursoredPage);
             }
             return cursoredPage;
         }

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredCursorPaginationOperation.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/repository/SemistructuredCursorPaginationOperation.java
@@ -114,7 +114,7 @@ class SemistructuredCursorPaginationOperation implements CursorPaginationOperati
         RepositoryMethod method = context.method();
         EntityMetadata entityMetadata = context.entityMetadata();
         var mappedResult = cursoredPage.content().stream().map(returnType.mapper(method, entityMetadata)).toList();
-        return (T) new MappedCursoredPage<>(mappedResult, cursoredPage);
+        return (T) MappedCursoredPage.of(mappedResult, cursoredPage);
     }
 
     private static PageRequest pageRequest(RepositoryMethod method, SpecialParameters special) {

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/MappedCursoredPageTest.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/test/java/org/eclipse/jnosql/mapping/semistructured/MappedCursoredPageTest.java
@@ -43,7 +43,7 @@ class MappedCursoredPageTest {
             var delegate = new CursoredPageRecord<>(
                     List.of(1), List.of(cursor), 3, pageRequest, nextPageRequest, previousPageRequest);
 
-            var page = new MappedCursoredPage<>(List.of("Ada"), delegate);
+            var page = MappedCursoredPage.of(List.of("Ada"), delegate);
 
             assertSoftly(softly -> {
                 softly.assertThat(page.content()).as("mapped content").containsExactly("Ada");
@@ -71,7 +71,7 @@ class MappedCursoredPageTest {
                     List.of(1), List.of(PageRequest.Cursor.forKey("Ada")), -1,
                     PageRequest.ofSize(1), true, true);
 
-            var page = new MappedCursoredPage<>(content, delegate);
+            var page = MappedCursoredPage.of(content, delegate);
             content.clear();
 
             assertSoftly(softly -> {
@@ -95,7 +95,7 @@ class MappedCursoredPageTest {
             var delegate = new CursoredPageRecord<>(
                     List.of(1), List.of(), -1, pageRequest, nextPageRequest, null);
 
-            var page = new MappedCursoredPage<>(List.of("Ada"), delegate);
+            var page = MappedCursoredPage.of(List.of("Ada"), delegate);
 
             assertSoftly(softly -> {
                 softly.assertThat(page.hasNext()).as("next page availability").isTrue();
@@ -112,7 +112,7 @@ class MappedCursoredPageTest {
                     List.of(1), List.of(PageRequest.Cursor.forKey("Ada")), -1,
                     PageRequest.ofSize(1), true, true);
 
-            var page = new MappedCursoredPage<>(List.of("Ada"), delegate);
+            var page = MappedCursoredPage.of(List.of("Ada"), delegate);
 
             assertSoftly(softly -> {
                 softly.assertThat(page.hasTotals()).as("total availability").isFalse();
@@ -139,7 +139,7 @@ class MappedCursoredPageTest {
 
             assertThatNullPointerException()
                     .as("null content")
-                    .isThrownBy(() -> new MappedCursoredPage<>(null, delegate))
+                    .isThrownBy(() -> MappedCursoredPage.of(null, delegate))
                     .withMessage("content is required");
         }
 
@@ -153,7 +153,7 @@ class MappedCursoredPageTest {
 
             assertThatNullPointerException()
                     .as("null content element")
-                    .isThrownBy(() -> new MappedCursoredPage<>(content, delegate));
+                    .isThrownBy(() -> MappedCursoredPage.of(content, delegate));
         }
 
         @Test
@@ -161,7 +161,7 @@ class MappedCursoredPageTest {
         void shouldRejectNullDelegate() {
             assertThatNullPointerException()
                     .as("null delegate")
-                    .isThrownBy(() -> new MappedCursoredPage<>(List.of("Ada"), null))
+                    .isThrownBy(() -> MappedCursoredPage.of(List.of("Ada"), null))
                     .withMessage("delegate is required");
         }
     }


### PR DESCRIPTION
This pull request refactors the creation of `MappedCursoredPage` instances throughout the semistructured mapping module. The main change is to replace direct constructor calls with a new static factory method, `MappedCursoredPage.of`, improving encapsulation and consistency. The update affects both production and test code.

**Refactoring and API Consistency:**

* Introduced a static factory method `MappedCursoredPage.of` for creating mapped cursor pages, replacing direct use of the constructor and making the constructor private. This improves encapsulation and provides a single entry point for instance creation.
* Updated all usages in the main codebase to use `MappedCursoredPage.of` instead of the constructor, including in `AbstractSemiStructuredTemplate`, `AbstractSemiStructuredRepositoryProxy`, and `SemistructuredCursorPaginationOperation`. [[1]](diffhunk://#diff-717f676ce5ef5e7b3582e87d6acc6fc1daadd5ab122a94c3eb1acb50ee8c4061L341-R341) [[2]](diffhunk://#diff-84b2b017785cfc96793e950cf74c4dfd339aecee65de6b0ec2f8acfc796cee1cL146-R146) [[3]](diffhunk://#diff-7e50a5f401e90a5cab5f136e6c13fc5f7af6499b61f153c64c1618928800b594L117-R117)

**Test Code Updates:**

* Refactored all test cases in `MappedCursoredPageTest` to use the new `MappedCursoredPage.of` factory method, ensuring tests align with the updated API and verifying null checks and behavior remain intact. [[1]](diffhunk://#diff-91ca277397f34e25461273b5953abbd0a5b807483c7510b78daf786e8e0da0afL46-R46) [[2]](diffhunk://#diff-91ca277397f34e25461273b5953abbd0a5b807483c7510b78daf786e8e0da0afL74-R74) [[3]](diffhunk://#diff-91ca277397f34e25461273b5953abbd0a5b807483c7510b78daf786e8e0da0afL98-R98) [[4]](diffhunk://#diff-91ca277397f34e25461273b5953abbd0a5b807483c7510b78daf786e8e0da0afL115-R115) [[5]](diffhunk://#diff-91ca277397f34e25461273b5953abbd0a5b807483c7510b78daf786e8e0da0afL142-R142) [[6]](diffhunk://#diff-91ca277397f34e25461273b5953abbd0a5b807483c7510b78daf786e8e0da0afL156-R164)