### PR TITLE
docs: use timestamp as time-series entity id

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -497,13 +497,10 @@ Map a time-series record as a Jakarta NoSQL entity:
 public class SensorReading {
 
     @Id
-    private String id;
+    private Instant timestamp;
 
     @Column
     private String sensor;
-
-    @Column
-    private Instant timestamp;
 
     @Column
     private double value;
@@ -520,15 +517,14 @@ Inject `TimeSeriesTemplate` to perform persistence and query operations:
 private TimeSeriesTemplate template;
 
 SensorReading reading = new SensorReading(
-        UUID.randomUUID().toString(),
-        "sensor-1",
         Instant.now(),
+        "sensor-1",
         21.5);
 
 template.insert(reading);
 
 Optional<SensorReading> result =
-        template.find(SensorReading.class, reading.getId());
+        template.find(SensorReading.class, reading.getTimestamp());
 
 List<SensorReading> readings = template.select(SensorReading.class)
         .where("sensor").eq("sensor-1")


### PR DESCRIPTION
This pull request updates how time-series records are identified and persisted in the example code. The main change is switching the primary key of the `SensorReading` entity from a string-based `id` field to using the `timestamp` field as the identifier. This affects both the entity mapping and how records are inserted and queried.

**Entity mapping update:**

* Changed the `@Id` field in `SensorReading` from `String id` to `Instant timestamp`, making the timestamp the primary key.

**Persistence and querying adjustments:**

* Updated the construction of `SensorReading` objects and related persistence/query operations to use `timestamp` as the identifier instead of a generated string `id`.