### PR TITLE
Migrate service discovery consumers to ServiceDiscovery

### DIFF
--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/TypeReferenceReaderDecorator.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/TypeReferenceReaderDecorator.java
@@ -12,6 +12,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  *
  */
 package org.eclipse.jnosql.communication;
@@ -19,7 +20,7 @@ package org.eclipse.jnosql.communication;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 
 /**
  * Decorators of all {@link TypeReferenceReader}
@@ -33,8 +34,8 @@ public final class TypeReferenceReaderDecorator implements TypeReferenceReader {
     private final List<TypeReferenceReader> readers = new ArrayList<>();
 
     {
-        ServiceLoader.load(TypeReferenceReader.class).stream()
-                .map(ServiceLoader.Provider::get)
+        ServiceDiscovery.of(TypeReferenceReader.class, TypeReferenceReader.class)
+                .all()
                 .forEach(readers::add);
     }
 

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ValueReaderDecorator.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ValueReaderDecorator.java
@@ -12,6 +12,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  *
  */
 package org.eclipse.jnosql.communication;
@@ -21,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -37,8 +38,8 @@ public final class ValueReaderDecorator implements ValueReader {
     private final List<ValueReader> readers = new ArrayList<>();
 
     {
-        ServiceLoader.load(ValueReader.class).stream()
-                .map(ServiceLoader.Provider::get)
+        ServiceDiscovery.of(ValueReader.class, ValueReader.class)
+                .all()
                 .forEach(readers::add);
     }
 

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ValueWriterDecorator.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ValueWriterDecorator.java
@@ -12,6 +12,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  *
  */
 
@@ -20,7 +21,7 @@ package org.eclipse.jnosql.communication;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 
 /**
  * Decorators of all {@link ValueWriter} supported by Diana
@@ -36,7 +37,9 @@ public final class ValueWriterDecorator<T, S> implements ValueWriter<T, S> {
     private final List<ValueWriter> writers = new ArrayList<>();
 
     {
-        ServiceLoader.load(ValueWriter.class).forEach(writers::add);
+        ServiceDiscovery.of(ValueWriter.class, ValueWriter.class)
+                .all()
+                .forEach(writers::add);
     }
 
     private ValueWriterDecorator() {

--- a/jnosql-communication/jnosql-communication-key-value/src/main/java/org/eclipse/jnosql/communication/keyvalue/KeyValueConfiguration.java
+++ b/jnosql-communication/jnosql-communication-key-value/src/main/java/org/eclipse/jnosql/communication/keyvalue/KeyValueConfiguration.java
@@ -8,17 +8,17 @@
  *  You may elect to redistribute this code under either of these licenses.
  *  Contributors:
  *  Otavio Santana
+ *  Mohan Lal
  */
 package org.eclipse.jnosql.communication.keyvalue;
 
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
 
 import org.eclipse.jnosql.communication.CommunicationException;
 import org.eclipse.jnosql.communication.Settings;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.ServiceLoader;
-import java.util.function.Function;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 
 /**
  * It is a function that reads from {@link Settings} and then creates a manager factory instance.
@@ -29,28 +29,30 @@ import java.util.function.Function;
  */
 public interface KeyValueConfiguration extends Function<Settings, BucketManagerFactory> {
 
-    List<KeyValueConfiguration> CONFIGURATIONS = ServiceLoader.load(KeyValueConfiguration.class).stream()
-            .map(ServiceLoader.Provider::get)
-            .toList();
+    List<KeyValueConfiguration> CONFIGURATIONS =
+            ServiceDiscovery.of(KeyValueConfiguration.class, KeyValueConfiguration.class)
+                    .all();
 
     /**
-     * creates and returns a  {@link KeyValueConfiguration}  instance from {@link ServiceLoader}
+     * Creates and returns a {@link KeyValueConfiguration} instance.
      *
      * @param <T> the configuration type
      * @return {@link KeyValueConfiguration} instance
      */
     @SuppressWarnings("unchecked")
     static <T extends KeyValueConfiguration> T getConfiguration() {
-       return (T) CONFIGURATIONS
+        return (T) CONFIGURATIONS
                 .stream()
-               .findFirst().orElseThrow(() -> new CommunicationException("No KeyValueConfiguration implementation found!"));
+                .findFirst()
+                .orElseThrow(() ->
+                        new CommunicationException("No KeyValueConfiguration implementation found!"));
     }
 
     /**
-     * creates and returns a  {@link KeyValueConfiguration} instance from {@link ServiceLoader}
+     * Creates and returns a {@link KeyValueConfiguration} instance
      * for a particular provider implementation.
      *
-     * @param <T>      the configuration type
+     * @param <T>  the configuration type
      * @param type the particular provider
      * @return {@link KeyValueConfiguration} instance
      */
@@ -60,6 +62,9 @@ public interface KeyValueConfiguration extends Function<Settings, BucketManagerF
         return (T) CONFIGURATIONS
                 .stream()
                 .filter(type::isInstance)
-                .findFirst().orElseThrow(() -> new CommunicationException("No KeyValueConfiguration implementation found!"));
+                .findFirst()
+                .orElseThrow(() ->
+                        new CommunicationException(
+                                "No KeyValueConfiguration implementation found!"));
     }
 }

--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ClassConverter.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ClassConverter.java
@@ -42,7 +42,7 @@ public interface ClassConverter extends Function<Class<?>, EntityMetadata> {
             .first()
             .orElseThrow(() ->
                     new MetadataException(
-                            "No implementation of ClassConverter found via ServiceLoader"));
+                            "No implementation of ClassConverter found via ServiceDiscovery"));
 
     /**
      * Loads and returns an instance of the {@link ClassConverter} implementation using the ServiceLoader mechanism.

--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ClassScanner.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ClassScanner.java
@@ -33,7 +33,7 @@ public interface ClassScanner {
             .first()
             .orElseThrow(() ->
                     new MetadataException(
-                            "No implementation of ClassScanner found via ServiceLoader"));
+                            "No implementation of ClassScanner found via ServiceDiscovery"));
 
     /**
      * Returns a set of classes that are annotated with the {@link jakarta.nosql.Entity} annotation.

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
@@ -16,16 +16,16 @@
  */
 package org.eclipse.jnosql.mapping.core.repository;
 
-import jakarta.data.page.PageRequest;
-import org.eclipse.jnosql.mapping.PreparedStatement;
-import org.eclipse.jnosql.mapping.core.NoSQLPage;
-
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import jakarta.data.page.PageRequest;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
+import org.eclipse.jnosql.mapping.PreparedStatement;
+import org.eclipse.jnosql.mapping.core.NoSQLPage;
 
 /**
  * The converter within the return method at Repository class.
@@ -36,9 +36,10 @@ public enum DynamicReturnConverter {
 
     private final RepositoryReturn defaultReturn = new DefaultRepositoryReturn();
 
-    private final List<RepositoryReturn> repositoryReturns = ServiceLoader.load(RepositoryReturn.class) .stream()
-            .map(ServiceLoader.Provider::get)
-            .toList();
+    private final List<RepositoryReturn> repositoryReturns =
+            ServiceDiscovery
+                    .of(RepositoryReturn.class, DynamicReturnConverter.class)
+                    .all();
 
     /**
      * Converts the entity from the Method return type.

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionFieldMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionFieldMetadata.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  */
 package org.eclipse.jnosql.mapping.reflection;
 
@@ -30,14 +31,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 
 final class DefaultCollectionFieldMetadata extends AbstractFieldMetadata implements CollectionFieldMetadata {
 
     @SuppressWarnings("rawtypes")
-    private static final List<CollectionSupplier> COLLECTION_SUPPLIERS = ServiceLoader.load(CollectionSupplier.class) .stream()
-            .map(ServiceLoader.Provider::get)
-            .toList();
+    private static final List<CollectionSupplier> COLLECTION_SUPPLIERS =
+            ServiceDiscovery.of(CollectionSupplier.class, DefaultCollectionFieldMetadata.class)
+                    .all();
 
     private final TypeSupplier<?> typeSupplier;
     private final boolean entityField;

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionParameterMetaData.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionParameterMetaData.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  */
 package org.eclipse.jnosql.mapping.reflection;
 
@@ -26,14 +27,14 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
 import java.util.List;
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 
 class DefaultCollectionParameterMetaData extends DefaultParameterMetaData implements CollectionParameterMetaData {
 
     @SuppressWarnings("rawtypes")
-    private static final List<CollectionSupplier> COLLECTION_SUPPLIERS = ServiceLoader.load(CollectionSupplier.class).stream()
-            .map(ServiceLoader.Provider::get)
-            .toList();
+    private static final List<CollectionSupplier> COLLECTION_SUPPLIERS =
+            ServiceDiscovery.of(CollectionSupplier.class, DefaultCollectionParameterMetaData.class)
+                    .all();
 
     private final Class<?> elementType;
 


### PR DESCRIPTION
## Description

Follow-up to #769 and related to #766.

Migrates the remaining service discovery consumers in the communication modules to the centralized `ServiceDiscovery` utility.

### Changes

* Migrated `TypeReferenceReaderDecorator` to `ServiceDiscovery`.
* Migrated `ValueReaderDecorator` to `ServiceDiscovery`.
* Migrated `ValueWriterDecorator` to `ServiceDiscovery`.
* Migrated `KeyValueConfiguration` to `ServiceDiscovery`.
* Removed direct `ServiceLoader` usage from these consumers.
* Updated contributor entries for the modified files.

### Validation

* Full project tests passed.
* Build completed successfully.
* Verification completed successfully.
* `git diff --check` passed.
* Working tree is clean.
* Branch is pushed and reports as able to merge.

### Scope

This change only migrates existing service discovery consumers to the shared `ServiceDiscovery` abstraction. The underlying `ServiceLoader` usage remains encapsulated within `ServiceDiscovery`.