### PR TITLE
Migrate service discovery consumers to ServiceDiscovery

### DIFF
--- a/jnosql-communication/jnosql-communication-core/src/main/java/module-info.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/module-info.java
@@ -12,11 +12,13 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  *
  */
 module org.eclipse.jnosql.communication.core {
     requires jakarta.json;
     exports org.eclipse.jnosql.communication;
+    exports org.eclipse.jnosql.communication.util;
     opens org.eclipse.jnosql.communication;
     opens org.eclipse.jnosql.communication.reader;
     opens org.eclipse.jnosql.communication.writer;

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/TypeReferenceReaderDecorator.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/TypeReferenceReaderDecorator.java
@@ -12,6 +12,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  *
  */
 package org.eclipse.jnosql.communication;
@@ -19,7 +20,7 @@ package org.eclipse.jnosql.communication;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 
 /**
  * Decorators of all {@link TypeReferenceReader}
@@ -33,9 +34,9 @@ public final class TypeReferenceReaderDecorator implements TypeReferenceReader {
     private final List<TypeReferenceReader> readers = new ArrayList<>();
 
     {
-        readers.addAll(ServiceLoader.load(TypeReferenceReader.class).stream()
-                .map(ServiceLoader.Provider::get)
-                .toList());
+        ServiceDiscovery.of(TypeReferenceReader.class, TypeReferenceReader.class)
+                .all()
+                .forEach(readers::add);
     }
 
     /**

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ValueReaderDecorator.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ValueReaderDecorator.java
@@ -12,6 +12,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  *
  */
 package org.eclipse.jnosql.communication;
@@ -21,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -37,9 +38,9 @@ public final class ValueReaderDecorator implements ValueReader {
     private final List<ValueReader> readers = new ArrayList<>();
 
     {
-        readers.addAll(ServiceLoader.load(ValueReader.class).stream()
-                .map(ServiceLoader.Provider::get)
-                .toList());
+        ServiceDiscovery.of(ValueReader.class, ValueReader.class)
+                .all()
+                .forEach(readers::add);
     }
 
     /**

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ValueWriterDecorator.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/ValueWriterDecorator.java
@@ -12,15 +12,15 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  *
  */
 
 package org.eclipse.jnosql.communication;
 
-
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.ServiceLoader;
 
 /**
  * Decorators of all {@link ValueWriter} supported by Diana
@@ -36,7 +36,9 @@ public final class ValueWriterDecorator<T, S> implements ValueWriter<T, S> {
     private final List<ValueWriter> writers = new ArrayList<>();
 
     {
-        ServiceLoader.load(ValueWriter.class).forEach(writers::add);
+        ServiceDiscovery.of(ValueWriter.class, ValueWriter.class)
+                .all()
+                .forEach(writers::add);
     }
 
     private ValueWriterDecorator() {

--- a/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/util/ServiceDiscovery.java
+++ b/jnosql-communication/jnosql-communication-core/src/main/java/org/eclipse/jnosql/communication/util/ServiceDiscovery.java
@@ -1,0 +1,138 @@
+/*
+ *
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at
+ *   https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Mohan Lal
+ *
+ */
+package org.eclipse.jnosql.communication.util;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+/**
+ * A lazily initialized handle to service providers of a given type.
+ *
+ * <p>The thread context class loader (TCCL) is tried first. When it cannot
+ * discover a provider, the class loader of the reference class is used as a
+ * fallback. This supports environments where the context class loader and
+ * the class loader that loaded the API classes are different, such as a
+ * Quarkus/Vert.x event-loop thread whose context class loader does not see
+ * the application's {@code META-INF/services} entries.</p>
+ *
+ * <p>An instance lazily discovers and resolves the providers as a
+ * {@code List}. Discovery runs at most once per instance; subsequent calls
+ * to {@link #first()} and {@link #all()} reuse the retained list rather
+ * than invoking {@link ServiceLoader} again. This class does not maintain a
+ * global cache of providers or class loaders; the lifecycle of a
+ * {@code ServiceDiscovery} instance belongs to its caller.</p>
+ *
+ * <p>This abstraction is not suitable for service lookups that must execute
+ * from within a caller's own named JPMS module. Such call sites may need to
+ * invoke {@link ServiceLoader} directly so that the caller module's
+ * {@code uses} declaration is honored.</p>
+ *
+ * @param <T> the service type
+ */
+public final class ServiceDiscovery<T> {
+
+    private final Class<T> service;
+    private final Class<?> referenceClass;
+
+    private List<T> services;
+
+    private ServiceDiscovery(
+            Class<T> service,
+            Class<?> referenceClass) {
+        this.service = Objects.requireNonNull(service, "service is required");
+        this.referenceClass = Objects.requireNonNull(
+                referenceClass, "referenceClass is required");
+    }
+
+    /**
+     * Creates a new service discovery structure.
+     *
+     * @param service the service type
+     * @param referenceClass a class whose class loader is used as a fallback
+     * @param <T> the service type
+     * @return a new {@code ServiceDiscovery} instance
+     * @throws NullPointerException if {@code service} or
+     *         {@code referenceClass} is {@code null}
+     */
+    public static <T> ServiceDiscovery<T> of(
+            Class<T> service,
+            Class<?> referenceClass) {
+        return new ServiceDiscovery<>(service, referenceClass);
+    }
+
+    /**
+     * Returns the first available implementation of this discovery's service
+     * type.
+     *
+     * <p>Discovery runs lazily on first access and is reused by subsequent
+     * calls.</p>
+     *
+     * @return the first available service implementation, or an empty
+     *         optional when no implementation is available
+     */
+    public Optional<T> first() {
+        List<T> found = services();
+        return found.isEmpty() ? Optional.empty() : Optional.of(found.get(0));
+    }
+
+    /**
+     * Returns every available implementation visible through this
+     * discovery's selected class loader (see {@link #first()} for how the
+     * loader is selected). Providers visible only through the other,
+     * non-selected class loader are not included — the two are never
+     * merged.
+     *
+     * @return every available service implementation found through the
+     *         selected class loader; empty when none are found
+     */
+    public List<T> all() {
+        return services();
+    }
+
+    private synchronized List<T> services() {
+        if (services == null) {
+            services = discover();
+        }
+        return services;
+    }
+
+    private List<T> discover() {
+        ClassLoader contextClassLoader =
+                Thread.currentThread().getContextClassLoader();
+
+        if (contextClassLoader != null) {
+            List<T> discovered = ServiceLoader.load(service, contextClassLoader)
+                    .stream()
+                    .map(ServiceLoader.Provider::get)
+                    .toList();
+
+            if (!discovered.isEmpty()) {
+                return discovered;
+            }
+        }
+
+        ClassLoader referenceClassLoader = referenceClass.getClassLoader();
+
+        return ServiceLoader.load(service, referenceClassLoader)
+                .stream()
+                .map(ServiceLoader.Provider::get)
+                .toList();
+    }
+}

--- a/jnosql-communication/jnosql-communication-core/src/test/java/org/eclipse/jnosql/communication/util/ServiceDiscoveryTest.java
+++ b/jnosql-communication/jnosql-communication-core/src/test/java/org/eclipse/jnosql/communication/util/ServiceDiscoveryTest.java
@@ -1,0 +1,282 @@
+/*
+ *
+ *  Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License 2.0
+ *   and Apache License v2.0 which accompanies this distribution.
+ *   The Eclipse Public License is available at https://www.eclipse.org/legal/epl-2.0
+ *   and the Apache License v2.0 is available at
+ *   https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ *   You may elect to redistribute this code under either of these licenses.
+ *
+ *   Contributors:
+ *
+ *   Mohan Lal
+ *
+ */
+package org.eclipse.jnosql.communication.util;
+
+import org.eclipse.jnosql.communication.TypeReferenceReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class ServiceDiscoveryTest {
+
+    private final ClassLoader originalClassLoader =
+            Thread.currentThread().getContextClassLoader();
+
+    @AfterEach
+    void restoreContextClassLoader() {
+        Thread.currentThread().setContextClassLoader(originalClassLoader);
+    }
+
+    @Nested
+    @DisplayName("When loading a provider")
+    class WhenTheProviderLoading {
+
+        @Test
+        @DisplayName("Should return a provider from the context class loader")
+        void shouldLoadUsingContextClassLoader() {
+            // Given
+            var service = TypeReferenceReader.class;
+            var referenceClass = TypeReferenceReader.class;
+            Thread.currentThread().setContextClassLoader(
+                    TypeReferenceReader.class.getClassLoader());
+
+            // When
+            Optional<TypeReferenceReader> result =
+                    ServiceDiscovery.of(service, referenceClass).first();
+
+            // Then
+            assertThat(result)
+                    .as("provider discovered through the context class loader")
+                    .isPresent();
+        }
+
+        @Test
+        @DisplayName("Should fall back to the reference class loader when the context class loader has no provider")
+        void shouldFallBackToReferenceClassLoaderWhenContextCannotFindProvider() {
+            // Given
+            var service = TypeReferenceReader.class;
+            var referenceClass = TypeReferenceReader.class;
+            Thread.currentThread().setContextClassLoader(new ClassLoader(null) {
+            });
+
+            // When
+            Optional<TypeReferenceReader> result =
+                    ServiceDiscovery.of(service, referenceClass).first();
+
+            // Then
+            assertThat(result)
+                    .as("provider discovered through the reference class loader")
+                    .isPresent();
+        }
+
+        @Test
+        @DisplayName("Should fall back to the reference class loader when the context class loader is null")
+        void shouldFallBackToReferenceClassLoaderWhenContextClassLoaderIsNull() {
+            // Given
+            var service = TypeReferenceReader.class;
+            var referenceClass = TypeReferenceReader.class;
+            Thread.currentThread().setContextClassLoader(null);
+
+            // When
+            Optional<TypeReferenceReader> result =
+                    ServiceDiscovery.of(service, referenceClass).first();
+
+            // Then
+            assertThat(result)
+                    .as("provider discovered through the reference class loader")
+                    .isPresent();
+        }
+
+        @Test
+        @DisplayName("Should return an empty optional when neither class loader provides a provider")
+        void shouldReturnEmptyWhenNoProviderExists() {
+            // Given
+            var emptyClassLoader = new EmptyServicesClassLoader();
+            Class<?> referenceClass = emptyClassLoader.loadMarker();
+            Thread.currentThread().setContextClassLoader(emptyClassLoader);
+            var service = TypeReferenceReader.class;
+
+            // When
+            Optional<TypeReferenceReader> result =
+                    ServiceDiscovery.of(service, referenceClass).first();
+
+            // Then
+            assertThat(result)
+                    .as("no provider is visible from either class loader")
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should return an empty optional when the context and reference class loaders are the same")
+        void shouldReturnEmptyWhenContextAndReferenceClassLoadersAreTheSame() {
+            // Given
+            var emptyClassLoader = new EmptyServicesClassLoader();
+            Class<?> referenceClass = emptyClassLoader.loadMarker();
+            Thread.currentThread().setContextClassLoader(emptyClassLoader);
+            var service = TypeReferenceReader.class;
+
+            // When
+            Optional<TypeReferenceReader> result =
+                    ServiceDiscovery.of(service, referenceClass).first();
+
+            // Then
+            assertThat(result)
+                    .as("no provider is visible when both loaders are empty")
+                    .isEmpty();
+        }
+    }
+
+    /**
+     * A class loader that defines its own copy of {@link Marker} directly
+     * (rather than delegating to its parent), and reports no resources for
+     * any {@code META-INF/services} provider-configuration file. Used to
+     * deterministically force the "no provider found" outcome of
+     * {@link ServiceDiscovery#first()} independent of ambient providers.
+     */
+    private static final class EmptyServicesClassLoader extends ClassLoader {
+
+        EmptyServicesClassLoader() {
+            super(null);
+        }
+
+        Class<?> loadMarker() {
+            try {
+                String path = Marker.class.getName().replace('.', '/') + ".class";
+                byte[] bytes;
+                try (var in = EmptyServicesClassLoader.class.getClassLoader()
+                        .getResourceAsStream(path)) {
+                    bytes = Objects.requireNonNull(
+                                    in, "Marker class bytes not found")
+                            .readAllBytes();
+                }
+                return defineClass(
+                        Marker.class.getName(), bytes, 0, bytes.length);
+            } catch (java.io.IOException e) {
+                throw new IllegalStateException(
+                        "Unable to define Marker for test", e);
+            }
+        }
+
+        @Override
+        protected java.util.Enumeration<java.net.URL> findResources(
+                String name) {
+            return java.util.Collections.emptyEnumeration();
+        }
+
+        @Override
+        protected java.net.URL findResource(String name) {
+            return null;
+        }
+    }
+
+    /**
+     * A no-op class redefined by {@link EmptyServicesClassLoader} so that
+     * its {@code getClassLoader()} reports that isolated loader.
+     */
+    private static final class Marker {
+    }
+
+    @Nested
+    @DisplayName("When validating the discovery")
+    class WhenTheValidation {
+
+        @Test
+        @DisplayName("Should reject a null service type")
+        void shouldRejectNullService() {
+            // Given
+            Class<TypeReferenceReader> service = null;
+            var referenceClass = TypeReferenceReader.class;
+
+            // When / Then
+            assertThatNullPointerException()
+                    .isThrownBy(() ->
+                            ServiceDiscovery.of(service, referenceClass))
+                    .withMessage("service is required");
+        }
+
+        @Test
+        @DisplayName("Should reject a null reference class")
+        void shouldRejectNullReferenceClass() {
+            // Given
+            var service = TypeReferenceReader.class;
+            Class<?> referenceClass = null;
+
+            // When / Then
+            assertThatNullPointerException()
+                    .isThrownBy(() ->
+                            ServiceDiscovery.of(service, referenceClass))
+                    .withMessage("referenceClass is required");
+        }
+    }
+
+    @Nested
+    @DisplayName("When loading all providers")
+    class WhenTheAllProviderLoading {
+
+        @Test
+        @DisplayName("Should return every provider from the context class loader")
+        void shouldLoadAllUsingContextClassLoader() {
+            // Given
+            var service = TypeReferenceReader.class;
+            var referenceClass = TypeReferenceReader.class;
+            Thread.currentThread().setContextClassLoader(
+                    TypeReferenceReader.class.getClassLoader());
+
+            // When
+            var result = ServiceDiscovery.of(service, referenceClass).all();
+
+            // Then
+            assertThat(result)
+                    .as("providers discovered through the context class loader")
+                    .isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("Should return an empty list when neither class loader provides a provider")
+        void shouldReturnEmptyListWhenNoProviderExists() {
+            // Given
+            var emptyClassLoader = new EmptyServicesClassLoader();
+            Class<?> referenceClass = emptyClassLoader.loadMarker();
+            Thread.currentThread().setContextClassLoader(emptyClassLoader);
+            var service = TypeReferenceReader.class;
+
+            // When
+            var result = ServiceDiscovery.of(service, referenceClass).all();
+
+            // Then
+            assertThat(result)
+                    .as("no providers are visible from either class loader")
+                    .isEmpty();
+        }
+
+        @Test
+        @DisplayName("Should fall back to the reference class loader when the context class loader has no providers")
+        void shouldFallBackToReferenceClassLoaderForAll() {
+            // Given
+            var service = TypeReferenceReader.class;
+            var referenceClass = TypeReferenceReader.class;
+            Thread.currentThread().setContextClassLoader(new ClassLoader(null) {
+            });
+
+            // When
+            var result = ServiceDiscovery.of(service, referenceClass).all();
+
+            // Then
+            assertThat(result)
+                    .as("providers discovered through the reference class loader")
+                    .isNotEmpty();
+        }
+    }
+}

--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ClassConverter.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ClassConverter.java
@@ -11,12 +11,13 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  */
 package org.eclipse.jnosql.mapping.metadata;
 
 
 
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 import java.util.function.Function;
 
 /**
@@ -37,9 +38,12 @@ import java.util.function.Function;
  */
 public interface ClassConverter extends Function<Class<?>, EntityMetadata> {
 
-    ClassConverter INSTANCE = ServiceLoader.load(ClassConverter.class)
-            .findFirst()
-            .orElseThrow(() -> new MetadataException("No implementation of ClassConverter found via ServiceLoader"));
+    ClassConverter INSTANCE = ServiceDiscovery
+            .of(ClassConverter.class, ClassConverter.class)
+            .first()
+            .orElseThrow(() ->
+                    new MetadataException(
+                            "No implementation of ClassConverter found via ServiceDiscovery"));
 
     /**
      * Loads and returns an instance of the {@link ClassScanner} implementation using the ServiceLoader mechanism.

--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ClassScanner.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ClassScanner.java
@@ -11,13 +11,14 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  */
 package org.eclipse.jnosql.mapping.metadata;
 
 
 import jakarta.data.repository.DataRepository;
 
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 import java.util.Set;
 
 /**
@@ -28,9 +29,12 @@ import java.util.Set;
  */
 public interface ClassScanner {
 
-    ClassScanner INSTANCE =  ServiceLoader.load(ClassScanner.class)
-            .findFirst()
-            .orElseThrow(() ->   new MetadataException("No implementation of ClassScanner found via ServiceLoader"));
+    ClassScanner INSTANCE = ServiceDiscovery
+            .of(ClassScanner.class, ClassScanner.class)
+            .first()
+            .orElseThrow(() ->
+                    new MetadataException(
+                            "No implementation of ClassScanner found via ServiceDiscovery"));
     /**
      * Returns a set of classes that are annotated with the {@link jakarta.nosql.Entity} annotation.
      *

--- a/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilder.java
+++ b/jnosql-mapping/jnosql-mapping-api-core/src/main/java/org/eclipse/jnosql/mapping/metadata/ConstructorBuilder.java
@@ -19,8 +19,7 @@ package org.eclipse.jnosql.mapping.metadata;
 import jakarta.nosql.NoSQLException;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.ServiceLoader;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 
 /**
  * The ConstructorBuilder interface provides a way to create an entity from a constructor.
@@ -32,27 +31,15 @@ import java.util.ServiceLoader;
  */
 public interface ConstructorBuilder {
 
-    ConstructorBuilderSupplier CONSTRUCTOR_BUILDER_SUPPLIER = loadConstructorBuilderSupplier();
-
-    private static ConstructorBuilderSupplier loadConstructorBuilderSupplier() {
-        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
-
-        if (tccl != null) {
-            Optional<ConstructorBuilderSupplier> viaTccl =
-                    ServiceLoader.load(ConstructorBuilderSupplier.class, tccl).findFirst();
-
-            if (viaTccl.isPresent()) {
-                return viaTccl.get();
-            }
-        }
-
-        return ServiceLoader.load(
-                        ConstructorBuilderSupplier.class,
-                        ConstructorBuilder.class.getClassLoader())
-                .findFirst()
-                .orElseThrow(() ->
-                        new NoSQLException("There is not implementation for the ConstructorBuilderSupplier"));
-    }
+    ConstructorBuilderSupplier CONSTRUCTOR_BUILDER_SUPPLIER =
+            ServiceDiscovery
+                    .of(
+                            ConstructorBuilderSupplier.class,
+                            ConstructorBuilder.class)
+                    .first()
+                    .orElseThrow(() ->
+                            new NoSQLException(
+                                    "There is not implementation for the ConstructorBuilderSupplier"));
 
     /**
      * Returns the constructor parameters.

--- a/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
+++ b/jnosql-mapping/jnosql-mapping-core/src/main/java/org/eclipse/jnosql/mapping/core/repository/DynamicReturnConverter.java
@@ -11,17 +11,18 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  */
 package org.eclipse.jnosql.mapping.core.repository;
 
 import jakarta.data.page.PageRequest;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 import org.eclipse.jnosql.mapping.PreparedStatement;
 import org.eclipse.jnosql.mapping.core.NoSQLPage;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.stream.Stream;
@@ -35,9 +36,10 @@ public enum DynamicReturnConverter {
 
     private final RepositoryReturn defaultReturn = new DefaultRepositoryReturn();
 
-    private final List<RepositoryReturn> repositoryReturns = ServiceLoader.load(RepositoryReturn.class) .stream()
-            .map(ServiceLoader.Provider::get)
-            .toList();
+    private final List<RepositoryReturn> repositoryReturns =
+            ServiceDiscovery
+                    .of(RepositoryReturn.class, DynamicReturnConverter.class)
+                    .all();
 
     /**
      * Converts the entity from the Method return type.

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionFieldMetadata.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionFieldMetadata.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  */
 package org.eclipse.jnosql.mapping.reflection;
 
@@ -18,6 +19,7 @@ import jakarta.nosql.AttributeConverter;
 import jakarta.nosql.Embeddable;
 import jakarta.nosql.Entity;
 import org.eclipse.jnosql.communication.TypeSupplier;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 import org.eclipse.jnosql.communication.Value;
 import org.eclipse.jnosql.mapping.metadata.CollectionFieldMetadata;
 import org.eclipse.jnosql.mapping.metadata.CollectionSupplier;
@@ -30,14 +32,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.ServiceLoader;
 
 final class DefaultCollectionFieldMetadata extends AbstractFieldMetadata implements CollectionFieldMetadata {
 
     @SuppressWarnings("rawtypes")
-    private static final List<CollectionSupplier> COLLECTION_SUPPLIERS = ServiceLoader.load(CollectionSupplier.class) .stream()
-            .map(ServiceLoader.Provider::get)
-            .toList();
+    private static final List<CollectionSupplier> COLLECTION_SUPPLIERS =
+            ServiceDiscovery.of(CollectionSupplier.class, DefaultCollectionFieldMetadata.class)
+                    .all();
     private final TypeSupplier<?> typeSupplier;
     private final boolean entityField;
     private final boolean embeddableField;

--- a/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionParameterMetaData.java
+++ b/jnosql-mapping/jnosql-mapping-reflection/src/main/java/org/eclipse/jnosql/mapping/reflection/DefaultCollectionParameterMetaData.java
@@ -11,6 +11,7 @@
  *   Contributors:
  *
  *   Otavio Santana
+ *   Mohan Lal
  */
 package org.eclipse.jnosql.mapping.reflection;
 
@@ -18,6 +19,7 @@ import jakarta.nosql.AttributeConverter;
 import jakarta.nosql.Embeddable;
 import jakarta.nosql.Entity;
 import org.eclipse.jnosql.communication.TypeSupplier;
+import org.eclipse.jnosql.communication.util.ServiceDiscovery;
 import org.eclipse.jnosql.mapping.metadata.CollectionParameterMetaData;
 import org.eclipse.jnosql.mapping.metadata.CollectionSupplier;
 import org.eclipse.jnosql.mapping.metadata.MappingType;
@@ -26,14 +28,13 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
 import java.util.List;
-import java.util.ServiceLoader;
 
 class DefaultCollectionParameterMetaData extends DefaultParameterMetaData implements CollectionParameterMetaData {
 
     @SuppressWarnings("rawtypes")
-    private static final List<CollectionSupplier> COLLECTION_SUPPLIERS = ServiceLoader.load(CollectionSupplier.class).stream()
-            .map(ServiceLoader.Provider::get)
-            .toList();
+    private static final List<CollectionSupplier> COLLECTION_SUPPLIERS =
+            ServiceDiscovery.of(CollectionSupplier.class, DefaultCollectionParameterMetaData.class)
+                    .all();
 
     private final Class<?> elementType;
 


### PR DESCRIPTION
## Description

This is the `master` counterpart of #780.

PR #780, which migrates service discovery consumers to the centralized `ServiceDiscovery` utility, was merged into `1.1.x`. Following that merge, this PR ports the same service discovery changes to the current `master` branch.

### Changes

* Add `ServiceDiscovery` and its unit tests.
* Migrate applicable `ServiceLoader` consumers to `ServiceDiscovery`.
* Replace the duplicated service discovery logic in `ConstructorBuilder`.
* Update `ClassConverter` and `ClassScanner` to use `ServiceDiscovery`.
* Migrate the applicable mapping and communication service discovery consumers.
* Export the `org.eclipse.jnosql.communication.util` package.

`KeyValueConfiguration` and `DatabaseConfiguration` remain direct `ServiceLoader` consumers because they require service discovery from their own named JPMS modules.

**Related Issue:** #766

## Type of Contribution

* [x] Bug fix
* [ ] Feature request
* [ ] New database support
* [ ] Use case implementation
* [ ] Documentation update
* [ ] Other:

## Architectural and Design Decisions

This PR ports the centralized service discovery approach already implemented and merged through #769 and #780.

`ServiceDiscovery` provides common TCCL-first service discovery with a fallback to the reference class loader, avoiding duplicated class-loader handling across consumers.

The migration is limited to existing service discovery consumers and does not introduce changes to the Mapper, Grammar, or public API contracts.

Some named JPMS modules intentionally continue to use direct `ServiceLoader` because service discovery must be initiated from the module that declares the corresponding `uses` relationship.

## Contribution Checklist

* [ ] **ECA:** I have signed the [[Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php)](http://www.eclipse.org/legal/ECA.php).
* [ ] **DCO:** All my commits are signed with Signed-off-by (git commit -s).
* [x] **[Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional):** I followed the [Conventional Commits](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional) pattern.
* [x] **Tests:** I have added/updated unit and integration tests.
* [ ] **Documentation:** I have updated the relevant .adoc files.
* [ ] **Verification:** I have run mvn clean verify and it passed successfully.

## Validation Results

* `ServiceDiscoveryTest`: 10 tests passed.
* Mapping API Core compilation: passed.
* Communication Key-Value compilation: passed.
* Mapping Graph tests: 39 tests passed.
* `git diff --check`: passed.
* Full `mvn clean install` was attempted three times but was blocked by an external HTTP 503 while Maven PMD attempted to retrieve the project's `pmd/pmd-rules.xml` from `raw.githubusercontent.com`.
* No compilation or test failure related to this change was encountered.