### PR TITLE
Include JNoSQL Timeseries

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 === Added
 
+- Add the `jnosql-mapping-timeseries` module with `TimeSeriesTemplate`, repository, CDI, and configuration support
 - Add CDI interceptor support to semistructured and key-value repositories
 - Add support for scalar function expressions (UPPER, LOWER, LEFT, RIGHT, LENGTH, ABS) in JDQL string queries
 - Include support to Restriction interface

--- a/README.adoc
+++ b/README.adoc
@@ -20,7 +20,7 @@ Eclipse JNoSQL is a compatible implementation of the https://jakarta.ee/specific
 
 == Why Eclipse JNoSQL?
 
-Eclipse JNoSQL is a Java framework that unifies NoSQL access across different database types, including Key-Value, Column Family, Document, and Graph. Built on top of the Jakarta NoSQL and Jakarta Data specifications, it simplifies development through standard annotations, fluent APIs, and full compatibility with Jakarta EE and MicroProfile runtimes.
+Eclipse JNoSQL is a Java framework that unifies NoSQL access across different database types, including Key-Value, Column Family, Document, Graph, and Time Series. Built on top of the Jakarta NoSQL and Jakarta Data specifications, it simplifies development through standard annotations, fluent APIs, and full compatibility with Jakarta EE and MicroProfile runtimes.
 
 Use Eclipse JNoSQL to:
 
@@ -144,14 +144,15 @@ Eclipse JNoSQL requires these minimum requirements:
 
 === NoSQL Database Types
 
-Eclipse JNoSQL provides common annotations and interfaces. Thus, the same annotations and interfaces, ```Template``` and ```Repository```, will work on the four NoSQL database types.
+Eclipse JNoSQL provides common annotations and interfaces. Thus, the same annotations and interfaces, ```Template``` and ```Repository```, will work across the supported NoSQL database types.
 
-As a reference implementation for Jakarta NoSQL, Eclipse JNosql provides particular behavior to the database type required by the specification, including the Graph database type, it means, Eclipse JNoSQL covers the four NoSQL database types:
+As a reference implementation for Jakarta NoSQL, Eclipse JNoSQL provides particular behavior for each database type required by the specification and also supports Graph and Time Series databases:
 
 * Key-Value
 * Column Family
 * Document
 * Graph
+* Time Series
 
 === Key-Value
 
@@ -473,6 +474,120 @@ public DocumentManager getManagerB() {
 }
 ----
 
+=== Time Series
+
+Use the Time Series Mapping module to store, query, and manage Java entities in a time-series database.
+
+Add the module to your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.eclipse.jnosql.mapping</groupId>
+    <artifactId>jnosql-mapping-timeseries</artifactId>
+    <version>1.1.17</version>
+</dependency>
+----
+
+Map a time-series record as a Jakarta NoSQL entity:
+
+[source,java]
+----
+@Entity
+public class SensorReading {
+
+    @Id
+    private String id;
+
+    @Column
+    private String sensor;
+
+    @Column
+    private Instant timestamp;
+
+    @Column
+    private double value;
+
+    // constructors, getters, and setters
+}
+----
+
+Inject `TimeSeriesTemplate` to perform persistence and query operations:
+
+[source,java]
+----
+@Inject
+private TimeSeriesTemplate template;
+
+SensorReading reading = new SensorReading(
+        UUID.randomUUID().toString(),
+        "sensor-1",
+        Instant.now(),
+        21.5);
+
+template.insert(reading);
+
+Optional<SensorReading> result =
+        template.find(SensorReading.class, reading.getId());
+
+List<SensorReading> readings = template.select(SensorReading.class)
+        .where("sensor").eq("sensor-1")
+        .result();
+----
+
+You can also use Jakarta Data repositories:
+
+[source,java]
+----
+@Repository
+public interface SensorReadingRepository
+        extends BasicRepository<SensorReading, String> {
+
+    List<SensorReading> findBySensor(String sensor);
+}
+
+@Inject
+@Database(DatabaseType.TIME_SERIES)
+private SensorReadingRepository repository;
+----
+
+Configure the database name and provider using MicroProfile Config:
+
+[source,properties]
+----
+jnosql.timeseries.database=<DATABASE>
+jnosql.timeseries.provider=<CLASS-DRIVER>
+jnosql.provider.host=<HOST>
+jnosql.provider.user=<USER>
+jnosql.provider.******
+----
+
+TIP: The `jnosql.timeseries.provider` property is necessary when more than one time-series database provider is available in the classpath.
+
+Applications that create the database manager programmatically can expose it through CDI:
+
+[source,java]
+----
+@Produces
+@Database(DatabaseType.TIME_SERIES)
+public DatabaseManager getTimeSeriesManager() {
+    return manager;
+}
+----
+
+Use named providers when the application connects to multiple time-series databases:
+
+[source,java]
+----
+@Inject
+@Database(value = DatabaseType.TIME_SERIES, provider = "metrics")
+private TimeSeriesTemplate metrics;
+
+@Inject
+@Database(value = DatabaseType.TIME_SERIES, provider = "audit")
+private TimeSeriesTemplate audit;
+----
+
 === Graph
 
 Eclipse JNoSQL provides a Graph API that simplifies working with graph databases such as Neo4j and Apache TinkerPop. This API enables seamless integration with graph databases while following the Jakarta NoSQL specifications.
@@ -562,7 +677,7 @@ Eclipse JNoSQL as a https://jakarta.ee/specifications/data/1.0/jakarta-data-1.0[
 
 === Jakarta NoSQL
 
-Eclipse JNoSQL is a https://jakarta.ee/specifications/nosql/1.0/jakarta-nosql-1.0[Jakarta NoSQL] implementation that provides a standard way to access NoSQL databases in Java applications. It offers a set of annotations and APIs to interact with various NoSQL database types, including Key-Value, Column Family, Document, and Graph.
+Eclipse JNoSQL is a https://jakarta.ee/specifications/nosql/1.0/jakarta-nosql-1.0[Jakarta NoSQL] implementation that provides a standard way to access NoSQL databases in Java applications. It offers a set of annotations and APIs to interact with various NoSQL database types, including Key-Value, Column Family, Document, Graph, and Time Series.
 
 === More Information
 

--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/DatabaseMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/DatabaseMetadata.java
@@ -23,7 +23,7 @@ import java.util.Objects;
  * CDI qualifiers allow for distinguishing between different instances of the same type.
  *
  * <p>Supported types of NoSQL databases are {@link DatabaseType#KEY_VALUE}, {@link DatabaseType#COLUMN},
- * {@link DatabaseType#DOCUMENT}, and {@link DatabaseType#GRAPH}.
+ * {@link DatabaseType#DOCUMENT}, {@link DatabaseType#GRAPH}, and {@link DatabaseType#TIME_SERIES}.
  *
  * @see DatabaseType
  */
@@ -48,6 +48,11 @@ public final class DatabaseMetadata {
      * A default DatabaseMetadata instance for graph databases without a specific provider.
      */
     public static final DatabaseMetadata DEFAULT_GRAPH = new DatabaseMetadata(DatabaseType.GRAPH, "");
+
+    /**
+     * A default DatabaseMetadata instance for time-series databases without a specific provider.
+     */
+    public static final DatabaseMetadata DEFAULT_TIME_SERIES = new DatabaseMetadata(DatabaseType.TIME_SERIES, "");
 
 
     private final DatabaseType type;

--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/DatabaseQualifier.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/DatabaseQualifier.java
@@ -24,6 +24,7 @@ import static org.eclipse.jnosql.mapping.DatabaseType.COLUMN;
 import static org.eclipse.jnosql.mapping.DatabaseType.DOCUMENT;
 import static org.eclipse.jnosql.mapping.DatabaseType.GRAPH;
 import static org.eclipse.jnosql.mapping.DatabaseType.KEY_VALUE;
+import static org.eclipse.jnosql.mapping.DatabaseType.TIME_SERIES;
 
 
 /**
@@ -38,6 +39,8 @@ public final class DatabaseQualifier extends AnnotationLiteral<Database> impleme
     private static final DatabaseQualifier DEFAULT_KEY_VALUE_PROVIDER = new DatabaseQualifier("", KEY_VALUE);
 
     private static final DatabaseQualifier DEFAULT_GRAPH_PROVIDER = new DatabaseQualifier("", GRAPH);
+
+    private static final DatabaseQualifier DEFAULT_TIME_SERIES_PROVIDER = new DatabaseQualifier("", TIME_SERIES);
 
     private final String provider;
 
@@ -160,5 +163,31 @@ public final class DatabaseQualifier extends AnnotationLiteral<Database> impleme
             return DEFAULT_KEY_VALUE_PROVIDER;
         }
         return new DatabaseQualifier(provider, GRAPH);
+    }
+
+    /**
+     * Returns the qualifier filter with time-series type {@link DatabaseType#TIME_SERIES}
+     * and the NoSQL provider default.
+     *
+     * @return the default time-series provider
+     */
+    public static DatabaseQualifier ofTimeSeries() {
+        return DEFAULT_TIME_SERIES_PROVIDER;
+    }
+
+    /**
+     * Returns the qualifier filter with time-series type {@link DatabaseType#TIME_SERIES} and the
+     * NoSQL provider defined.
+     *
+     * @param provider the provider
+     * @return the qualifier filter instance
+     * @throws NullPointerException when provider is null
+     */
+    public static DatabaseQualifier ofTimeSeries(String provider) {
+        Objects.requireNonNull(provider, "provider is required");
+        if (StringUtils.isBlank(provider)) {
+            return DEFAULT_TIME_SERIES_PROVIDER;
+        }
+        return new DatabaseQualifier(provider, TIME_SERIES);
     }
 }

--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/DatabaseType.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/DatabaseType.java
@@ -51,6 +51,11 @@ public enum DatabaseType {
      */
     GRAPH,
     /**
+     * A time-series database is optimized for storing and querying data points indexed in time order.
+     * It is commonly used for metrics, events, telemetry, and other values that change over time.
+     */
+    TIME_SERIES,
+    /**
      * That is not a NoSQL type; it defines resources shared among the NoSQL types.
      */
     SHARED

--- a/jnosql-mapping/jnosql-mapping-api-core/src/test/java/org/eclipse/jnosql/mapping/DatabaseQualifierTest.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/test/java/org/eclipse/jnosql/mapping/DatabaseQualifierTest.java
@@ -22,6 +22,7 @@ import static org.eclipse.jnosql.mapping.DatabaseType.COLUMN;
 import static org.eclipse.jnosql.mapping.DatabaseType.DOCUMENT;
 import static org.eclipse.jnosql.mapping.DatabaseType.GRAPH;
 import static org.eclipse.jnosql.mapping.DatabaseType.KEY_VALUE;
+import static org.eclipse.jnosql.mapping.DatabaseType.TIME_SERIES;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -160,6 +161,40 @@ class DatabaseQualifierTest {
             assertSoftly(softly -> {
                 softly.assertThat(qualifier.provider()).isEmpty();
                 softly.assertThat(qualifier.value()).isEqualTo(GRAPH);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("When the time-series qualifier is requested")
+    class WhenTheTimeSeriesQualifierIsRequested {
+
+        @Test
+        @DisplayName("Should reject a null provider")
+        void shouldRejectANullProvider() {
+            assertThatNullPointerException().isThrownBy(() -> DatabaseQualifier.ofTimeSeries(null));
+        }
+
+        @Test
+        @DisplayName("Should return a time-series qualifier with the given provider")
+        void shouldReturnATimeSeriesQualifierWithTheGivenProvider() {
+            String provider = "provider";
+            DatabaseQualifier qualifier = DatabaseQualifier.ofTimeSeries(provider);
+
+            assertSoftly(softly -> {
+                softly.assertThat(qualifier.provider()).isEqualTo(provider);
+                softly.assertThat(qualifier.value()).isEqualTo(TIME_SERIES);
+            });
+        }
+
+        @Test
+        @DisplayName("Should return the default time-series qualifier")
+        void shouldReturnTheDefaultTimeSeriesQualifier() {
+            DatabaseQualifier qualifier = DatabaseQualifier.ofTimeSeries();
+
+            assertSoftly(softly -> {
+                softly.assertThat(qualifier.provider()).isEmpty();
+                softly.assertThat(qualifier.value()).isEqualTo(TIME_SERIES);
             });
         }
     }

--- a/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/spi/ColumnCustomExtensionTest.java
+++ b/jnosql-mapping/jnosql-mapping-column/src/test/java/org/eclipse/jnosql/mapping/column/spi/ColumnCustomExtensionTest.java
@@ -49,7 +49,7 @@ class ColumnCustomExtensionTest {
 
     @Inject
     @Database(value = DatabaseType.COLUMN, provider = "columnRepositoryMock")
-    private People pepoleMock;
+    private People peopleMock;
 
     @Inject
     private People repository;
@@ -79,11 +79,11 @@ class ColumnCustomExtensionTest {
         void shouldInjectProviderCustomRepository() {
 
             // When
-            Person person = pepoleMock.insert(Person.builder().build());
+            Person person = peopleMock.insert(Person.builder().build());
 
             // Then
             assertSoftly(softly -> {
-                softly.assertThat(pepoleMock).isNotNull();
+                softly.assertThat(peopleMock).isNotNull();
                 softly.assertThat(person).isNotNull();
                 softly.assertThat(person.getName()).isEqualTo("columnRepositoryMock");
             });

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/config/MappingConfigurations.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/config/MappingConfigurations.java
@@ -39,6 +39,15 @@ public enum MappingConfigurations implements Supplier<String> {
      */
     DOCUMENT_DATABASE("jnosql.document.database"),
     /**
+     * Define the DatabaseConfiguration that creates a time-series DatabaseManager instance.
+     * It is necessary when there is more than one implementation; otherwise, it will find one automatically.
+     */
+    TIME_SERIES_PROVIDER("jnosql.timeseries.provider"),
+    /**
+     * Define the time-series database name.
+     */
+    TIME_SERIES_DATABASE("jnosql.timeseries.database"),
+    /**
      * Define the ColumnConfiguration that creates a ColumnManager instance.
      * It is necessary when there is more than one implementation; otherwise,  it will find automatically.
      */

--- a/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/config/MappingConfigurationsTest.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/test/java/org/eclipse/jnosql/mapping/core/config/MappingConfigurationsTest.java
@@ -58,6 +58,18 @@ class MappingConfigurationsTest {
             String expectedValue = "jnosql.document.database";
             assertThat(MappingConfigurations.DOCUMENT_DATABASE.get()).isEqualTo(expectedValue);
         }
+        @DisplayName("Should return value for time-series provider")
+        @Test
+        void shouldReturnValueForTimeSeriesProvider() {
+            String expectedValue = "jnosql.timeseries.provider";
+            assertThat(MappingConfigurations.TIME_SERIES_PROVIDER.get()).isEqualTo(expectedValue);
+        }
+        @DisplayName("Should return value for time-series database")
+        @Test
+        void shouldReturnValueForTimeSeriesDatabase() {
+            String expectedValue = "jnosql.timeseries.database";
+            assertThat(MappingConfigurations.TIME_SERIES_DATABASE.get()).isEqualTo(expectedValue);
+        }
         @DisplayName("Should return value for column provider")
         @Test
         void shouldReturnValueForColumnProvider() {

--- a/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/spi/DocumentCustomExtensionTest.java
+++ b/jnosql-mapping/jnosql-mapping-document/src/test/java/org/eclipse/jnosql/mapping/document/spi/DocumentCustomExtensionTest.java
@@ -49,7 +49,7 @@ class DocumentCustomExtensionTest {
 
     @Inject
     @Database(value = DatabaseType.DOCUMENT, provider = "documentRepositoryMock")
-    private People pepoleMock;
+    private People peopleMock;
 
     @Inject
     private People repository;
@@ -78,11 +78,11 @@ class DocumentCustomExtensionTest {
         void shouldInjectProviderCustomRepository() {
 
             // When
-            Person person = pepoleMock.insert(Person.builder().build());
+            Person person = peopleMock.insert(Person.builder().build());
 
             // Then
             assertSoftly(softly -> {
-                softly.assertThat(pepoleMock).isNotNull();
+                softly.assertThat(peopleMock).isNotNull();
                 softly.assertThat(person).isNotNull();
                 softly.assertThat(person.getName()).isEqualTo("documentRepositoryMock");
             });

--- a/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/spi/GraphCustomExtensionTest.java
+++ b/jnosql-mapping/jnosql-mapping-graph/src/test/java/org/eclipse/jnosql/mapping/graph/spi/GraphCustomExtensionTest.java
@@ -48,7 +48,7 @@ class GraphCustomExtensionTest {
 
     @Inject
     @Database(value = DatabaseType.GRAPH, provider = "graphRepositoryMock")
-    private People pepoleMock;
+    private People peopleMock;
 
     @Inject
     private People repository;
@@ -72,10 +72,10 @@ class GraphCustomExtensionTest {
         @Test
         @DisplayName("Should use mock custom repository")
         void shouldUseMock(){
-            Person person = pepoleMock.insert(Person.builder().build());
+            Person person = peopleMock.insert(Person.builder().build());
 
             assertSoftly(soft -> {
-                soft.assertThat(pepoleMock).isNotNull();
+                soft.assertThat(peopleMock).isNotNull();
                 soft.assertThat(person).isNotNull();
                 soft.assertThat(person.getName()).isEqualTo("graphRepositoryMock");
             });

--- a/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseRepositoryBean.java
+++ b/jnosql-mapping/jnosql-mapping-semistructured/src/main/java/org/eclipse/jnosql/mapping/semistructured/query/BaseRepositoryBean.java
@@ -69,6 +69,7 @@ abstract class BaseRepositoryBean<T> extends AbstractBean<T> {
             case COLUMN -> DatabaseQualifier.ofColumn();
             case DOCUMENT -> DatabaseQualifier.ofDocument();
             case GRAPH -> DatabaseQualifier.ofGraph();
+            case TIME_SERIES -> DatabaseQualifier.ofTimeSeries();
             default -> throw new IllegalArgumentException("Unsupported database type: " + databaseType);
         };
     }
@@ -78,6 +79,7 @@ abstract class BaseRepositoryBean<T> extends AbstractBean<T> {
             case COLUMN -> DatabaseQualifier.ofColumn(provider);
             case DOCUMENT -> DatabaseQualifier.ofDocument(provider);
             case GRAPH -> DatabaseQualifier.ofGraph(provider);
+            case TIME_SERIES -> DatabaseQualifier.ofTimeSeries(provider);
             default -> throw new IllegalArgumentException("Unsupported database type: " + databaseType);
         };
     }

--- a/jnosql-mapping/jnosql-mapping-timeseries/pom.xml
+++ b/jnosql-mapping/jnosql-mapping-timeseries/pom.xml
@@ -1,0 +1,38 @@
+<!--
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
+  ~   All rights reserved. This program and the accompanying materials
+  ~   are made available under the terms of the Eclipse Public License 2.0
+  ~   and Apache License v2.0 which accompanies this distribution.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+  ~
+  ~   You may elect to redistribute this code under either of these licenses.
+  ~
+  ~   Contributors:
+  ~
+  ~   Otavio Santana
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.jnosql.mapping</groupId>
+        <artifactId>jnosql-mapping-parent</artifactId>
+        <version>1.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jnosql-mapping-timeseries</artifactId>
+    <name>JNoSQL Mapping Time Series</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jnosql-mapping-semistructured</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/DefaultTimeSeriesTemplate.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/DefaultTimeSeriesTemplate.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Default;
+import jakarta.inject.Inject;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.Database;
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.semistructured.AbstractSemiStructuredTemplate;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactory;
+import org.eclipse.jnosql.mapping.semistructured.EventPersistManager;
+
+
+@Default
+@ApplicationScoped
+@Database(DatabaseType.TIME_SERIES)
+class DefaultTimeSeriesTemplate extends AbstractSemiStructuredTemplate implements TimeSeriesTemplate {
+
+
+    private final EntityConverter converter;
+
+    private final  DatabaseManager manager;
+
+    private final  EventPersistManager eventManager;
+
+    private final  EntitiesMetadata entities;
+
+    private final  Converters converters;
+
+
+
+    @Inject
+    DefaultTimeSeriesTemplate(EntityConverterFactory converterFactory,
+                            @Database(DatabaseType.TIME_SERIES) DatabaseManager manager,
+                            EventPersistManager eventManager,
+                            EntitiesMetadata entities, Converters converters){
+        this.converter = converterFactory.create(manager);
+        this.manager = manager;
+        this.eventManager = eventManager;
+        this.entities = entities;
+        this.converters = converters;
+    }
+
+    DefaultTimeSeriesTemplate() {
+        this.converter = null;
+        this.manager = null;
+        this.eventManager = null;
+        this.entities = null;
+        this.converters = null;
+    }
+
+    @Override
+    protected EntityConverter converter() {
+        return converter;
+    }
+
+    @Override
+    protected DatabaseManager manager() {
+        return manager;
+    }
+
+    @Override
+    protected EventPersistManager eventManager() {
+        return eventManager;
+    }
+
+    @Override
+    protected EntitiesMetadata entities() {
+        return entities;
+    }
+
+    @Override
+    protected Converters converters() {
+        return converters;
+    }
+
+
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/TimeSeriesTemplate.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/TimeSeriesTemplate.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ *
+ */
+package org.eclipse.jnosql.mapping.timeseries;
+
+
+
+import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
+
+
+/**
+ * Specializes the mapping template for time-series databases.
+ * <p>
+ * Use this API to persist mapped measurements or events, retrieve them by identifier, and execute
+ * queries over fields such as a source, timestamp, or measured value.
+ * </p>
+ * <p>
+ * The default template can be injected directly:
+ * </p>
+ * <pre>
+ * &#64;Inject
+ * &#64;Database(DatabaseType.TIME_SERIES)
+ * TimeSeriesTemplate template;
+ * </pre>
+ * <p>
+ * When an application uses multiple time-series databases, select one with
+ * {@link org.eclipse.jnosql.mapping.Database#provider()}.
+ * </p>
+ */
+public interface TimeSeriesTemplate extends SemiStructuredTemplate {
+
+
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/TimeSeriesTemplateProducer.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/TimeSeriesTemplateProducer.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Vetoed;
+import jakarta.inject.Inject;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.metadata.EntitiesMetadata;
+import org.eclipse.jnosql.mapping.semistructured.AbstractSemiStructuredTemplate;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverterFactory;
+import org.eclipse.jnosql.mapping.semistructured.EventPersistManager;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Creates a {@link TimeSeriesTemplate} for an application-managed {@link DatabaseManager}.
+ * <p>
+ * This is useful when the application builds managers programmatically or needs a template for a manager
+ * that is not the default CDI-managed time-series database.
+ * </p>
+ */
+@ApplicationScoped
+public class TimeSeriesTemplateProducer implements Function<DatabaseManager, TimeSeriesTemplate> {
+
+    @Inject
+    private EntityConverterFactory converter;
+
+    @Inject
+    private EventPersistManager eventManager;
+
+    @Inject
+    private EntitiesMetadata entities;
+
+    @Inject
+    private Converters converters;
+
+
+    /**
+     * Associates a mapping template with the supplied database manager.
+     *
+     * @param manager the manager that will execute the template operations
+     * @return a time-series template backed by the manager
+     * @throws NullPointerException when the manager is {@code null}
+     */
+    @Override
+    public TimeSeriesTemplate apply(DatabaseManager manager) {
+        Objects.requireNonNull(manager, "manager is required");
+        return new ProducerTimeSeriesTemplate(converter, manager,
+                eventManager, entities, converters);
+    }
+
+    @Vetoed
+    static class ProducerTimeSeriesTemplate  extends AbstractSemiStructuredTemplate implements TimeSeriesTemplate {
+
+        private final EntityConverter converter;
+
+        private final  DatabaseManager manager;
+
+        private final EventPersistManager eventManager;
+
+        private final EntitiesMetadata entities;
+
+        private final  Converters converters;
+
+        ProducerTimeSeriesTemplate(EntityConverterFactory converter,
+                               DatabaseManager manager,
+                               EventPersistManager eventManager,
+                               EntitiesMetadata entities,
+                               Converters converters) {
+            this.converter = converter.create(manager);
+            this.manager = manager;
+            this.eventManager = eventManager;
+            this.entities = entities;
+            this.converters = converters;
+        }
+
+        ProducerTimeSeriesTemplate() {
+            this.converter = null;
+            this.manager = null;
+            this.eventManager = null;
+            this.entities = null;
+            this.converters = null;
+        }
+
+        @Override
+        protected EntityConverter converter() {
+            return converter;
+        }
+
+        @Override
+        protected DatabaseManager manager() {
+            return manager;
+        }
+
+        @Override
+        protected EventPersistManager eventManager() {
+            return eventManager;
+        }
+
+        @Override
+        protected EntitiesMetadata entities() {
+            return entities;
+        }
+
+        @Override
+        protected Converters converters() {
+            return converters;
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/configuration/TimeSeriesManagerSupplier.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/configuration/TimeSeriesManagerSupplier.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.configuration;
+
+import jakarta.data.exceptions.MappingException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import org.eclipse.jnosql.communication.Settings;
+import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.Database;
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.eclipse.jnosql.mapping.core.config.MicroProfileSettings;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.eclipse.jnosql.mapping.core.config.MappingConfigurations.TIME_SERIES_DATABASE;
+import static org.eclipse.jnosql.mapping.core.config.MappingConfigurations.TIME_SERIES_PROVIDER;
+
+@ApplicationScoped
+class TimeSeriesManagerSupplier implements Supplier<DatabaseManager> {
+
+    private static final Logger LOGGER = Logger.getLogger(TimeSeriesManagerSupplier.class.getName());
+
+    @Override
+    @Produces
+    @ApplicationScoped
+    @Database(DatabaseType.TIME_SERIES)
+    public DatabaseManager get() {
+        Settings settings = MicroProfileSettings.INSTANCE;
+
+        DatabaseConfiguration configuration = settings.get(TIME_SERIES_PROVIDER, Class.class)
+                .filter(DatabaseConfiguration.class::isAssignableFrom)
+                .map(c -> (DatabaseConfiguration) Reflections.newInstance(c)).orElseGet(DatabaseConfiguration::getConfiguration);
+
+        var managerFactory = configuration.apply(settings);
+
+        Optional<String> database = settings.get(TIME_SERIES_DATABASE, String.class);
+        String db = database.orElseThrow(() -> new MappingException("Please, inform the database filling up the property "
+                + TIME_SERIES_DATABASE.get()));
+        DatabaseManager manager = managerFactory.apply(db);
+
+        LOGGER.log(Level.FINEST, "Starting  a TimeSeriesManager instance using Eclipse MicroProfile Config," +
+                " database name: " + db);
+        return manager;
+    }
+
+    /**
+     * Releases the default time-series manager when its CDI application scope ends.
+     *
+     * @param manager the manager being removed from the CDI context
+     */
+    void close(@Disposes @Database(DatabaseType.TIME_SERIES) DatabaseManager manager) {
+        LOGGER.log(Level.FINEST, "Closing TimeSeriesManager resource, database name: " + manager.name());
+        manager.close();
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/package-info.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/package-info.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+
+/**
+ * Maps Java entities to time-series databases and integrates templates and Jakarta Data repositories with CDI.
+ * Applications can use the default database or select named providers through {@code @Database}.
+ */
+package org.eclipse.jnosql.mapping.timeseries;

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/query/CustomRepositoryTimeSeriesBean.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/query/CustomRepositoryTimeSeriesBean.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.query;
+
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.eclipse.jnosql.mapping.timeseries.TimeSeriesTemplate;
+import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
+import org.eclipse.jnosql.mapping.semistructured.query.CustomRepositoryBean;
+
+
+/**
+ * Registers a custom repository implementation to use a time-series template.
+ * The provider selects the database used by the repository's mapping operations.
+ *
+ * @param <T> the type of the repository
+ */
+public class CustomRepositoryTimeSeriesBean<T> extends CustomRepositoryBean<T> {
+
+    /**
+     * Registers the custom repository type for the selected time-series provider.
+     *
+     * @param type the repository type
+     * @param provider the provider name, or an empty value for the default database
+     */
+    public CustomRepositoryTimeSeriesBean(Class<?> type, String provider) {
+        super(type, provider, DatabaseType.TIME_SERIES);
+    }
+
+    @Override
+    protected Class<? extends SemiStructuredTemplate> getTemplateClass() {
+        return TimeSeriesTemplate.class;
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/query/RepositoryTimeSeriesBean.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/query/RepositoryTimeSeriesBean.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.query;
+
+import jakarta.data.repository.DataRepository;
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.eclipse.jnosql.mapping.timeseries.TimeSeriesTemplate;
+import org.eclipse.jnosql.mapping.semistructured.SemiStructuredTemplate;
+import org.eclipse.jnosql.mapping.semistructured.query.RepositoryBean;
+
+/**
+ * Registers a Jakarta Data repository to execute against a time-series database.
+ * The provider selects which configured database backs the repository.
+ *
+ * @param <T> the repository type
+ */
+public class RepositoryTimeSeriesBean<T extends DataRepository<T, ?>> extends RepositoryBean<T> {
+
+    /**
+     * Registers the repository type for the selected time-series provider.
+     *
+     * @param type the repository type
+     * @param provider the provider name, or an empty value for the default database
+     */
+    public RepositoryTimeSeriesBean(Class<?> type, String provider) {
+        super(type, provider, DatabaseType.TIME_SERIES);
+    }
+
+    @Override
+    protected Class<? extends SemiStructuredTemplate>  getTemplateClass() {
+        return TimeSeriesTemplate.class;
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/spi/TemplateBean.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/spi/TemplateBean.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.spi;
+
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.nosql.Template;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.DatabaseQualifier;
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.eclipse.jnosql.mapping.core.spi.AbstractBean;
+import org.eclipse.jnosql.mapping.timeseries.TimeSeriesTemplate;
+import org.eclipse.jnosql.mapping.timeseries.TimeSeriesTemplateProducer;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Set;
+
+class TemplateBean extends AbstractBean<TimeSeriesTemplate> {
+
+    private static final Set<Type> TYPES = Set.of(TimeSeriesTemplate.class, Template.class);
+
+    private final String provider;
+
+    private final Set<Annotation> qualifiers;
+
+    TemplateBean( String provider) {
+        this.provider = provider;
+        this.qualifiers = Collections.singleton(DatabaseQualifier.ofTimeSeries(provider));
+    }
+
+    @Override
+    public Class<?> getBeanClass() {
+        return TimeSeriesTemplate.class;
+    }
+
+
+    @Override
+    public TimeSeriesTemplate create(CreationalContext<TimeSeriesTemplate> context) {
+
+        var producer = getInstance(TimeSeriesTemplateProducer.class);
+        var manager = getManager();
+        return producer.apply(manager);
+    }
+
+    private DatabaseManager getManager() {
+        return getInstance(DatabaseManager.class, DatabaseQualifier.ofTimeSeries(provider));
+    }
+
+    @Override
+    public Set<Type> getTypes() {
+        return TYPES;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public String getId() {
+        return TimeSeriesTemplate.class.getName() + DatabaseType.TIME_SERIES + "-" + provider;
+    }
+
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/spi/TimeSeriesExtension.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/java/org/eclipse/jnosql/mapping/timeseries/spi/TimeSeriesExtension.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.spi;
+
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.AfterBeanDiscovery;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessProducer;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.DatabaseMetadata;
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.eclipse.jnosql.mapping.Databases;
+import org.eclipse.jnosql.mapping.timeseries.query.CustomRepositoryTimeSeriesBean;
+import org.eclipse.jnosql.mapping.timeseries.query.RepositoryTimeSeriesBean;
+import org.eclipse.jnosql.mapping.metadata.ClassScanner;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+
+
+/**
+ * Enables CDI integration for time-series mapping.
+ * <p>
+ * The extension discovers {@link DatabaseType#TIME_SERIES} managers and makes the corresponding
+ * {@code TimeSeriesTemplate}, Jakarta Data repositories, and custom repositories available for injection.
+ * Named managers are exposed through the provider declared in {@code @Database}.
+ * </p>
+ */
+public class TimeSeriesExtension implements Extension {
+
+    private static final Logger LOGGER = Logger.getLogger(TimeSeriesExtension.class.getName());
+
+    private final Set<DatabaseMetadata> databases = new HashSet<>();
+
+
+    <T, X extends DatabaseManager> void observes(@Observes final ProcessProducer<T, X> pp) {
+        Databases.addDatabase(pp, DatabaseType.TIME_SERIES, databases);
+    }
+
+
+    void onAfterBeanDiscovery(@Observes final AfterBeanDiscovery afterBeanDiscovery) {
+
+        ClassScanner scanner = ClassScanner.load();
+
+        Set<Class<?>> crudTypes = scanner.repositoriesStandard();
+
+        Set<Class<?>> customRepositories = scanner.customRepositories();
+
+        LOGGER.info(() -> String.format("Processing TimeSeries extension: %d databases crud %d found, custom repositories: %d",
+                databases.size(), crudTypes.size(), customRepositories.size()));
+        LOGGER.info(() -> "Processing repositories as a TimeSeries implementation: " + crudTypes);
+
+        databases.forEach(type -> {
+            if (!type.getProvider().isBlank()) {
+                final TemplateBean bean = new TemplateBean(type.getProvider());
+                afterBeanDiscovery.addBean(bean);
+            }
+        });
+
+        crudTypes.forEach(type -> {
+            if (!databases.contains(DatabaseMetadata.DEFAULT_TIME_SERIES)) {
+                afterBeanDiscovery.addBean(new RepositoryTimeSeriesBean<>(type, ""));
+            }
+            databases.forEach(database ->
+                afterBeanDiscovery.addBean(new RepositoryTimeSeriesBean<>(type, database.getProvider())));
+        });
+
+        customRepositories.forEach(type -> {
+            if (!databases.contains(DatabaseMetadata.DEFAULT_TIME_SERIES)) {
+                afterBeanDiscovery.addBean(new CustomRepositoryTimeSeriesBean<>(type, ""));
+            }
+            databases.forEach(database ->
+                    afterBeanDiscovery.addBean(new CustomRepositoryTimeSeriesBean<>(type, database.getProvider())));
+        });
+
+    }
+
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/resources/META-INF/beans.xml
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,21 @@
+<!--
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
+  ~   All rights reserved. This program and the accompanying materials
+  ~   are made available under the terms of the Eclipse Public License 2.0
+  ~   and Apache License v2.0 which accompanies this distribution.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+  ~
+  ~   You may elect to redistribute this code under either of these licenses.
+  ~
+  ~   Contributors:
+  ~
+  ~   Otavio Santana
+  -->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="annotated">
+</beans>

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/main/resources/META-INF/services/jakarta.enterprise.inject.spi.Extension
@@ -1,0 +1,15 @@
+#
+#  Copyright (c) 2026 Contributors to the Eclipse Foundation
+#   All rights reserved. This program and the accompanying materials
+#   are made available under the terms of the Eclipse Public License 2.0
+#   and Apache License v2.0 which accompanies this distribution.
+#   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+#   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#   You may elect to redistribute this code under either of these licenses.
+#
+#   Contributors:
+#
+#   Otavio Santana
+#
+org.eclipse.jnosql.mapping.timeseries.spi.TimeSeriesExtension

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/DefaultTimeSeriesTemplateProducerTest.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/DefaultTimeSeriesTemplateProducerTest.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries;
+
+import jakarta.inject.Inject;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.timeseries.spi.TimeSeriesExtension;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, EntityConverter.class, TimeSeriesTemplate.class})
+@AddPackages(MockProducer.class)
+@AddPackages(Reflections.class)
+@AddExtensions({ReflectionEntityMetadataExtension.class, TimeSeriesExtension.class})
+@DisplayName("TimeSeries template producer")
+class DefaultTimeSeriesTemplateProducerTest {
+
+    @Inject
+    private TimeSeriesTemplateProducer producer;
+
+
+    @Nested
+    @DisplayName("When creating a template")
+    class WhenTheTemplateCreation {
+
+        @Test
+        @DisplayName("Should require a database manager")
+        void shouldRequireDatabaseManager() {
+
+            // When / Then
+            assertThatNullPointerException().isThrownBy(() -> producer.apply(null));
+        }
+
+        @Test
+        @DisplayName("Should create a time-series template")
+        void shouldCreateTimeSeriesTemplate() {
+
+            // Given
+            var manager = Mockito.mock(DatabaseManager.class);
+
+            // When
+            TimeSeriesTemplate timeSeriesTemplate = producer.apply(manager);
+
+            // Then
+            assertThat(timeSeriesTemplate).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("When creating the CDI producer")
+    class WhenTheProducerCreation {
+
+        @Test
+        @DisplayName("Should expose a default constructor")
+        void shouldExposeDefaultConstructor() {
+
+            // When
+            TimeSeriesTemplateProducer.ProducerTimeSeriesTemplate template = new TimeSeriesTemplateProducer.ProducerTimeSeriesTemplate();
+
+            // Then
+            assertThat(template).isNotNull();
+        }
+    }
+
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/MockProducer.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/MockProducer.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries;
+
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.interceptor.Interceptor;
+import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.communication.semistructured.Element;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+import org.eclipse.jnosql.mapping.Database;
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+@ApplicationScoped
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION)
+public class MockProducer implements Supplier<DatabaseManager> {
+
+    @Produces
+    @Override
+    @Database(DatabaseType.TIME_SERIES)
+    public DatabaseManager get() {
+        CommunicationEntity entity = CommunicationEntity.of("Person");
+        entity.add(Element.of("name", "Default"));
+        entity.add(Element.of("age", 10));
+        DatabaseManager manager = mock(DatabaseManager.class);
+        when(manager.insert(Mockito.any(CommunicationEntity.class))).thenReturn(entity);
+        return manager;
+    }
+
+    @Produces
+    @Database(value = DatabaseType.TIME_SERIES, provider = "timeseriesRepositoryMock")
+    public DatabaseManager getTimeSeriesManagerMock() {
+        CommunicationEntity entity = CommunicationEntity.of("Person");
+        entity.add(Element.of("name", "timeseriesRepositoryMock"));
+        entity.add(Element.of("age", 10));
+        DatabaseManager manager = mock(DatabaseManager.class);
+        when(manager.insert(Mockito.any(CommunicationEntity.class))).thenReturn(entity);
+        when(manager.singleResult(Mockito.any(SelectQuery.class))).thenReturn(Optional.empty());
+        return manager;
+
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/TimeSeriesTemplateTest.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/TimeSeriesTemplateTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries;
+
+import jakarta.inject.Inject;
+import jakarta.nosql.Template;
+import org.eclipse.jnosql.mapping.Database;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.timeseries.spi.TimeSeriesExtension;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jnosql.mapping.DatabaseType.TIME_SERIES;
+
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, EntityConverter.class, TimeSeriesTemplate.class})
+@AddPackages(MockProducer.class)
+@AddPackages(Reflections.class)
+@AddExtensions({ReflectionEntityMetadataExtension.class, TimeSeriesExtension.class})
+@DisplayName("TimeSeries template")
+class TimeSeriesTemplateTest {
+
+    @Inject
+    private Template template;
+
+    @Inject
+    @Database(TIME_SERIES)
+    private Template qualifier;
+
+
+    @Nested
+    @DisplayName("When injecting templates")
+    class WhenTheTemplateInjection {
+
+        @Test
+        @DisplayName("Should inject the default template")
+        void shouldInjectDefaultTemplate() {
+
+            // Then
+            assertThat(template).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Should inject the qualified template")
+        void shouldInjectQualifiedTemplate() {
+
+            // Then
+            assertThat(qualifier).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("When creating a template")
+    class WhenTheTemplateCreation {
+
+        @Test
+        @DisplayName("Should expose a default constructor")
+        void shouldExposeDefaultConstructor() {
+
+            // When
+            DefaultTimeSeriesTemplate template = new DefaultTimeSeriesTemplate();
+
+            // Then
+            assertThat(template).isNotNull();
+        }
+    }
+
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/configuration/TimeSeriesConfigurationMock.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/configuration/TimeSeriesConfigurationMock.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.configuration;
+
+import org.eclipse.jnosql.communication.Settings;
+import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
+import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManagerFactory;
+import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+class TimeSeriesConfigurationMock implements DatabaseConfiguration {
+
+
+    @Override
+    public TimeSeriesManagerFactoryMock apply(Settings settings) {
+        return new TimeSeriesManagerFactoryMock(settings);
+    }
+
+    public record TimeSeriesManagerFactoryMock(Settings settings) implements DatabaseManagerFactory {
+
+        @Override
+            public TimeSeriesManagerMock apply(String database) {
+                return new TimeSeriesManagerMock(database);
+            }
+
+            @Override
+            public void close() {
+
+            }
+        }
+
+    public record TimeSeriesManagerMock(String name) implements DatabaseManager {
+
+        @Override
+        public CommunicationEntity insert(CommunicationEntity entity) {
+            return null;
+        }
+
+        @Override
+        public CommunicationEntity insert(CommunicationEntity entity, Duration ttl) {
+            return null;
+        }
+
+        @Override
+        public Iterable<CommunicationEntity> insert(Iterable<CommunicationEntity> entities) {
+            return null;
+        }
+
+        @Override
+        public Iterable<CommunicationEntity> insert(Iterable<CommunicationEntity> entities, Duration ttl) {
+            return null;
+        }
+
+        @Override
+        public CommunicationEntity update(CommunicationEntity entity) {
+            return null;
+        }
+
+        @Override
+        public Iterable<CommunicationEntity> update(Iterable<CommunicationEntity> entities) {
+            return null;
+        }
+
+        @Override
+        public void delete(DeleteQuery query) {
+
+        }
+
+        @Override
+        public Stream<CommunicationEntity> select(SelectQuery query) {
+            return null;
+        }
+
+        @Override
+        public long count(String entity) {
+            return 0;
+        }
+
+        @Override
+        public void close() {
+
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/configuration/TimeSeriesConfigurationMock2.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/configuration/TimeSeriesConfigurationMock2.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.configuration;
+
+import org.eclipse.jnosql.communication.Settings;
+import org.eclipse.jnosql.communication.semistructured.CommunicationEntity;
+import org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManagerFactory;
+import org.eclipse.jnosql.communication.semistructured.DeleteQuery;
+import org.eclipse.jnosql.communication.semistructured.SelectQuery;
+
+import java.time.Duration;
+import java.util.stream.Stream;
+
+public class TimeSeriesConfigurationMock2 implements DatabaseConfiguration {
+
+
+    @Override
+    public TimeSeriesManagerFactoryMock apply(Settings settings) {
+        return new TimeSeriesManagerFactoryMock(settings);
+    }
+
+    public record TimeSeriesManagerFactoryMock(Settings settings) implements DatabaseManagerFactory {
+
+        @Override
+            public TimeSeriesManagerMock apply(String database) {
+                return new TimeSeriesManagerMock(database);
+            }
+
+            @Override
+            public void close() {
+
+            }
+        }
+
+    public record TimeSeriesManagerMock(String name) implements DatabaseManager {
+
+        @Override
+        public CommunicationEntity insert(CommunicationEntity entity) {
+            return null;
+        }
+
+        @Override
+        public CommunicationEntity insert(CommunicationEntity entity, Duration ttl) {
+            return null;
+        }
+
+        @Override
+        public Iterable<CommunicationEntity> insert(Iterable<CommunicationEntity> entities) {
+            return null;
+        }
+
+        @Override
+        public Iterable<CommunicationEntity> insert(Iterable<CommunicationEntity> entities, Duration ttl) {
+            return null;
+        }
+
+        @Override
+        public CommunicationEntity update(CommunicationEntity entity) {
+            return null;
+        }
+
+        @Override
+        public Iterable<CommunicationEntity> update(Iterable<CommunicationEntity> entities) {
+            return null;
+        }
+
+        @Override
+        public void delete(DeleteQuery query) {
+
+        }
+
+        @Override
+        public Stream<CommunicationEntity> select(SelectQuery query) {
+            return null;
+        }
+
+        @Override
+        public long count(String entity) {
+            return 0;
+        }
+
+        @Override
+        public void close() {
+
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/configuration/TimeSeriesManagerSupplierTest.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/configuration/TimeSeriesManagerSupplierTest.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.configuration;
+
+import jakarta.data.exceptions.MappingException;
+import jakarta.inject.Inject;
+import org.eclipse.jnosql.communication.semistructured.DatabaseManager;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.timeseries.MockProducer;
+import org.eclipse.jnosql.mapping.timeseries.spi.TimeSeriesExtension;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.eclipse.jnosql.mapping.core.config.MappingConfigurations.TIME_SERIES_DATABASE;
+import static org.eclipse.jnosql.mapping.core.config.MappingConfigurations.TIME_SERIES_PROVIDER;
+
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, EntityConverter.class})
+@AddPackages(MockProducer.class)
+@AddPackages(Reflections.class)
+@AddExtensions({ReflectionEntityMetadataExtension.class, TimeSeriesExtension.class})
+@DisplayName("TimeSeries manager supplier")
+class TimeSeriesManagerSupplierTest {
+
+    @Inject
+    private TimeSeriesManagerSupplier supplier;
+
+    @BeforeEach
+    void beforeEach() {
+        System.clearProperty(TIME_SERIES_PROVIDER.get());
+        System.clearProperty(TIME_SERIES_DATABASE.get());
+    }
+
+    @Nested
+    @DisplayName("When resolving a time-series manager")
+    class WhenTheManagerResolution {
+
+        @Test
+        @DisplayName("Should use the configured provider")
+        void shouldUseConfiguredProvider() {
+
+            // Given
+            System.setProperty(TIME_SERIES_PROVIDER.get(), TimeSeriesConfigurationMock.class.getName());
+            System.setProperty(TIME_SERIES_DATABASE.get(), "database");
+
+            // When
+            DatabaseManager manager = supplier.get();
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(manager).isNotNull();
+                softly.assertThat(manager).isInstanceOf(TimeSeriesConfigurationMock.TimeSeriesManagerMock.class);
+            });
+        }
+
+        @Test
+        @DisplayName("Should use the default configuration when the provider is invalid")
+        void shouldUseDefaultConfigurationWhenProviderIsInvalid() {
+
+            // Given
+            System.setProperty(TIME_SERIES_PROVIDER.get(), Integer.class.getName());
+            System.setProperty(TIME_SERIES_DATABASE.get(), "database");
+
+            // When
+            DatabaseManager manager = supplier.get();
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(manager).isNotNull();
+                softly.assertThat(manager).isInstanceOf(TimeSeriesConfigurationMock2.TimeSeriesManagerMock.class);
+            });
+        }
+
+        @Test
+        @DisplayName("Should use the default configuration when no provider is configured")
+        void shouldUseDefaultConfigurationWhenNoProviderIsConfigured() {
+
+            // Given
+            System.setProperty(TIME_SERIES_DATABASE.get(), "database");
+
+            // When
+            DatabaseManager manager = supplier.get();
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(manager).isNotNull();
+                softly.assertThat(manager).isInstanceOf(TimeSeriesConfigurationMock2.TimeSeriesManagerMock.class);
+            });
+        }
+
+        @Test
+        @DisplayName("Should throw an exception when the database is missing")
+        void shouldThrowExceptionWhenDatabaseIsMissing() {
+
+            // When / Then
+            assertThatExceptionOfType(MappingException.class).isThrownBy(supplier::get);
+        }
+    }
+
+    @Nested
+    @DisplayName("When closing a time-series manager")
+    class WhenTheManagerClosing {
+
+        @Test
+        @DisplayName("Should close the manager")
+        void shouldCloseManager() {
+
+            // Given
+            DatabaseManager manager = Mockito.mock(DatabaseManager.class);
+
+            // When
+            supplier.close(manager);
+
+            // Then
+            Mockito.verify(manager).close();
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/entities/People.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/entities/People.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.entities;
+
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+
+
+@Repository
+public interface People {
+
+    @Insert
+    Person insert(Person person);
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/entities/Person.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/entities/Person.java
@@ -1,0 +1,113 @@
+/*
+ *   Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *    All rights reserved. This program and the accompanying materials
+ *    are made available under the terms of the Eclipse Public License 2.0
+ *    and Apache License v2.0 which accompanies this distribution.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *    You may elect to redistribute this code under either of these licenses.
+ *
+ *    Contributors:
+ *
+ *    Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.entities;
+
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+import jakarta.nosql.MappedSuperclass;
+
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@MappedSuperclass
+public class Person {
+
+    @Id
+    private long id;
+
+    @Column
+    private String name;
+
+    @Column
+    private int age;
+
+    @Column
+    private List<String> phones;
+
+    private String ignore;
+
+
+    public long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public List<String> getPhones() {
+        return phones;
+    }
+
+    public String getIgnore() {
+        return ignore;
+    }
+
+    public boolean isAdult() {
+        return age > 21;
+    }
+
+    Person() {
+    }
+
+    Person(long id, String name, int age, List<String> phones, String ignore) {
+        this.id = id;
+        this.name = name;
+        this.age = age;
+        this.phones = phones;
+        this.ignore = ignore;
+    }
+
+    @Override
+    public String toString() {
+        return  "Person{" + "id=" + id +
+                ", name='" + name + '\'' +
+                ", age=" + age +
+                ", phones=" + phones +
+                ", ignore='" + ignore + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Person person = (Person) o;
+        return id == person.id &&
+                age == person.age &&
+                Objects.equals(name, person.name) &&
+                Objects.equals(phones, person.phones);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, age, phones, ignore);
+    }
+
+    public static PersonBuilder builder() {
+        return new PersonBuilder();
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/entities/PersonBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/entities/PersonBuilder.java
@@ -1,0 +1,60 @@
+/*
+ *   Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *    All rights reserved. This program and the accompanying materials
+ *    are made available under the terms of the Eclipse Public License 2.0
+ *    and Apache License v2.0 which accompanies this distribution.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *    You may elect to redistribute this code under either of these licenses.
+ *
+ *    Contributors:
+ *
+ *    Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.entities;
+
+import java.util.List;
+
+public class PersonBuilder {
+    private long id;
+    private String name;
+    private int age;
+    private List<String> phones;
+    private String ignore;
+
+    public PersonBuilder withId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public PersonBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public PersonBuilder withAge() {
+        this.age = 10;
+        return this;
+    }
+
+    public PersonBuilder withAge(int age) {
+        this.age = age;
+        return this;
+    }
+
+
+    public PersonBuilder withPhones(List<String> phones) {
+        this.phones = phones;
+        return this;
+    }
+
+    public PersonBuilder withIgnore() {
+        this.ignore = "Just Ignore";
+        return this;
+    }
+
+    public Person build() {
+        return new Person(id, name, age, phones, ignore);
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/entities/PersonRepository.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/entities/PersonRepository.java
@@ -1,0 +1,23 @@
+/*
+ *   Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *    All rights reserved. This program and the accompanying materials
+ *    are made available under the terms of the Eclipse Public License 2.0
+ *    and Apache License v2.0 which accompanies this distribution.
+ *    The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *    and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *    You may elect to redistribute this code under either of these licenses.
+ *
+ *    Contributors:
+ *
+ *    Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.entities;
+
+
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface PersonRepository extends BasicRepository<Person, Long> {
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/query/TimeSeriesRepositoryExtensionTest.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/query/TimeSeriesRepositoryExtensionTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.query;
+
+import jakarta.inject.Inject;
+import org.eclipse.jnosql.mapping.Database;
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.timeseries.TimeSeriesTemplate;
+import org.eclipse.jnosql.mapping.timeseries.MockProducer;
+import org.eclipse.jnosql.mapping.timeseries.entities.Person;
+import org.eclipse.jnosql.mapping.timeseries.entities.PersonRepository;
+import org.eclipse.jnosql.mapping.timeseries.spi.TimeSeriesExtension;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.eclipse.jnosql.mapping.semistructured.query.SemiStructuredRepositoryProxy;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, EntityConverter.class, SemiStructuredRepositoryProxy.class})
+@AddPackages({MockProducer.class, TimeSeriesTemplate.class, Reflections.class})
+@AddExtensions({ReflectionEntityMetadataExtension.class, TimeSeriesExtension.class})
+@DisplayName("TimeSeries repository extension")
+class TimeSeriesRepositoryExtensionTest {
+
+    @Inject
+    @Database(value = DatabaseType.TIME_SERIES)
+    private PersonRepository repository;
+
+    @Inject
+    @Database(value = DatabaseType.TIME_SERIES, provider = "timeseriesRepositoryMock")
+    private PersonRepository repositoryMock;
+
+    @Nested
+    @DisplayName("When injecting time-series repositories")
+    class WhenTheRepositoryInjection {
+
+        @Test
+        @DisplayName("Should inject the default repository")
+        void shouldInjectDefaultRepository() {
+
+            // When
+            Person person = repository.save(Person.builder().build());
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(repository).isNotNull();
+                softly.assertThat(person.getName()).isEqualTo("Default");
+            });
+        }
+
+        @Test
+        @DisplayName("Should inject the provider-specific repository")
+        void shouldInjectProviderRepository() {
+
+            // When
+            Person person = repositoryMock.save(Person.builder().build());
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(repositoryMock).isNotNull();
+                softly.assertThat(person.getName()).isEqualTo("timeseriesRepositoryMock");
+            });
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/spi/TimeSeriesCustomExtensionTest.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/spi/TimeSeriesCustomExtensionTest.java
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.spi;
+
+import jakarta.inject.Inject;
+import org.eclipse.jnosql.mapping.Database;
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.timeseries.TimeSeriesTemplate;
+import org.eclipse.jnosql.mapping.timeseries.MockProducer;
+import org.eclipse.jnosql.mapping.timeseries.entities.People;
+import org.eclipse.jnosql.mapping.timeseries.entities.Person;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, EntityConverter.class, TimeSeriesTemplate.class})
+@AddPackages(MockProducer.class)
+@AddPackages(Reflections.class)
+@AddExtensions({ReflectionEntityMetadataExtension.class, TimeSeriesExtension.class})
+@DisplayName("TimeSeries custom extension")
+class TimeSeriesCustomExtensionTest {
+
+    @Inject
+    @Database(value = DatabaseType.TIME_SERIES)
+    private People people;
+
+    @Inject
+    @Database(value = DatabaseType.TIME_SERIES, provider = "timeseriesRepositoryMock")
+    private People pepoleMock;
+
+    @Inject
+    private People repository;
+
+    @Nested
+    @DisplayName("When injecting custom repositories")
+    class WhenTheCustomRepositoryInjection {
+
+        @Test
+        @DisplayName("Should inject the default custom repository")
+        void shouldInjectDefaultCustomRepository() {
+
+            // When
+            Person person = people.insert(Person.builder().build());
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(people).isNotNull();
+                softly.assertThat(person).isNotNull();
+                softly.assertThat(person.getName()).isEqualTo("Default");
+            });
+        }
+
+        @Test
+        @DisplayName("Should inject the provider-specific custom repository")
+        void shouldInjectProviderCustomRepository() {
+
+            // When
+            Person person = pepoleMock.insert(Person.builder().build());
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(pepoleMock).isNotNull();
+                softly.assertThat(person).isNotNull();
+                softly.assertThat(person.getName()).isEqualTo("timeseriesRepositoryMock");
+            });
+        }
+
+        @Test
+        @DisplayName("Should inject the unqualified custom repository")
+        void shouldInjectUnqualifiedCustomRepository() {
+
+            // When
+            Person person = repository.insert(Person.builder().build());
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(repository).isNotNull();
+                softly.assertThat(person).isNotNull();
+                softly.assertThat(person.getName()).isEqualTo("Default");
+            });
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/spi/TimeSeriesCustomExtensionTest.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/spi/TimeSeriesCustomExtensionTest.java
@@ -49,7 +49,7 @@ class TimeSeriesCustomExtensionTest {
 
     @Inject
     @Database(value = DatabaseType.TIME_SERIES, provider = "timeseriesRepositoryMock")
-    private People pepoleMock;
+    private People peopleMock;
 
     @Inject
     private People repository;
@@ -78,11 +78,11 @@ class TimeSeriesCustomExtensionTest {
         void shouldInjectProviderCustomRepository() {
 
             // When
-            Person person = pepoleMock.insert(Person.builder().build());
+            Person person = peopleMock.insert(Person.builder().build());
 
             // Then
             assertSoftly(softly -> {
-                softly.assertThat(pepoleMock).isNotNull();
+                softly.assertThat(peopleMock).isNotNull();
                 softly.assertThat(person).isNotNull();
                 softly.assertThat(person.getName()).isEqualTo("timeseriesRepositoryMock");
             });

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/spi/TimeSeriesExtensionTest.java
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/java/org/eclipse/jnosql/mapping/timeseries/spi/TimeSeriesExtensionTest.java
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Otavio Santana
+ */
+package org.eclipse.jnosql.mapping.timeseries.spi;
+
+import jakarta.inject.Inject;
+import org.eclipse.jnosql.mapping.Database;
+import org.eclipse.jnosql.mapping.DatabaseType;
+import org.eclipse.jnosql.mapping.core.Converters;
+import org.eclipse.jnosql.mapping.timeseries.TimeSeriesTemplate;
+import org.eclipse.jnosql.mapping.timeseries.MockProducer;
+import org.eclipse.jnosql.mapping.timeseries.entities.Person;
+import org.eclipse.jnosql.mapping.timeseries.entities.PersonRepository;
+import org.eclipse.jnosql.mapping.reflection.Reflections;
+import org.eclipse.jnosql.mapping.reflection.spi.ReflectionEntityMetadataExtension;
+import org.eclipse.jnosql.mapping.semistructured.EntityConverter;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+
+@EnableAutoWeld
+@AddPackages(value = {Converters.class, EntityConverter.class, TimeSeriesTemplate.class})
+@AddPackages(MockProducer.class)
+@AddPackages(Reflections.class)
+@AddExtensions({ReflectionEntityMetadataExtension.class, TimeSeriesExtension.class})
+@DisplayName("TimeSeries extension")
+class TimeSeriesExtensionTest {
+
+
+    @Inject
+    @Database(value = DatabaseType.TIME_SERIES)
+    private PersonRepository repository;
+
+    @Inject
+    @Database(value = DatabaseType.TIME_SERIES, provider = "timeseriesRepositoryMock")
+    private PersonRepository repositoryMock;
+
+    @Inject
+    @Database(value = DatabaseType.TIME_SERIES, provider = "timeseriesRepositoryMock")
+    private TimeSeriesTemplate templateMock;
+
+    @Inject
+    private TimeSeriesTemplate template;
+
+    @Nested
+    @DisplayName("When injecting time-series repositories")
+    class WhenTheRepositoryInjection {
+
+        @Test
+        @DisplayName("Should inject the default repository")
+        void shouldInjectDefaultRepository() {
+
+            // When
+            Person person = repository.save(Person.builder().build());
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(repository).isNotNull();
+                softly.assertThat(person.getName()).isEqualTo("Default");
+            });
+        }
+
+        @Test
+        @DisplayName("Should inject the provider-specific repository")
+        void shouldInjectProviderRepository() {
+
+            // When
+            Person person = repositoryMock.save(Person.builder().build());
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(repositoryMock).isNotNull();
+                softly.assertThat(person.getName()).isEqualTo("timeseriesRepositoryMock");
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("When injecting time-series templates")
+    class WhenTheTemplateInjection {
+
+        @Test
+        @DisplayName("Should inject default and provider-specific templates")
+        void shouldInjectTemplates() {
+
+            // Then
+            assertSoftly(softly -> {
+                softly.assertThat(templateMock).isNotNull();
+                softly.assertThat(template).isNotNull();
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("When resolving time-series repositories")
+    class WhenTheRepositoryResolution {
+
+        @Test
+        @DisplayName("Should expose default and provider-specific repositories")
+        void shouldExposeRepositories() {
+
+            // Then
+            assertThat(repository).isNotNull();
+            assertThat(repositoryMock).isNotNull();
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/resources/META-INF/beans.xml
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,21 @@
+<!--
+  ~  Copyright (c) 2022 Contributors to the Eclipse Foundation
+  ~   All rights reserved. This program and the accompanying materials
+  ~   are made available under the terms of the Eclipse Public License 2.0
+  ~   and Apache License v2.0 which accompanies this distribution.
+  ~   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+  ~   and the Apache License v2.0 is available at https://www.apache.org/licenses/LICENSE-2.0.
+  ~
+  ~   You may elect to redistribute this code under either of these licenses.
+  ~
+  ~   Contributors:
+  ~
+  ~   Otavio Santana
+  -->
+
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+		http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="annotated">
+</beans> 

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/resources/META-INF/microprofile-config.properties
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,5 @@
+time-series=time-series
+timeseries.settings.key=value
+timeseries.settings.key2=value2
+timeseries.database=database
+timeseries.provider=org.eclipse.jnosql.mapping.timeseries.configuration.TimeSeriesConfigurationMock

--- a/jnosql-mapping/jnosql-mapping-timeseries/src/test/resources/META-INF/services/org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration
+++ b/jnosql-mapping/jnosql-mapping-timeseries/src/test/resources/META-INF/services/org.eclipse.jnosql.communication.semistructured.DatabaseConfiguration
@@ -1,0 +1,1 @@
+org.eclipse.jnosql.mapping.timeseries.configuration.TimeSeriesConfigurationMock2

--- a/jnosql-mapping/pom.xml
+++ b/jnosql-mapping/pom.xml
@@ -38,6 +38,7 @@
         <module>jnosql-mapping-semistructured</module>
         <module>jnosql-mapping-graph</module>
         <module>jnosql-mapping-document</module>
+        <module>jnosql-mapping-timeseries</module>
         <module>jnosql-mapping-column</module>
         <module>jnosql-mapping-key-value</module>
     </modules>


### PR DESCRIPTION
This pull request introduces first-class support for time-series databases in Eclipse JNoSQL. It adds a new `jnosql-mapping-timeseries` module, updates core APIs to support the new database type, and extends documentation and configuration to guide users in integrating time-series capabilities. The implementation ensures that time-series support is consistent with existing database types, including CDI, repository, and configuration integration.

**Time-Series Database Support**

* Added a new module, `jnosql-mapping-timeseries`, providing the `TimeSeriesTemplate` class and integration with CDI, repository, and configuration mechanisms. [[1]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93R28) [[2]](diffhunk://#diff-62b27d9974903cbd0594ae009cac968565f9f6dc4d66a6e1486fe6c5fe851069R1-R38) [[3]](diffhunk://#diff-949da84115f4ac8da5885129f0f3697581feaf1089f86f0b2c64579fb6550e50R1-R95)
* Extended the public API (`DatabaseType`, `DatabaseMetadata`, `DatabaseQualifier`) to support the `TIME_SERIES` database type, including default qualifiers and metadata instances. [[1]](diffhunk://#diff-fb72007483f663be67048926249ac91fac2d00f58ec2a56d4bab2c84d662afc7R53-R57) [[2]](diffhunk://#diff-c306d3fe621f31439996dbb15cd8c887b28ee517fc498579283e203ea968a750L26-R26) [[3]](diffhunk://#diff-c306d3fe621f31439996dbb15cd8c887b28ee517fc498579283e203ea968a750R52-R56) [[4]](diffhunk://#diff-6fa20f51b4801a79c66f2ad51f58db938db1ab34d6bee6b4b2804b5f6106944aR27) [[5]](diffhunk://#diff-6fa20f51b4801a79c66f2ad51f58db938db1ab34d6bee6b4b2804b5f6106944aR43-R44) [[6]](diffhunk://#diff-6fa20f51b4801a79c66f2ad51f58db938db1ab34d6bee6b4b2804b5f6106944aR167-R192)

**Repository and Configuration Integration**

* Updated repository bean logic to recognize and handle the `TIME_SERIES` type and provider, ensuring seamless CDI and repository support. [[1]](diffhunk://#diff-8ee75df5a02fabe72d87244185e11fe263c057eb7998773f5a37080d8d6321dbR72) [[2]](diffhunk://#diff-8ee75df5a02fabe72d87244185e11fe263c057eb7998773f5a37080d8d6321dbR82)
* Added new configuration keys for time-series database and provider to the mapping configuration API and corresponding tests. [[1]](diffhunk://#diff-4fa0d5360bdcc517982d4cbd4082e2652fd3d65133d15bd02b6f844d41f88553R41-R49) [[2]](diffhunk://#diff-eccad4b97e2e3756259caca93a25436e31abe0bbbb399de5d1d123afe165e985R61-R72)

**Documentation Updates**

* Updated the `README.adoc` and `CHANGELOG.adoc` to document time-series support, including usage examples, configuration, and integration instructions. [[1]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L23-R23) [[2]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L147-R155) [[3]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124R477-R590) [[4]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L565-R680) [[5]](diffhunk://#diff-bc34fd17a77bda3e2cbef0e783a3ee58a970a9bb65f9476cfdd27c8e78831a93R28)

**Testing**

* Added comprehensive unit tests for the new time-series qualifier logic to ensure correctness and robustness. [[1]](diffhunk://#diff-b2fe6f535d68c97c41fd685cf6ad428845d89d40de1bb191e98efbac4a549d0fR25) [[2]](diffhunk://#diff-b2fe6f535d68c97c41fd685cf6ad428845d89d40de1bb191e98efbac4a549d0fR167-R200)

Ref: https://github.com/eclipse-jnosql/jnosql/issues/718
